### PR TITLE
Add Sandbox Organization Blocks

### DIFF
--- a/src/components/bf-navigation/BfNavigationSecondary.vue
+++ b/src/components/bf-navigation/BfNavigationSecondary.vue
@@ -518,8 +518,4 @@ hr {
   margin-top: 5px;
   margin-left: -13px;
 }
-
-.disabled-nav-item {
-  pointer-events: none;
-}
 </style>

--- a/src/components/bf-navigation/BfNavigationSecondary.vue
+++ b/src/components/bf-navigation/BfNavigationSecondary.vue
@@ -148,7 +148,7 @@
         :link="{ name: 'dataset-permissions' }"
         icon="icon-collaborators"
         label="Permissions"
-        class="secondary"
+        :class="hasFeature('sandbox_org_feature') ? 'disabled' : 'secondary' "
         :condensed="secondaryNavCondensed"
       />
 
@@ -517,5 +517,9 @@ hr {
 .el-popper[x-placement^='bottom'] {
   margin-top: 5px;
   margin-left: -13px;
+}
+
+.disabled-nav-item {
+  pointer-events: none;
 }
 </style>

--- a/src/components/bf-navigation/UserMenu/UserMenu.vue
+++ b/src/components/bf-navigation/UserMenu/UserMenu.vue
@@ -43,6 +43,7 @@
               <a
                 href="#"
                 class="bf-menu-item"
+                :class="[maxOrgsCreated ? 'disabled': '']"
                 @click.prevent="requestCreateOrganization"
               >
                 Request to Create New Organization
@@ -242,6 +243,16 @@ export default {
     ]),
 
     /**
+     * Checks where user has created the maximum number of organizations
+     * @returns {Boolean}
+     */
+    maxOrgsCreated: function() {
+      // NOTE: Adding the first condition so that this can go through
+      // as these properties do not exist in the profile object yet
+      return this.profile.maxOrganizationsAllowed === 3 && this.profile.organizationsCreated === this.profile.maxOrganizationsAllowed
+    },
+
+    /**
        * Checks if route is a 404 page
        * @returns {Boolean}
        */
@@ -310,7 +321,9 @@ export default {
      * Open Create Organization Dialog
      */
     openCreateOrganizationDialog: function() {
-      this.isCreateOrgDialogVisible = true
+      if (!this.maxOrgsCreated) {
+        this.isCreateOrgDialogVisible = true
+      }
     },
 
     /**

--- a/src/components/bf-navigation/bf-navigation-item/BfNavigationItem.vue
+++ b/src/components/bf-navigation/bf-navigation-item/BfNavigationItem.vue
@@ -111,6 +111,9 @@
     .svg-icon {
       color: $gray_2;
     }
+    &.disabled {
+      pointer-events: none;
+    }
     &.secondary {
       .svg-icon {
         color: inherit;

--- a/src/mixins/global-message-handler/index.js
+++ b/src/mixins/global-message-handler/index.js
@@ -480,6 +480,9 @@ export default {
       if (!url) {
         return
       }
+      if (this.hasFeature('sandbox_org_feature')) {
+        return
+      }
       return this.sendXhr(url).then(resp => {
         const members = this.updateMembers(resp)
         this.updateOrgMembers(members)

--- a/src/routes/CreateOrg/CreateOrg.vue
+++ b/src/routes/CreateOrg/CreateOrg.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script>
-import { mapState } from 'Vuex'
+import { mapState } from 'vuex'
 
 import BfButton from '@/components/shared/bf-button/BfButton.vue'
 import CreateOrganizationDialog from '@/components/CreateOrganizationDialog/CreateOrganizationDialog'

--- a/src/routes/CreateOrg/CreateOrg.vue
+++ b/src/routes/CreateOrg/CreateOrg.vue
@@ -9,6 +9,7 @@
     <h2>Restricted Access</h2>
     <p>You must create a new organization in order to access this feature on the platform. </p>
     <bf-button
+     :disabled="maxOrgsCreated"
       class="primary"
       @click="requestCreateOrganization"
     >
@@ -22,6 +23,8 @@
 </template>
 
 <script>
+import { mapState } from 'Vuex'
+
 import BfButton from '@/components/shared/bf-button/BfButton.vue'
 import CreateOrganizationDialog from '@/components/CreateOrganizationDialog/CreateOrganizationDialog'
   export default {
@@ -34,6 +37,19 @@ import CreateOrganizationDialog from '@/components/CreateOrganizationDialog/Crea
       return {
         isDialogVisible: false
       }
+    },
+
+    computed: {
+      ...mapState(['profile']),
+     /**
+       * Checks where user has created the maximum number of organizations
+       * @returns {Boolean}
+       */
+      maxOrgsCreated: function() {
+        // NOTE: Adding the first condition so that this can go through
+        // as these properties do not exist in the profile object yet
+        return this.profile.maxOrganizationsAllowed === 3 && this.profile.organizationsCreated === this.profile.maxOrganizationsAllowed
+      },
     },
     methods: {
       openCreateOrgModal: function() {


### PR DESCRIPTION
# Description

Features blocked:
- Call to get all organization users
- Permissions tab
- Disable create organization button when max organizations is reached for a user (This was here from before, not sure if we want to keep it in)


## Clickup Ticket

[u5da3b](https://app.clickup.com/t/u5da3b)


## Type of change

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Get users in sandbox org:

The call to get org users happens during the login process without visual feedback, so to test that it is properly blocked, the devtools will be necessary.
1. Log out
2. Open the network tab in chrome devtools
3. Log in as a sandbox user
4. During the log in, verify that a call to `/organizations/{orgId}/members` is **not** made
5. Open the vue devtools
6. Select the vuex tab
7. In the state object, `orgMembers` should be an empty array `[]`
8. Log in as a non sandbox user
9. Repeat steps 2-7 but make sure the call is made and that `orgMembers` is **not** empty

Permissions tab

1. As a sandbox user
2. Navigate to a dataset's overview page
3. The `Permissions` tab in the secondary nav bar should be greyed out
4. You should not be able to click on the tab
5. Log in as a non sandbox user
6. Repeat step 2
7. The `Permissions` tab should be clickable and not greyed out.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
