### PR TITLE
Fix links for terms and privacy on create user

### DIFF
--- a/src/routes/CreateAccount/CreateAccount.vue
+++ b/src/routes/CreateAccount/CreateAccount.vue
@@ -79,14 +79,14 @@
           <p class="agreement">
             By clicking “Create Account" you are agreeing to the Pennsieve
             <a
-              href="https://www.blackfynn.com/terms"
+              href="https://docs.pennsieve.io/page/pennsieve-terms-of-use"
               target="_blank"
             >
               Terms of Use
             </a>
             and
             <a
-              href="https://www.blackfynn.com/privacy"
+              href="https://docs.pennsieve.io/page/privacy-policy"
               target="_blank"
             >
               Privacy Policy


### PR DESCRIPTION
# Description

The purpose of this PR is to Fix links for terms and privacy on create user.

## Clickup Ticket

[tq54pk](https://app.clickup.com/t/tq54pk)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The terms and privacy links on the create account page should go to the Pennsieve docs.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
