### PR TITLE
Link files menu

### DIFF
--- a/src/assets/_variables.scss
+++ b/src/assets/_variables.scss
@@ -13,6 +13,7 @@ $green_2: #14a758;
 
 $black: #000000;
 $white: #ffffff;
+$gray_0: #FAFAF9;
 $gray_1: #F9F9F8;
 $gray_2: #E7E5E1;
 $gray_3: #CAC5BF;

--- a/src/components/datasets/explore/ConceptInstance/ConceptInstance.vue
+++ b/src/components/datasets/explore/ConceptInstance/ConceptInstance.vue
@@ -418,31 +418,31 @@
         </el-collapse>
 
         <!-- BEGIN PROPERTIES TABLE -->
-        <el-collapse
-          v-if="!isFile && !isRecordsLoading"
-          key="properties"
-          v-model="activeSections"
-          class="concept-instance-section collapse-properties no-border"
-        >
-          <el-collapse-item
-            title="Consistency"
-            name="properties"
-          >
-            <div
-              slot="title"
-              class="relationship-title"
-            >
-              <svg-icon
-                class="icon-collapse"
-                name="icon-arrow-up"
-                :dir="arrowDirection('properties')"
-                height="10"
-                width="10"
-                color="#404554"
-              />
-              <h2>Properties</h2>
-            </div>
-
+<!--        <el-collapse-->
+<!--          v-if="!isFile && !isRecordsLoading"-->
+<!--          key="properties"-->
+<!--          v-model="activeSections"-->
+<!--          class="concept-instance-section collapse-properties no-border"-->
+<!--        >-->
+<!--          <el-collapse-item-->
+<!--            title="Consistency"-->
+<!--            name="properties"-->
+<!--          >-->
+<!--            <div-->
+<!--              slot="title"-->
+<!--              class="relationship-title"-->
+<!--            >-->
+<!--              <svg-icon-->
+<!--                class="icon-collapse"-->
+<!--                name="icon-arrow-up"-->
+<!--                :dir="arrowDirection('properties')"-->
+<!--                height="10"-->
+<!--                width="10"-->
+<!--                color="#404554"-->
+<!--              />-->
+<!--              <h2>Properties</h2>-->
+<!--            </div>-->
+        <div class="property-list">
             <concept-instance-property
               v-for="property in properties"
               :key="property.name"
@@ -478,8 +478,9 @@
                 :date="instance.updatedAt"
               />
             </div>
-          </el-collapse-item>
-        </el-collapse>
+<!--          </el-collapse-item>-->
+<!--        </el-collapse>-->
+        </div>
         <!-- END PROPERTIES TABLE -->
 
         <!-- BEGIN FILES TABLE EMPTY STATE -->
@@ -3440,7 +3441,7 @@ export default {
   }
 
   .static-prop-section{
-    margin-top: 16px;
+    margin-top: 8px;
   }
   .collapse-properties .el-collapse-item__wrap {
     padding-bottom: 16px;
@@ -3602,6 +3603,12 @@ export default {
       color: #000;
     }
   }
+}
+
+.property-list {
+  padding: 0 16px;
+  background: $gray_0;
+  margin-bottom: 16px;
 }
 
 .relationships-empty-state {

--- a/src/components/datasets/explore/ConceptInstance/_concept-instance-static-property.scss
+++ b/src/components/datasets/explore/ConceptInstance/_concept-instance-static-property.scss
@@ -4,7 +4,7 @@
   box-sizing: border-box;
   color: $gray_4;
   border-top: 1px solid $gray_2;
-  min-height: 16px;
+  min-height: 49px;
   padding: 8px 0;
   &:first-child {
     border: none;

--- a/src/components/datasets/explore/LinkRecordMenu/LinkRecordMenu.vue
+++ b/src/components/datasets/explore/LinkRecordMenu/LinkRecordMenu.vue
@@ -197,7 +197,7 @@ export default {
 
 <style lang="scss" scoped>
   @import '../../../../assets/_variables.scss';
-  
+
   .link-record-menu {
     .bf-button {
       border: none;

--- a/src/components/datasets/explore/LinkRecordMenu/LinkRecordMenu.vue
+++ b/src/components/datasets/explore/LinkRecordMenu/LinkRecordMenu.vue
@@ -10,26 +10,7 @@
       transition=""
       :visible-arrow="false"
     >
-      <div
-        v-if="modelsWithRecords.length === 0 && modelsWithoutRecords.length === 0"
-        class="empty-state"
-      >
-        <img
-          class="mb-16"
-          src="/static/images/illustrations/illo-missing-relationships.svg"
-          alt=""
-          width="120"
-          height="80"
-        >
-        <h2>No Relationships Defined</h2>
-        <p>
-          Set up some <router-link :to="{ name: 'relationship-types' }">
-            relationship types
-          </router-link> in your models tab to enable links to records.
-        </p>
-      </div>
-
-      <template v-else>
+      <template>
         <div
           v-if="showExistingFile"
           class="bf-menu existing-file-menu"
@@ -41,18 +22,34 @@
                 class="bf-menu-item"
                 @click.prevent="onMenuClick('files')"
               >
-                A File or Folder
+                Files or folders
               </a>
             </li>
           </ul>
         </div>
 
-
         <div class="scroll-wrap">
           <div class="bf-menu scroll-menu">
-            <template v-if="modelsWithRecords.length">
-              <h2>Relationships with Records</h2>
-              <ul>
+            <template >
+              <div
+                v-if="modelsWithRecords.length === 0 && modelsWithoutRecords.length === 0"
+                class="empty-state"
+              >
+
+                <img
+                  class="mb-16"
+                  src="/static/images/illustrations/illo-missing-relationships.svg"
+                  alt=""
+                  width="120"
+                  height="80"
+                >
+                <p>
+                  Set up <router-link :to="{ name: 'relationship-types' }">
+                  relationship types
+                </router-link> for your models to enable linking metadata records.
+                </p>
+              </div>
+              <ul v-else>
                 <li
                   v-for="model in modelsWithRecords"
                   :key="model.id"
@@ -68,19 +65,6 @@
               </ul>
             </template>
 
-            <template v-if="modelsWithoutRecords.length">
-              <h2>Relationships without records</h2>
-              <ul>
-                <li
-                  v-for="model in modelsWithoutRecords"
-                  :key="model.id"
-                >
-                  <span class="bf-menu-item disabled">
-                    {{ model.displayName }}
-                  </span>
-                </li>
-              </ul>
-            </template>
           </div>
         </div>
       </template>
@@ -213,6 +197,7 @@ export default {
 
 <style lang="scss" scoped>
   @import '../../../../assets/_variables.scss';
+  
   .link-record-menu {
     .bf-button {
       border: none;
@@ -227,7 +212,7 @@ export default {
     border-bottom: 1px solid $gray_2;
   }
   .empty-state {
-    padding: 64px 24px;
+    padding: 24px;
     text-align: center;
     p {
       margin: 0;


### PR DESCRIPTION
# Description

other(model-service): Remove collapse menu for properties of a metadata record. Properties should always be visible and no need to add clutter with additional ways to collapse.

# How Has This Been Tested?
Visual inspection on local branch. 
This PR has no functional changes


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
