### PR TITLE
Lock Down Org Features CU-tq5m45

### DIFF
--- a/src/components/datasets/DatasetPermissions/AddPermissionForm/AddPermissionForm.vue
+++ b/src/components/datasets/DatasetPermissions/AddPermissionForm/AddPermissionForm.vue
@@ -98,7 +98,7 @@
     </el-select>
 
     <bf-button
-      :disabled="isFormInvalid"
+      :disabled="isFormInvalid || isSandboxOrg"
       :processing="processing"
       @click="submit"
     >
@@ -196,7 +196,8 @@
       ...mapState([
         'orgMembers',
         'teams',
-        'activeOrganization'
+        'activeOrganization',
+        'isSandboxOrg'
       ]),
 
       ...mapGetters([

--- a/src/components/datasets/settings/BfDatasetSettings.vue
+++ b/src/components/datasets/settings/BfDatasetSettings.vue
@@ -28,7 +28,7 @@
             </router-link>
           </li>
           <li>
-            <router-link :to="{ name: 'publishing-settings' }">
+            <router-link :class="[ isSandboxOrg ? 'tab-disabled' : '']" :to="{ name: 'publishing-settings' }">
               Publishing
             </router-link>
           </li>
@@ -290,7 +290,7 @@ export default {
   },
 
   computed: {
-    ...mapState(['concepts', 'datasetEtag']),
+    ...mapState(['concepts', 'datasetEtag', 'isSandboxOrg']),
 
     ...mapGetters([
       'activeOrganization',
@@ -626,6 +626,11 @@ hr {
 .tag-wrap {
   display: flex;
   flex-wrap: wrap;
+}
+
+.tab-disabled {
+  opacity: 0.5;
+  pointer-events: none;
 }
 
 .sharing-blurb {

--- a/src/components/my-settings/MySettingsContainer.vue
+++ b/src/components/my-settings/MySettingsContainer.vue
@@ -404,7 +404,7 @@ export default {
       'userToken',
       'config',
       'onboardingEvents',
-      'cognitoUser',
+      'cognitoUser'
     ]),
 
     ...mapGetters(['hasOrcidId']),

--- a/src/components/my-settings/MySettingsContainer.vue
+++ b/src/components/my-settings/MySettingsContainer.vue
@@ -404,7 +404,7 @@ export default {
       'userToken',
       'config',
       'onboardingEvents',
-      'cognitoUser'
+      'cognitoUser',
     ]),
 
     ...mapGetters(['hasOrcidId']),

--- a/src/components/people/list/PeopleList.vue
+++ b/src/components/people/list/PeopleList.vue
@@ -220,9 +220,6 @@ export default {
   },
 
   beforeRouteEnter(to, from, next) {
-    if (this.isSandboxOrg) {
-      this.$router.push({name: 'create-org'})
-    }
     next(vm => {
      if (vm.isSandboxOrg) {
       vm.$router.push({name: 'create-org'})

--- a/src/components/people/list/PeopleList.vue
+++ b/src/components/people/list/PeopleList.vue
@@ -425,7 +425,7 @@ export default {
       this.offset = 0
       this.limit = limit
     }
-  },
+  }
 }
 </script>
 

--- a/src/components/people/list/PeopleList.vue
+++ b/src/components/people/list/PeopleList.vue
@@ -137,7 +137,7 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
+import { mapGetters, mapActions, mapState } from 'vuex'
 
 import BfRafter from '../../shared/bf-rafter/BfRafter.vue'
 import BfButton from '../../shared/bf-button/BfButton.vue'
@@ -192,6 +192,9 @@ export default {
       'hasFeature',
       'profile'
     ]),
+    ...mapState([
+      'isSandboxOrg'
+    ]),
     hasAdminRights: function() {
       const isAdmin = propOr(false, 'isAdmin', this.activeOrganization)
       const isOwner = propOr(false, 'isOwner', this.activeOrganization)
@@ -214,6 +217,17 @@ export default {
       },
       immediate: true
     }
+  },
+
+  beforeRouteEnter(to, from, next) {
+    if (this.isSandboxOrg) {
+      this.$router.push({name: 'create-org'})
+    }
+    next(vm => {
+     if (vm.isSandboxOrg) {
+      vm.$router.push({name: 'create-org'})
+    }
+    })
   },
 
   methods: {
@@ -414,7 +428,7 @@ export default {
       this.offset = 0
       this.limit = limit
     }
-  }
+  },
 }
 </script>
 

--- a/src/components/settings/OrgSettings.vue
+++ b/src/components/settings/OrgSettings.vue
@@ -268,7 +268,8 @@ export default {
       'config',
       'orgMembers',
       'datasets',
-      'orgDatasetStatuses'
+      'orgDatasetStatuses',
+      'isSandboxOrg'
     ]),
 
     ...mapGetters(['hasFeature']),
@@ -343,6 +344,14 @@ export default {
   mounted() {
     this.handleGetOrg(this.activeOrganization)
     this.getUsers(this.orgMembers)
+  },
+
+  beforeRouteEnter(to, from, next) {
+    next(vm => {
+     if (vm.isSandboxOrg) {
+      vm.$router.push({name: 'create-org'})
+    }
+    })
   },
 
   methods: {

--- a/src/components/teams/list/TeamsList.vue
+++ b/src/components/teams/list/TeamsList.vue
@@ -170,7 +170,8 @@ export default {
     ]),
     ...mapState([
       'teamsLoading',
-      'teams'
+      'teams',
+      'isSandboxOrg'
     ]),
     hasAdminRights: function() {
       if (this.activeOrganization) {
@@ -196,6 +197,14 @@ export default {
       },
       immediate: true
     }
+  },
+
+  beforeRouteEnter(to, from, next) {
+    next(vm => {
+     if (vm.isSandboxOrg) {
+      vm.$router.push({name: 'create-org'})
+    }
+    })
   },
 
   methods: {

--- a/src/routes/CreateOrg/CreateOrg.vue
+++ b/src/routes/CreateOrg/CreateOrg.vue
@@ -1,15 +1,56 @@
 <template>
-  <div>
-    This is the create org page!
-  </div>
+  <bf-page class="create-org">
+    <img
+      src="/static/images/illustrations/illo-research-platform.svg"
+      alt="Patient Data"
+      width="446"
+      height="220"
+    >
+    <h2>Restricted Access</h2>
+    <p>You must create a new organization in order to access this feature on the platform. </p>
+    <a :href="takeMeHomeLink">
+      <bf-button class="primary">
+        Create Organization
+      </bf-button>
+    </a>
+  </bf-page>
 </template>
 
 <script>
+import BfButton from '@/components/shared/bf-button/BfButton.vue'
   export default {
-    name: 'CreateOrg'
+    name: 'CreateOrg',
+    components: {
+      BfButton,
+    },
   }
 </script>
 
 <style lang="scss" scoped>
+.create-org {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
 
+h2 {
+  font-size: 22px;
+  line-height: 26px;
+  font-weight: bold;
+  margin-right: 30px;
+}
+
+p {
+  margin-bottom: 20px;
+}
+
+img {
+  margin-top: -125px;
+  margin-bottom: 20px;
+}
+
+.bf-button {
+  margin-right: 30px;
+}
 </style>

--- a/src/routes/CreateOrg/CreateOrg.vue
+++ b/src/routes/CreateOrg/CreateOrg.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    This is the create org page!
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'CreateOrg'
+  }
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/src/routes/Publishing/PublishingView.vue
+++ b/src/routes/Publishing/PublishingView.vue
@@ -86,7 +86,7 @@ export default {
     ]),
 
     ...mapState([
-      'config', 'activeOrganization', 'primaryNavOpen'
+      'config', 'activeOrganization', 'primaryNavOpen', 'isSandboxOrg'
     ]),
 
     ...mapState('publishingModule', [
@@ -135,6 +135,14 @@ export default {
       this.togglePrimaryNav(true)
     }
 
+  },
+
+   beforeRouteEnter(to, from, next) {
+    next(vm => {
+     if (vm.isSandboxOrg) {
+      vm.$router.push({name: 'create-org'})
+    }
+    })
   },
 
   methods: {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -358,7 +358,8 @@ const routes = [
     name: 'create-org',
     path: '/:orgId/create-org',
     components: {
-      page: CreateOrg
+      page: CreateOrg,
+      navigation: BfNavigation
     },
     props: true
   },

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -12,6 +12,7 @@ const Login = () => import('./login/Login.vue')
 const Viewer = () => import('../components/viewer/BfViewer/BfViewer.vue')
 const ResetPassword = () => import('./ResetPassword/ResetPassword.vue')
 const DocsLogin = () => import('./DocsLogin/DocsLogin.vue')
+const CreateOrg = () => import('./CreateOrg/CreateOrg.vue')
 
 /**
  * User Onboarding Components
@@ -350,6 +351,14 @@ const routes = [
     path: '/:orgId/datasets/:datasetId/viewer/:fileId',
     components: {
       page: Viewer
+    },
+    props: true
+  },
+  {
+    name: 'create-org',
+    path: '/:orgId/create-org',
+    components: {
+      page: CreateOrg
     },
     props: true
   },

--- a/src/vuex/store.js
+++ b/src/vuex/store.js
@@ -110,7 +110,8 @@ export const state = {
   dataUseAgreements: [],
   cognitoUser: {},
   onboardingEvents: [],
-  shouldShowLinkOrcidDialog: false
+  shouldShowLinkOrcidDialog: false,
+  isSandboxOrg: true // TODO: REMOVE WHEN ENDPOINT IN PLACE
 }
 
 const initialFilterState = state.datasetFilters


### PR DESCRIPTION
# Description

The purpose of this PR is to restrict access to certain parts of the platform for users who first sign up and are set to the default sandbox organization. Users would need to create an account in order to get access to the following features:

- People Page
- Teams Page
- Publishing Page
- Settings Page
- Within a dataset, the ability to add permissions if you have access
- Within a dataset, the ability to access the publishing tab

All but the last two will redirect to a create organization page. The button is not active yet, as I'm working on the create organization modal in another branch.

This is being pushed to a feature branch for now so as not to mess with the current functionality in dev while the backend is being worked on.


## Clickup Ticket

[CU-tq5m45](https://app.clickup.com/t/CU-tq5m45)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Navigate to the app and login as usual. An `isSandboxOrg` flag has been added to Vuex and set to true for testing purposes.
2. Try navigating to all the pages listed above. You should be redirected to the restricted access page.
3. Navigate to a dataset in which you have access to. You should not be able to view the Publishing tab in settings or add permissions to users.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
