### PR TITLE
Replace Create New Org option with request to create new organization

### DIFF
--- a/src/components/bf-navigation/UserMenu/UserMenu.vue
+++ b/src/components/bf-navigation/UserMenu/UserMenu.vue
@@ -438,6 +438,8 @@ export default {
      * organization
      */
     requestCreateOrganization: function() {
+      this.closeMenus()
+
       window.Intercom('show')
     }
   }

--- a/src/components/bf-navigation/UserMenu/UserMenu.vue
+++ b/src/components/bf-navigation/UserMenu/UserMenu.vue
@@ -43,9 +43,9 @@
               <a
                 href="#"
                 class="bf-menu-item"
-                @click.prevent="openCreateOrganizationDialog"
+                @click.prevent="requestCreateOrganization"
               >
-                Create New Organization
+                Request to Create New Organization
               </a>
             </li>
           </ul>
@@ -194,7 +194,10 @@
         </div>
       </a>
     </button>
-    <create-organization-dialog :visible.sync="isCreateOrgDialogVisible" @close-dialog="onCloseDialog"/>
+    <create-organization-dialog
+      :visible.sync="isCreateOrgDialogVisible"
+      @close-dialog="onCloseDialog"
+    />
   </div>
 </template>
 
@@ -427,6 +430,15 @@ export default {
       this.closeMenus()
 
       EventBus.$emit('logout')
+    },
+
+    /**
+     * Show the intercom window to allow
+     * user to talk to supprt to create an
+     * organization
+     */
+    requestCreateOrganization: function() {
+      window.Intercom('show')
     }
   }
 }


### PR DESCRIPTION
# Description

The purpose of this PR is to replace Create New Org option with request to create new organization. This will open up an Intercom window, which will allow users to request support to create a new org.

## Clickup Ticket

N/A

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Log in to Blackfynn
- Open the user menu, go to Switch Organization and click on "Request to Create New Organization"
- Intercom should open

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
