### PR TITLE
Switch owner by superadmin

### DIFF
--- a/src/components/datasets/collaborators/DatasetCollaborator/DatasetCollaborator.vue
+++ b/src/components/datasets/collaborators/DatasetCollaborator/DatasetCollaborator.vue
@@ -176,7 +176,7 @@ export default {
 
     /**
      * Filter roles for entity
-     * Allow Owners, and SuperAdmins to change ownership
+     * Allow Owners, and SuperAdmins to change ownership of a dataset
      *
      * Only users can become owners of a dataset
      * @returns {Array}

--- a/src/components/datasets/collaborators/DatasetCollaborator/DatasetCollaborator.vue
+++ b/src/components/datasets/collaborators/DatasetCollaborator/DatasetCollaborator.vue
@@ -151,7 +151,8 @@ export default {
     ]),
 
     ...mapGetters([
-      'getPermission'
+      'getPermission',
+      'isUserSuperAdmin'
     ]),
 
     /**
@@ -175,13 +176,15 @@ export default {
 
     /**
      * Filter roles for entity
+     * Allow Owners, and SuperAdmins to change ownership
+     *
      * Only users can become owners of a dataset
      * @returns {Array}
      */
     rolesForEntity: function() {
       const noOwnerRole = this.roles.filter(role => role.value !== 'owner')
 
-      const userRoles = this.datasetRole === 'owner'
+      const userRoles = (this.datasetRole === 'owner' || this.isUserSuperAdmin)
         ? this.roles
         : noOwnerRole
 
@@ -203,7 +206,7 @@ export default {
      */
     canEditCollaborator: function() {
       const role = propOr('viewer', 'permission', this.item)
-      return this.getPermission('manager') && role !== 'owner' && !this.isSystemTeam
+      return (this.getPermission('manager') || this.isSuperAdmin) && role !== 'owner' && !this.isSystemTeam
     },
 
     isSystemTeam: function() {

--- a/src/components/datasets/settings/DatasetSettingsPublishing/DatasetSettingsPublishing.vue
+++ b/src/components/datasets/settings/DatasetSettingsPublishing/DatasetSettingsPublishing.vue
@@ -147,7 +147,8 @@ export default {
       'config',
       'datasetOwnerHasOrcidId',
       'datasetLocked',
-      'getPublishedDataByIntId'
+      'getPublishedDataByIntId',
+      'isUserSuperAdmin'
     ]),
 
     /**
@@ -208,7 +209,7 @@ export default {
         this.datasetTags.length > 0,
         contributors.length > 0,
         Boolean(datasetDescription),
-        Boolean(this.getPermission('owner'))
+        Boolean(this.getPermission('owner') )
       ])
     },
 

--- a/src/vuex/store.js
+++ b/src/vuex/store.js
@@ -888,6 +888,9 @@ export const getters = {
     const owner = getters.datasetOwner
     return pathOr(false, ['orcid', 'orcid'], owner)
   },
+  isUserSuperAdmin: state => {
+    return state.profile.isSuperAdmin === true
+  },
   isUserPublisher: state => {
     return state.publishers.map(p => p.id).includes(state.profile.id)
   },


### PR DESCRIPTION
# Description

Updated front-end to allow superAdmins to change ownership of dataset if they have access to the dataset with any role.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
User with superAdmin role logged in and switched ownership of dataset that user had access to without being owner.
Checked that user without superAdmin role cannot do this 

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
