### PR TITLE
enable select files/folders without model relationships

### DIFF
--- a/src/components/datasets/explore/LinkRecordMenu/LinkRecordMenu.vue
+++ b/src/components/datasets/explore/LinkRecordMenu/LinkRecordMenu.vue
@@ -10,26 +10,7 @@
       transition=""
       :visible-arrow="false"
     >
-      <div
-        v-if="modelsWithRecords.length === 0 && modelsWithoutRecords.length === 0"
-        class="empty-state"
-      >
-        <img
-          class="mb-16"
-          src="/static/images/illustrations/illo-missing-relationships.svg"
-          alt=""
-          width="120"
-          height="80"
-        >
-        <h2>No Relationships Defined</h2>
-        <p>
-          Set up some <router-link :to="{ name: 'relationship-types' }">
-            relationship types
-          </router-link> in your models tab to enable links to records.
-        </p>
-      </div>
-
-      <template v-else>
+      <template>
         <div
           v-if="showExistingFile"
           class="bf-menu existing-file-menu"
@@ -41,18 +22,34 @@
                 class="bf-menu-item"
                 @click.prevent="onMenuClick('files')"
               >
-                A File or Folder
+                Files or folders
               </a>
             </li>
           </ul>
         </div>
 
-
         <div class="scroll-wrap">
           <div class="bf-menu scroll-menu">
-            <template v-if="modelsWithRecords.length">
-              <h2>Relationships with Records</h2>
-              <ul>
+            <template >
+              <div
+                v-if="modelsWithRecords.length === 0 && modelsWithoutRecords.length === 0"
+                class="empty-state"
+              >
+
+                <img
+                  class="mb-16"
+                  src="/static/images/illustrations/illo-missing-relationships.svg"
+                  alt=""
+                  width="120"
+                  height="80"
+                >
+                <p>
+                  Set up <router-link :to="{ name: 'relationship-types' }">
+                  relationship types
+                </router-link> for your models to enable linking metadata records.
+                </p>
+              </div>
+              <ul v-else>
                 <li
                   v-for="model in modelsWithRecords"
                   :key="model.id"
@@ -68,19 +65,6 @@
               </ul>
             </template>
 
-            <template v-if="modelsWithoutRecords.length">
-              <h2>Relationships without records</h2>
-              <ul>
-                <li
-                  v-for="model in modelsWithoutRecords"
-                  :key="model.id"
-                >
-                  <span class="bf-menu-item disabled">
-                    {{ model.displayName }}
-                  </span>
-                </li>
-              </ul>
-            </template>
           </div>
         </div>
       </template>
@@ -213,6 +197,7 @@ export default {
 
 <style lang="scss" scoped>
   @import '../../../../assets/_variables.scss';
+  
   .link-record-menu {
     .bf-button {
       border: none;
@@ -227,7 +212,7 @@ export default {
     border-bottom: 1px solid $gray_2;
   }
   .empty-state {
-    padding: 64px 24px;
+    padding: 24px;
     text-align: center;
     p {
       margin: 0;


### PR DESCRIPTION
# Description
fix(metadata-records): Update link-records menu to always show "link files/folders" even if not record-relationships are defined for the model. 


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Updated menu and checked:
1) render for records with no relationships defined in model
2) render for records with relationships in model
3) render for records with relationships in model but no records.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
