### PR TITLE
fix(ORCID): Fix issue where ORCID dialog is visible when it should

### DIFF
--- a/src/components/app/App.vue
+++ b/src/components/app/App.vue
@@ -42,7 +42,10 @@
 
     <office-365-dialog />
 
-    <link-orcid-dialog :visible.sync="isLinkOrcidDialogVisible" />
+    <link-orcid-dialog
+      v-if="userToken"
+      :visible.sync="isLinkOrcidDialogVisible"
+    />
   </div>
 </template>
 

--- a/src/components/app/app.js
+++ b/src/components/app/app.js
@@ -55,8 +55,7 @@ export default {
       // default meta description
       defaultPageDescription: 'Pennsieve secure Sign In page. Sign in to your Pennsieve customer account.',
       isUploadExternalFileModalOpen: false,
-      externalFile: {},
-      isLinkOrcidDialogVisible: false
+      externalFile: {}
     }
   },
 
@@ -66,7 +65,8 @@ export default {
       'primaryNavOpen',
       'secondaryNavOpen',
       'environment',
-      'searchModalVisible'
+      'searchModalVisible',
+      'isLinkOrcidDialogVisible'
     ]),
 
     ...mapState('datasetModule', [
@@ -200,7 +200,8 @@ export default {
       'setIsLoadingDatasetPublishedData',
       'setIsLoadingDatasetsError',
       'updateOrgDatasetStatuses',
-      'updateShouldShowLinkOrcidDialog'
+      'updateShouldShowLinkOrcidDialog',
+      'updateIsLinkOrcidDialogVisible'
     ]),
 
     ...mapActions('datasetModule', [
@@ -321,7 +322,6 @@ export default {
       return this.getBfTermsOfService()
         .then(() => this.getProfileAndOrg(userToken))
         .then(() => this.getOnboardingEventStates(userToken))
-        .then(() => this.setLinkOrcidDialog())
     },
 
     /**
@@ -368,7 +368,13 @@ export default {
           'Authorization': `bearer ${userToken}`
         }
       })
-      .then(this.updateOnboardingEvents.bind(this))
+      .then((response) =>  {
+        this.updateOnboardingEvents(response)
+        const hasAddedOrcid = response.includes('AddedOrcid')
+        if (!hasAddedOrcid)  {
+          this.setLinkOrcidDialog()
+        }
+      })
       .catch(this.handleXhrError.bind(this))
     },
 
@@ -377,8 +383,8 @@ export default {
      */
      setLinkOrcidDialog: function() {
       this.updateShouldShowLinkOrcidDialog(true)
-      if (this.$route.name !== 'terms-of-service') {
-        this.isLinkOrcidDialogVisible = !this.hasOrcidOnboardingEvent
+      if (this.$route.name !== 'terms-of-service' && !this.hasOrcidOnboardingEvent) {
+        this.updateIsLinkOrcidDialogVisible(!this.hasOrcidOnboardingEvent)
       }
     }
   }

--- a/src/mixins/logout-handler/index.js
+++ b/src/mixins/logout-handler/index.js
@@ -22,7 +22,6 @@ export default {
 
       // clear vuex
       this.clearState()
-      this.isLinkOrcidDialogVisible = false
       // remove user token
       Cookies.remove('user_token')
 

--- a/src/vuex/store.js
+++ b/src/vuex/store.js
@@ -110,7 +110,8 @@ export const state = {
   dataUseAgreements: [],
   cognitoUser: {},
   onboardingEvents: [],
-  shouldShowLinkOrcidDialog: false
+  shouldShowLinkOrcidDialog: false,
+  isLinkOrcidDialogVisible: false
 }
 
 const initialFilterState = state.datasetFilters
@@ -183,6 +184,8 @@ export const mutations = {
     Vue.set(state, 'datasetDescription', '')
     Vue.set(state, 'datasetDoi', '')
     Vue.set(state, 'searchModalVisible', false)
+    Vue.set(state, 'shouldShowLinkOrcidDialog', false)
+    Vue.set(state, 'isLinkOrcidDialogVisible', false)
   },
   UPDATE_CUR_DATASET (state, dataset) {
     Vue.set(state, 'curDataset', dataset)
@@ -590,10 +593,15 @@ export const mutations = {
   UPDATE_SHOULD_SHOW_LINK_ORCID_DIALOG(state, shouldShowLinkOrcidDialog) {
     state.shouldShowLinkOrcidDialog = shouldShowLinkOrcidDialog
   },
+
+  UPDATE_IS_LINK_ORCID_DIALOG_VISIBLE(state, isLinkOrcidDialogVisible) {
+    state.isLinkOrcidDialogVisible = isLinkOrcidDialogVisible
+  }
 }
 
 // actions
 export const actions = {
+  updateIsLinkOrcidDialogVisible: ({commit}, evt) => commit('UPDATE_IS_LINK_ORCID_DIALOG_VISIBLE', evt),
   updateCognitoUser: ({commit}, evt) => commit('UPDATE_COGNITO_USER', evt),
   updatePageNotFound: ({ commit }, evt) => commit('SET_PAGE_NOT_FOUND', evt),
   updateScientificUnits: ({ commit }, evt) => commit('UPDATE_SCIENTIFIC_UNITS', evt),


### PR DESCRIPTION
# Description

The purpose of this PR is to fix an issue where the Link ORCID dialog is visible when it shouldn't be.

## Clickup Ticket

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## With a user that has not seen the dialog
This can be done by inviting a new user and logging in to their account
- Log in to the app
- The link ORCID dialog should be visible
- Dimiss dialog
- Refresh app
- The link ORCID dialog should not be visible

## With a user who has seen the dialog
- Log in to the app
- Using Devtools, change the value of the `user_token` to `123` (this is an invalid token)
- Refresh the app
- You should be logged out and the ORCID should not be visible
- Log in to the app
- The link ORCID dialog should not be visible

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
