### PR TITLE
Conditional Logic to Disable Create Organization in User Menu CU-tq54pk

### DIFF
--- a/src/components/bf-navigation/UserMenu/UserMenu.vue
+++ b/src/components/bf-navigation/UserMenu/UserMenu.vue
@@ -43,6 +43,7 @@
               <a
                 href="#"
                 class="bf-menu-item"
+                :class="[maxOrgsCreated ? 'disabled': '']"
                 @click.prevent="openCreateOrganizationDialog"
               >
                 Create New Organization
@@ -239,6 +240,16 @@ export default {
     ]),
 
     /**
+     * Checks where user has created the maximum number of organizations
+     * @returns {Boolean}
+     */
+    maxOrgsCreated: function() {
+      // NOTE: Adding the first condition so that this can go through
+      // as these properties do not exist in the profile object yet
+      return this.profile.maxOrganizationsAllowed === 3 && this.profile.organizationsCreated === this.profile.maxOrganizationsAllowed
+    },
+
+    /**
        * Checks if route is a 404 page
        * @returns {Boolean}
        */
@@ -307,7 +318,9 @@ export default {
      * Open Create Organization Dialog
      */
     openCreateOrganizationDialog: function() {
-      this.isCreateOrgDialogVisible = true
+      if (!this.maxOrgsCreated) {
+        this.isCreateOrgDialogVisible = true
+      }
     },
 
     /**

--- a/src/mixins/global-message-handler/index.js
+++ b/src/mixins/global-message-handler/index.js
@@ -239,6 +239,7 @@ export default {
       return Promise.all([orgPromise, profilePromise])
         .then(([orgs, profile]) => {
           this.updateProfile(profile)
+          console.log('profile is now ', profile)
           this.updateUserToken(token)
 
           const sortedOrgs = this.returnSort('organization.name', orgs.organizations, 'asc')

--- a/src/mixins/global-message-handler/index.js
+++ b/src/mixins/global-message-handler/index.js
@@ -239,7 +239,6 @@ export default {
       return Promise.all([orgPromise, profilePromise])
         .then(([orgs, profile]) => {
           this.updateProfile(profile)
-          console.log('profile is now ', profile)
           this.updateUserToken(token)
 
           const sortedOrgs = this.returnSort('organization.name', orgs.organizations, 'asc')

--- a/src/routes/CreateOrg/CreateOrg.vue
+++ b/src/routes/CreateOrg/CreateOrg.vue
@@ -8,7 +8,7 @@
     >
     <h2>Restricted Access</h2>
     <p>You must create a new organization in order to access this feature on the platform. </p>
-      <bf-button class="primary" @click="openCreateOrgModal">
+      <bf-button :disabled="maxOrgsCreated" class="primary" @click="openCreateOrgModal">
         Create Organization
       </bf-button>
       <create-organization-dialog :visible.sync="isDialogVisible" @close-dialog="onCloseDialog"/>
@@ -16,6 +16,8 @@
 </template>
 
 <script>
+import { mapState } from 'Vuex'
+
 import BfButton from '@/components/shared/bf-button/BfButton.vue'
 import CreateOrganizationDialog from '@/components/CreateOrganizationDialog/CreateOrganizationDialog'
   export default {
@@ -28,6 +30,19 @@ import CreateOrganizationDialog from '@/components/CreateOrganizationDialog/Crea
       return {
         isDialogVisible: false
       }
+    },
+
+    computed: {
+      ...mapState(['profile']),
+     /**
+       * Checks where user has created the maximum number of organizations
+       * @returns {Boolean}
+       */
+      maxOrgsCreated: function() {
+        // NOTE: Adding the first condition so that this can go through
+        // as these properties do not exist in the profile object yet
+        return this.profile.maxOrganizationsAllowed === 3 && this.profile.organizationsCreated === this.profile.maxOrganizationsAllowed
+      },
     },
     methods: {
       openCreateOrgModal: function() {


### PR DESCRIPTION
# Description

The purpose of this PR is to add conditional logic to disable the `Create Organization` option from the User Menu and from the Restricted Access page once they have created three organizations. This will be pushed to a feature branch in the meantime so as not to interfere with the functionality on dev.

## Clickup Ticket

[CU-tq54pk](https://app.clickup.com/t/CU-tq54pk)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Log into the app and verify that you could click on the `Create Organization` menu item in the navigation bar user menu.
2. Using Vue Dev Tools, select `<App>` and in the console enter the following:

```
$vm0.$store.dispatch('updateProfile',  {
  ...$vm0.$store.state.profile,
maxOrganizationsAllowed: 3,
organizationsCreated: 3
  }
)
```
The `Create Organization` menu item should now be disabled and not-clickable.
3. Navigate to a restricted access page and verify that you can click the button to contact someone to create an organization. 
4. Repeat the same process using Vue Dev tools. The button should now be disabled.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
