### PR TITLE
Fix race condition with reCAPTCHA badge on create account

### DIFF
--- a/src/routes/CreateAccount/CreateAccount.vue
+++ b/src/routes/CreateAccount/CreateAccount.vue
@@ -155,7 +155,8 @@ export default {
     ])
   },
 
-  mounted() {
+  async mounted() {
+    await this.$recaptchaLoaded()
     this.$recaptchaInstance.showBadge()
   },
   destroyed() {


### PR DESCRIPTION
# Description

The purpose of this PR is to fix a race condition with reCAPTCHA badge on create account.

## Clickup Ticket

[tq5jj5](https://app.clickup.com/t/tq5jj5)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Direct load the [create account](http://localhost:3000/sign-up) page
- The reCAPTCHA badge should show in the bottom left, and no console errors should appear.
- Hit the cancel button to go back to the login page
- Click on "Create one" to go to the create account page
- The reCAPTCHA badge should show in the bottom left, and no console errors should appear.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
