### PR TITLE
Create Organization Modal CU-tq5qjd

### DIFF
--- a/src/components/CreateOrganizationDialog/CreateOrganizationDialog.vue
+++ b/src/components/CreateOrganizationDialog/CreateOrganizationDialog.vue
@@ -154,12 +154,18 @@ import EventBus from '@/utils/event-bus'
         }
       },
 
+      /**
+       * Send endpoint request
+       */
       sendRequest: function() {
         this.isCreating = true
         // TODO add endpoint logic to create organization once it becomes available
         this.handleSuccess()
       },
 
+      /**
+       * Handle endpoint request success
+       */
       handleSuccess: function() {
         // logic to handle endpoint success
          EventBus.$emit('toast', {

--- a/src/components/CreateOrganizationDialog/CreateOrganizationDialog.vue
+++ b/src/components/CreateOrganizationDialog/CreateOrganizationDialog.vue
@@ -1,0 +1,183 @@
+<template>
+    <el-dialog
+    :visible="visible"
+    :show-close="false"
+    :append-to-body="true"
+    class="create-new-organization"
+    @close="closeDialog"
+  >
+    <bf-dialog-header
+      slot="title"
+      title="Create Organization"
+    />
+
+    <dialog-body>
+      <div>
+        <p>Creating an organization on Pennsieve is quick and easy. Just enter an organization name and you'll
+          be moments away from experiencing the full power of data sharing on the platform.
+        </p>
+        <p>You have 3 out of 3 organizations remaining.</p>
+        <el-form
+          ref="newOrganizationForm"
+          :model="newOrganizationForm"
+          :rules="rules"
+          @submit.native.prevent="createOrganization('newOrganizationForm')"
+        >
+          <el-form-item
+            label="Organization Name"
+            prop="name"
+          >
+            <el-input
+              v-model="newOrganizationForm.name"
+              autofocus
+              :maxlength="255"
+            />
+          </el-form-item>
+        </el-form>
+      </div>
+    </dialog-body>
+
+    <div
+      slot="footer"
+      class="dialog-footer"
+    >
+      <bf-button
+        tabindex="4"
+        class="secondary"
+        @click="closeDialog"
+      >
+        Cancel
+      </bf-button>
+      <bf-button
+        :disabled="isCreating"
+        :processing="isCreating"
+        processing-text="Creating Organization"
+        @click="createOrganization('newOrganizationForm')"
+      >
+        Create Organization
+      </bf-button>
+    </div>
+  </el-dialog>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+
+import BfButton from '@/components/shared/bf-button/BfButton.vue'
+import BfDialogHeader from '@/components/shared/bf-dialog-header/BfDialogHeader'
+import DialogBody from '@/components/shared/dialog-body/DialogBody.vue'
+
+import Request from '@/mixins/request/index'
+import CheckUniqueNames from '@/mixins/check-unique-names'
+
+import EventBus from '@/utils/event-bus'
+  export default {
+    name: 'CreateOrganizationDialog',
+    components: {
+      BfButton,
+      BfDialogHeader,
+      DialogBody
+    },
+    mixins: [
+      Request,
+      CheckUniqueNames
+    ],
+    props: {
+      visible: {
+        type: Boolean,
+        default: false
+      },
+    },
+    data() {
+      return {
+         newOrganizationForm: {
+          name: ''
+        },
+        rules: {
+          name: [
+            { required: true, validator: this.validateOrganization, trigger: 'false' },
+          ]
+        },
+        duplicateOrganizationName: false,
+        isCreating: false
+      }
+    },
+
+    computed: {
+      ...mapGetters([
+        'organizations'
+      ])
+    },
+
+    methods: {
+      /**
+       * Close create organization dialog
+       */
+      closeDialog: function() {
+        this.isCreating = false
+        this.newOrganizationForm.name = ''
+        this.$refs.newOrganizationForm.resetFields()
+        this.$emit('close-dialog')
+      },
+
+       /**
+        * Create new organization
+        */
+      createOrganization: function(formName) {
+        this.duplicateOrganizationName = false
+
+        this.$refs[formName]
+          .validate((valid) => {
+            if (!valid) {
+              return
+            }
+            this.sendRequest()
+          })
+      },
+
+      /**
+       * Validate name
+       * @param {Object} rule
+       * @param {String} value
+       * @param {Function} callback
+       */
+      validateOrganization: function(rule, value, callback) {
+        const isUnique = this.checkUniqueName(this.organizations, ['organization', 'name'], value, '')
+        if (value === '') {
+          callback(new Error('Please provide a name'))
+        } else if (value.length > 255) {
+          callback(new Error('Organization name must be less than 255 characters'))
+        } else if  (!isUnique || this.duplicateName) {
+          callback(new Error('An organization with this name already exists'))
+        } else {
+          callback()
+        }
+      },
+
+      sendRequest: function() {
+        this.isCreating = true
+        // TODO add endpoint logic to create organization once it becomes available
+        this.handleSuccess()
+      },
+
+      handleSuccess: function() {
+        // logic to handle endpoint success
+         EventBus.$emit('toast', {
+            detail: {
+              msg: `The organization ${this.newOrganizationForm.name} has been created`,
+              type: 'success'
+            }
+          })
+          this.closeDialog()
+      }
+    },
+  }
+</script>
+
+<style lang="scss" scoped>
+.create-new-organization {
+  p {
+    margin-bottom: 15px;
+  }
+}
+</style>

--- a/src/components/bf-navigation/UserMenu/UserMenu.vue
+++ b/src/components/bf-navigation/UserMenu/UserMenu.vue
@@ -303,6 +303,9 @@ export default {
 
   methods: {
 
+    /**
+     * Open Create Organization Dialog
+     */
     openCreateOrganizationDialog: function() {
       this.isCreateOrgDialogVisible = true
     },

--- a/src/components/bf-navigation/UserMenu/UserMenu.vue
+++ b/src/components/bf-navigation/UserMenu/UserMenu.vue
@@ -38,6 +38,16 @@
                 />
               </a>
             </li>
+            <hr>
+            <li>
+              <a
+                href="#"
+                class="bf-menu-item"
+                @click.prevent="openCreateOrganizationDialog"
+              >
+                Create Organization
+              </a>
+            </li>
           </ul>
         </div>
 
@@ -184,6 +194,7 @@
         </div>
       </a>
     </button>
+    <create-organization-dialog :visible.sync="isCreateOrgDialogVisible" @close-dialog="onCloseDialog"/>
   </div>
 </template>
 
@@ -195,6 +206,7 @@ import BfNavigationItem from '../bf-navigation-item/BfNavigationItem.vue'
 import Avatar from '../../shared/avatar/Avatar.vue'
 import FilterInput from '../../shared/FilterInput/FilterInput.vue'
 import FilterEmptyState from '../../shared/FilterEmptyState/FilterEmptyState.vue'
+import CreateOrganizationDialog from '@/components/CreateOrganizationDialog/CreateOrganizationDialog.vue'
 
 import EventBus from '../../../utils/event-bus'
 
@@ -205,7 +217,8 @@ export default {
     BfNavigationItem,
     Avatar,
     FilterInput,
-    FilterEmptyState
+    FilterEmptyState,
+    CreateOrganizationDialog
   },
 
   data() {
@@ -213,7 +226,8 @@ export default {
       menuOpen: false,
       orgMenuOpen: false,
       orgFilterName: '',
-      userMenuMouseover: false
+      userMenuMouseover: false,
+      isCreateOrgDialogVisible: false
     }
   },
 
@@ -288,6 +302,18 @@ export default {
   },
 
   methods: {
+
+    openCreateOrganizationDialog: function() {
+      this.isCreateOrgDialogVisible = true
+    },
+
+    /**
+     * Close Create Organization Dialog
+     */
+    onCloseDialog: function() {
+      this.isCreateOrgDialogVisible = false
+    },
+
     /**
      * Close all menus
      */

--- a/src/components/bf-navigation/UserMenu/UserMenu.vue
+++ b/src/components/bf-navigation/UserMenu/UserMenu.vue
@@ -45,7 +45,7 @@
                 class="bf-menu-item"
                 @click.prevent="openCreateOrganizationDialog"
               >
-                Create Organization
+                Create New Organization
               </a>
             </li>
           </ul>

--- a/src/routes/CreateOrg/CreateOrg.vue
+++ b/src/routes/CreateOrg/CreateOrg.vue
@@ -8,20 +8,35 @@
     >
     <h2>Restricted Access</h2>
     <p>You must create a new organization in order to access this feature on the platform. </p>
-    <a :href="takeMeHomeLink">
-      <bf-button class="primary">
+      <bf-button class="primary" @click="openCreateOrgModal">
         Create Organization
       </bf-button>
-    </a>
+      <create-organization-dialog :visible.sync="isDialogVisible" @close-dialog="onCloseDialog"/>
   </bf-page>
 </template>
 
 <script>
 import BfButton from '@/components/shared/bf-button/BfButton.vue'
+import CreateOrganizationDialog from '@/components/CreateOrganizationDialog/CreateOrganizationDialog'
   export default {
     name: 'CreateOrg',
     components: {
       BfButton,
+      CreateOrganizationDialog
+    },
+    data() {
+      return {
+        isDialogVisible: false
+      }
+    },
+    methods: {
+      openCreateOrgModal: function() {
+        this.isDialogVisible = true
+      },
+
+      onCloseDialog: function() {
+        this.isDialogVisible = false
+      }
     },
   }
 </script>


### PR DESCRIPTION
# Description

The purpose of this PR is to add the Create New Organization modal in the restricted access page and in the organization menu. Please note that the backend isn't complete yet. 

## Clickup Ticket

[CU-tq5qjd](https://app.clickup.com/t/CU-tq5qjd)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Navigate to a restricted page and click on the `Create Organization` button. A modal to create an organization should come up (please note the `3 of 3 organizations remaining` text is static for now and will change when using backend data).
2. Play around with the form. When entering an org name and clicking `Create` a success toast should appear indicating that the org was created.
3. Click on `Create New Organization` from the user menu in the navigation bar. The same modal with functionality should appear. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
