### PR TITLE
Sandbox User Notification Banner

### DIFF
--- a/src/components/SandboxOrganizationBanner/SandboxOrganizationBanner.vue
+++ b/src/components/SandboxOrganizationBanner/SandboxOrganizationBanner.vue
@@ -1,0 +1,48 @@
+<template>
+  <div
+    v-if="hasFeature('sandbox_org_feature')"
+    class="sandbox-banner"
+  >
+    You are in a Sandbox organization with restricted access. Contact us to request your own organization with full access&nbsp;
+    <a href="#" @click.prevent="showIntercom">
+        here
+    </a>
+    .
+  </div>
+</template>
+
+<script>
+  import { mapGetters } from 'vuex';
+
+  export default {
+    computed: {
+      ...mapGetters(['hasFeature'])
+    },
+    
+    methods: {
+      /**
+      * Show intercom window
+      */
+      showIntercom: function() {
+        window.Intercom('show')
+      },
+    }
+  }
+</script>
+
+<style scoped lang="scss">
+  @import '../../assets/_variables';
+
+  .sandbox-banner {
+    background-color: $status_yellow;
+    padding: 18px 0 21px 0;
+    color: white;
+    display: flex;
+    justify-content: center;
+    font-weight: bold;
+    a {
+      color: white;
+      text-decoration: underline;
+    }
+  }
+</style>

--- a/src/components/SandboxOrganizationBanner/SandboxOrganizationBanner.vue
+++ b/src/components/SandboxOrganizationBanner/SandboxOrganizationBanner.vue
@@ -3,11 +3,10 @@
     v-if="hasFeature('sandbox_org_feature')"
     class="sandbox-banner"
   >
-    You are in a Sandbox organization with restricted access. Contact us to request your own organization with full access&nbsp;
-    <a href="#" @click.prevent="showIntercom">
-        here
+    You are working in the Pennsieve Sandbox - Data can be removed periodically.&nbsp;
+    <a href="https://docs.pennsieve.io/docs/pennsieve-sandbox" target="_blank">
+        More Info
     </a>
-    .
   </div>
 </template>
 
@@ -18,7 +17,7 @@
     computed: {
       ...mapGetters(['hasFeature'])
     },
-    
+
     methods: {
       /**
       * Show intercom window

--- a/src/components/layout/BfPage/BfPage.vue
+++ b/src/components/layout/BfPage/BfPage.vue
@@ -3,6 +3,7 @@
     class="bf-page"
     :class="[condensed ? 'condensed' : '']"
   >
+    <sandbox-organization-banner />
     <slot name="banner" />
     <slot name="heading" />
     <slot name="stage" />
@@ -13,9 +14,14 @@
 <script>
   import { pathOr } from 'ramda'
   import EventBus from '../../../utils/event-bus'
+  import SandboxOrganizationBanner from '@/components/SandboxOrganizationBanner/SandboxOrganizationBanner.vue'
 
   export default {
     name: 'BfPage',
+
+    components: {
+      SandboxOrganizationBanner
+    },
 
     data: function() {
       return {

--- a/src/routes/CreateOrg/CreateOrg.vue
+++ b/src/routes/CreateOrg/CreateOrg.vue
@@ -1,25 +1,27 @@
 <template>
-  <bf-page class="create-org">
-    <img
-      src="/static/images/illustrations/illo-research-platform.svg"
-      alt="Patient Data"
-      width="446"
-      height="220"
-    >
-    <h2>Restricted Access</h2>
-    <p>You must create a new organization in order to access this feature on the platform. </p>
-    <bf-button
-     :disabled="maxOrgsCreated"
+  <bf-page>
+    <div class="create-org">
+      <img
+        src="/static/images/illustrations/illo-research-platform.svg"
+        alt="Patient Data"
+        width="446"
+        height="220"
+      >
+      <h2>Restricted Access</h2>
+      <p>You must create a new organization in order to access this feature on the platform. </p>
+      <bf-button
+      :disabled="maxOrgsCreated"
 
-      class="primary"
-      @click="requestCreateOrganization"
-    >
-      Request to Create Organization
-    </bf-button>
-    <create-organization-dialog
-      :visible.sync="isDialogVisible"
-      @close-dialog="onCloseDialog"
-    />
+        class="primary"
+        @click="requestCreateOrganization"
+      >
+        Request to Create Organization
+      </bf-button>
+      <create-organization-dialog
+        :visible.sync="isDialogVisible"
+        @close-dialog="onCloseDialog"
+      />
+    </div>
   </bf-page>
 </template>
 
@@ -76,6 +78,7 @@ import CreateOrganizationDialog from '@/components/CreateOrganizationDialog/Crea
 <style lang="scss" scoped>
 .create-org {
   display: flex;
+  height: 100vh;
   flex-direction: column;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
# Description

Added a site-wide banner at the top of the page to notify sandbox users that they have restricted access. Also added a clickable link to open the intercom menu to request to create an organization.


## Clickup Ticket

[w1fg5m](https://app.clickup.com/t/w1fg5m)


## Type of change

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

1. Log in as a sandbox user.
2. The banner should be immediately visible at the top of the page.
3. Click on the "here" link.
4. The intercom window should open.
5. Close the intercom window.
6. Go to the people, teams, publishing, and my profile pages.
7. The banner should still be visible and the intercom link should work on all the above pages.
8. Log out and log back in as a non-sandbox user.
9. The banner should _not_ be visible.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
