### PR TITLE
Fix Onboarding Carousel and ORCID Signup bugs

### DIFF
--- a/src/components/app/App.vue
+++ b/src/components/app/App.vue
@@ -44,7 +44,7 @@
 
     <link-orcid-dialog
       v-if="userToken"
-      :visible.sync="isLinkOrcidDialogVisible"
+      :visible.sync="isLinkOrcidDialogVisibleWrapper"
     />
   </div>
 </template>

--- a/src/components/app/app.js
+++ b/src/components/app/app.js
@@ -119,6 +119,27 @@ export default {
         const orgId = pathOr('', ['organization', 'id'], this.activeOrganization)
         return `${this.config.apiUrl}/organizations/${orgId}/dataset-status?api_key=${this.userToken}`
       }
+    },
+
+    /**
+     * Wrapper to work around visible sync witha vuex
+     * state property
+     */
+    isLinkOrcidDialogVisibleWrapper: {
+      /**
+       * True if the link ORCID dialog should be visible
+       * @returns {Boolean}
+       */
+      get() {
+        return this.isLinkOrcidDialogVisible
+      },
+      /**
+       * Set the value in the vuex store
+       * @param {Boolean} val 
+       */
+      set(val) {
+        this.updateIsLinkOrcidDialogVisible(val)
+      }
     }
   },
 

--- a/src/components/datasets/dataset-list/BfDatasetList.vue
+++ b/src/components/datasets/dataset-list/BfDatasetList.vue
@@ -285,7 +285,8 @@
         'isLoadingDatasets',
         'isLoadingDatasetsError',
         'onboardingEvents',
-        'datasetFilters'
+        'datasetFilters',
+        'gettingStartedOpen'
       ]),
 
       ...mapState('datasetModule', [
@@ -348,16 +349,6 @@
       },
 
       /**
-       * Compute whether or not to render the onboarding carousel
-       * @returns {Boolean}
-       */
-      shouldLaunchCarousel: function() {
-        const launchCarousel = this.onboardingEvents.indexOf('LaunchCarousel') >= 0
-        const lessThan30 = this.userIsLessThan30DaysOld
-        return !launchCarousel && lessThan30
-      },
-
-      /**
        * Computes if datasets exist
        * @returns {Boolean}
        */
@@ -382,9 +373,9 @@
         },
         immediate: true
       },
-      onboardingEvents: {
-        handler: function(val) {
-          if (val && this.shouldLaunchCarousel) {
+      gettingStartedOpen: {
+        handler: function(bool) {
+          if (bool) {
             // onboarding carousel
             this.carouselDialog = OnboardingCarousel
           }

--- a/src/components/onboarding-carousel/OnboardingCarousel.vue
+++ b/src/components/onboarding-carousel/OnboardingCarousel.vue
@@ -171,7 +171,8 @@ export default {
 
   methods: {
     ...mapActions([
-      'updateOnboardingEvents'
+      'updateOnboardingEvents',
+      'setGettingStartedOpen'
     ]),
 
     /**
@@ -227,6 +228,7 @@ export default {
         // Update onboarding events
         const onboardingEvents = [...this.onboardingEvents, 'CompletedCarousel']
         this.updateOnboardingEvents(onboardingEvents)
+        this.setGettingStartedOpen(false)
       })
       .catch(this.handleXhrError.bind(this))
     },

--- a/src/mixins/global-message-handler/index.js
+++ b/src/mixins/global-message-handler/index.js
@@ -15,7 +15,7 @@ import { path, pathOr, propOr, find, pathEq, defaultTo, isEmpty, not, compose, p
 export default {
   data() {
     return {
-      minCompletedEvents: 5,
+      minCompletedEvents: 2,
       datasetStatusList: []
     }
   },
@@ -360,7 +360,7 @@ export default {
      */
     launchOnboarding: function() {
       const events = defaultTo([], this.onboardingEvents)
-      if (this.userIsLessThan30DaysOld && events.length < this.minCompletedEvents && events.indexOf('LaunchCarousel') >= 0) {
+      if (this.userIsLessThan30DaysOld && events.length < this.minCompletedEvents) {
         // getting started guide
         this.setGettingStartedOpen(true)
       } else if (this.shouldShowLinkOrcidDialog) {

--- a/src/site-config/local.json
+++ b/src/site-config/local.json
@@ -4,7 +4,7 @@
   "docsUrl": "https://docs.pennsieve.io",
   "maxDownloadSize": 15000000000,
   "environment": "local",
-  "ORCIDUrl": "https://sandbox.orcid.org/oauth/authorize?client_id=APP-4FK9BTFUGZITFOAJ&response_type=code&scope=/activities/update&redirect_uri=https://app.blackfynn.net/orcid-redirect",
+  "ORCIDUrl": "https://sandbox.orcid.org/oauth/authorize?client_id=APP-4FK9BTFUGZITFOAJ&response_type=code&scope=/activities/update&redirect_uri=https://app.pennsieve.net/orcid-redirect",
   "conceptsUrl": "https://api.pennsieve.net/models",
   "mockApiUrl": "http://localhost:9000",
   "timeSeriesUrl": "wss://api.pennsieve.net/streaming/ts/query",

--- a/src/vuex/store.js
+++ b/src/vuex/store.js
@@ -186,6 +186,7 @@ export const mutations = {
     Vue.set(state, 'searchModalVisible', false)
     Vue.set(state, 'shouldShowLinkOrcidDialog', false)
     Vue.set(state, 'isLinkOrcidDialogVisible', false)
+    Vue.set(state, 'gettingStartedOpen', false)
   },
   UPDATE_CUR_DATASET (state, dataset) {
     Vue.set(state, 'curDataset', dataset)


### PR DESCRIPTION
# Description

Adjusted the Onboarding carousel and Link ORCID dialog to each display only once. The onboarding carousel will appear on initial log in, and must be completed to not be shown. The link ORCID dialog will appear if the onboarding carousel has been completed.

I had to do a funky workaround to allow the link ORCID dialog to actually be closed. The problem was that the `.sync` modifier on the dialog component is using a vuex state property (`isLinkOrcidDialogVisible`), which doesn't play nice with the `event-bus` event to update that value: `this.$emit('update:visible', false)`. I ended up creating a computed property to wrap `isLinkOrcidDialogVisible` and making custom `get()` and `set()` methods such that the event could actually change the value in the store. This seems to work quite well and functions as expected.

Also updated the ORCID redirect uri for local testing.


## Clickup Ticket

[vz86a1](https://app.clickup.com/t/vz86a1)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Create a new account
2. Log in
3. You should be greeted by the onboarding carousel
4. Complete the carousel
5. Log out
6. Log back in
7. You should be greeted by the link ORCID dialog
8. Exit the dialog
9. Log out
10. Log back in
11. No dialogs will pop up


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
