### PR TITLE
update AWS authentication to use new user pool and user/password flow

### DIFF
--- a/src/site-config/dev.json
+++ b/src/site-config/dev.json
@@ -16,9 +16,10 @@
   "googleMapApi": "xxxxxxxxxxxxxx",
   "mapTiler": "xxxxx",
   "awsConfig": {
+    "authenticationFlowType": "USER_PASSWORD_AUTH",
     "region": "us-east-1",
-    "userPoolId": "us-east-1_XciE1JSvP",
-    "userPoolWebClientId": "2653f5r4vgk8eo1p17nvaftaea"
+    "userPoolId": "us-east-1_FVLhJ7CQA",
+    "userPoolWebClientId": "703lm5d8odccu21pagcfjkeaea"
   },
   "reCAPTCHASiteKey": "6Le2Wr0aAAAAAHouFUEmy7UwN6b9wa_PPRGrWxAG"
 }

--- a/src/utils/aws-exports.js
+++ b/src/utils/aws-exports.js
@@ -5,6 +5,7 @@ const awsConfig = {
     region: config.awsConfig.region,
     userPoolId: config.awsConfig.userPoolId,
     userPoolWebClientId: config.awsConfig.userPoolWebClientId,
+    authenticationFlowType: config.awsConfig.authenticationFlowType,
   }
 }
 export default awsConfig


### PR DESCRIPTION
# Description

This changes the AWS Cognito user pool that is used for authentication. Users will be transparently migrated from the old user pool to the new one upon logging in. This change is necessary to support federated login through ORCID.


## Clickup Ticket

[CLICKUP_TICKET](https://app.clickup.com/t/CLICKUP_TICKET)


## Type of change

_Delete those that don't apply._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] System configuration change


# How Has This Been Tested?

Login multiple times with App and other service changes. Observe user is created in the new user pool -- migrated from the old user pool (user-migration trigger). Observe that `cognito_id` is updated in the `Pennsieve.Users` Postgres table (post-authentication trigger). Login is successful, all dataset and platform access is normal. 


# Checklist:

_Delete those that don't apply. Only apply the final commit message using the changelog when merging a feature to `DEVELOPMENT` that will be deployed to all users._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
