### PR TITLE
fix(Notifications): Fix issue with websocket closing too early

### DIFF
--- a/src/components/notifications/Notifications.vue
+++ b/src/components/notifications/Notifications.vue
@@ -95,7 +95,7 @@ export default {
      * @param {String} userToken
      */
     _watchUserToken: function(userToken) {
-      if (userToken && userToken.length > 0) {
+      if ((userToken && userToken.length > 0) && !this.websocket) {
         this.socketUrl = `${site.notificationUrl}?access_token=${userToken}`
         this.openWebSocket()
       }


### PR DESCRIPTION
# Description
The purpose of this PR is to fix a bug with the websocket closing too early. A dang overzealous watcher opening a new connection. We have the WS open when the `userToken` has been set (or changed) and it is always changing every four minutes now because that’s when we refresh the new Cognito token!
I added a check in this watcher to ensure we’re not closing the WS if it’s still open at this time.

## Clickup Ticket

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- With the network tab open, log in to the app (or refresh just so you can see the WS connection to `wss://api.pennsieve.net/notifications/notification/connect` open
- Go to the tab where you can see the messages for this WS
- The websocket should stay open past four minutes.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
