### PR TITLE
Use feature flag on org for restricted access

### DIFF
--- a/src/components/datasets/DatasetPermissions/AddPermissionForm/AddPermissionForm.vue
+++ b/src/components/datasets/DatasetPermissions/AddPermissionForm/AddPermissionForm.vue
@@ -98,7 +98,7 @@
     </el-select>
 
     <bf-button
-      :disabled="isFormInvalid || isSandboxOrg"
+      :disabled="isFormInvalid || hasFeature('sandbox_org_feature')"
       :processing="processing"
       @click="submit"
     >
@@ -196,8 +196,7 @@
       ...mapState([
         'orgMembers',
         'teams',
-        'activeOrganization',
-        'isSandboxOrg'
+        'activeOrganization'
       ]),
 
       ...mapGetters([

--- a/src/components/datasets/settings/BfDatasetSettings.vue
+++ b/src/components/datasets/settings/BfDatasetSettings.vue
@@ -28,7 +28,10 @@
             </router-link>
           </li>
           <li>
-            <router-link :class="[ isSandboxOrg ? 'tab-disabled' : '']" :to="{ name: 'publishing-settings' }">
+            <router-link
+              :class="[ hasFeature('sandbox_org_feature') ? 'tab-disabled' : '']"
+              :to="{ name: 'publishing-settings' }"
+            >
               Publishing
             </router-link>
           </li>
@@ -151,7 +154,9 @@
           <!-- delete dataset -->
           <el-row>
             <el-col>
-              <h2 class="delete-title">Delete Dataset</h2>
+              <h2 class="delete-title">
+                Delete Dataset
+              </h2>
               <p>
                 Deleting a dataset removes all data from Pennsieve.
                 <strong>This cannot be undone.</strong>
@@ -290,7 +295,7 @@ export default {
   },
 
   computed: {
-    ...mapState(['concepts', 'datasetEtag', 'isSandboxOrg']),
+    ...mapState(['concepts', 'datasetEtag']),
 
     ...mapGetters([
       'activeOrganization',

--- a/src/components/people/list/PeopleList.vue
+++ b/src/components/people/list/PeopleList.vue
@@ -192,9 +192,6 @@ export default {
       'hasFeature',
       'profile'
     ]),
-    ...mapState([
-      'isSandboxOrg'
-    ]),
     hasAdminRights: function() {
       const isAdmin = propOr(false, 'isAdmin', this.activeOrganization)
       const isOwner = propOr(false, 'isOwner', this.activeOrganization)
@@ -221,7 +218,7 @@ export default {
 
   beforeRouteEnter(to, from, next) {
     next(vm => {
-     if (vm.isSandboxOrg) {
+     if (vm.hasFeature('sandbox_org_feature')) {
       vm.$router.push({name: 'create-org'})
     }
     })

--- a/src/components/settings/OrgSettings.vue
+++ b/src/components/settings/OrgSettings.vue
@@ -268,8 +268,7 @@ export default {
       'config',
       'orgMembers',
       'datasets',
-      'orgDatasetStatuses',
-      'isSandboxOrg'
+      'orgDatasetStatuses'
     ]),
 
     ...mapGetters(['hasFeature']),
@@ -348,7 +347,7 @@ export default {
 
   beforeRouteEnter(to, from, next) {
     next(vm => {
-     if (vm.isSandboxOrg) {
+     if (vm.hasFeature('sandbox_org_feature')) {
       vm.$router.push({name: 'create-org'})
     }
     })

--- a/src/components/teams/list/TeamsList.vue
+++ b/src/components/teams/list/TeamsList.vue
@@ -167,11 +167,11 @@ export default {
       'activeOrganization',
       'userToken',
       'config',
+      'hasFeature'
     ]),
     ...mapState([
       'teamsLoading',
-      'teams',
-      'isSandboxOrg'
+      'teams'
     ]),
     hasAdminRights: function() {
       if (this.activeOrganization) {
@@ -201,7 +201,7 @@ export default {
 
   beforeRouteEnter(to, from, next) {
     next(vm => {
-     if (vm.isSandboxOrg) {
+     if (vm.hasFeature('sandbox_org_feature')) {
       vm.$router.push({name: 'create-org'})
     }
     })

--- a/src/routes/Publishing/PublishingView.vue
+++ b/src/routes/Publishing/PublishingView.vue
@@ -78,7 +78,8 @@ export default {
   computed: {
     ...mapGetters([
       'isUserPublisher',
-      'publisherTeam'
+      'publisherTeam',
+      'hasFeature'
     ]),
 
     ...mapGetters('publishingModule', [
@@ -86,7 +87,7 @@ export default {
     ]),
 
     ...mapState([
-      'config', 'activeOrganization', 'primaryNavOpen', 'isSandboxOrg'
+      'config', 'activeOrganization', 'primaryNavOpen'
     ]),
 
     ...mapState('publishingModule', [
@@ -139,7 +140,7 @@ export default {
 
    beforeRouteEnter(to, from, next) {
     next(vm => {
-     if (vm.isSandboxOrg) {
+     if (vm.hasFeature('sandbox_org_feature')) {
       vm.$router.push({name: 'create-org'})
     }
     })

--- a/src/vuex/store.js
+++ b/src/vuex/store.js
@@ -110,8 +110,7 @@ export const state = {
   dataUseAgreements: [],
   cognitoUser: {},
   onboardingEvents: [],
-  shouldShowLinkOrcidDialog: false,
-  isSandboxOrg: true // TODO: REMOVE WHEN ENDPOINT IN PLACE
+  shouldShowLinkOrcidDialog: false
 }
 
 const initialFilterState = state.datasetFilters


### PR DESCRIPTION
# Description

The purpose of this PR is to change the logic to use feature flag on org for restricted access. Users would need to create an account in order to get access to the following features:

- People Page
- Teams Page
- Publishing Page
- Settings Page
- Within a dataset, the ability to add permissions if you have access
- Within a dataset, the ability to access the publishing tab


## Clickup Ticket

[CLICKUP_TICKET](https://app.clickup.com/t/CLICKUP_TICKET)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Navigate to the app and login as usual. 
- Using vue devtools, inspect `App` and enter the following in the console
```javascript
$vm0.$store.dispatch('updateActiveOrganization',  {
  ...$vm0.$store.state.activeOrganization,
  organization: {
    ...$vm0.$store.state.activeOrganization.organization,
    features: [...$vm0.$store.state.activeOrganization.organization.features, 'sandbox_org_feature']
  }
})
```
- Try navigating to all the pages listed above. You should be redirected to the restricted access page.
- Navigate to a dataset in which you have access to. You should not be able to view the Publishing tab in settings or add permissions to users.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
