### PR TITLE
Hide Create Account Link

### DIFF
--- a/src/routes/login/Login.vue
+++ b/src/routes/login/Login.vue
@@ -54,13 +54,13 @@
               Forgot your password?
             </router-link>
           </el-form-item>
-          <p class="terms sign-up">Don't have an account?
+          <!-- <p class="terms sign-up">Don't have an account?
             <router-link
               :to="{name: 'create-account'}"
               >
                 Create one here
             </router-link>
-          </p>
+          </p> -->
           <p class="terms">
             By signing in to Pennsieve you accept our <a
               class="grey-link"


### PR DESCRIPTION
# Description

Until all demo organization features are done, we will just hide the create account link and then put it back later.



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Navigate to the homepage
2. The `Create one here` link is no longer visible.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
