### PR TITLE
feat(integrations): Adding support for custom event tracking

### DIFF
--- a/src/components/Integrations/AddEditIntegrationDialog.vue
+++ b/src/components/Integrations/AddEditIntegrationDialog.vue
@@ -222,6 +222,15 @@
             <div class="check-description">
               All stages of publishing process
             </div>
+
+            <el-checkbox
+              v-model="integration.eventTypeList.CUSTOM"
+              class="input-property"
+              label="Custom"
+            />
+            <div class="check-description">
+              Custom events from users and integrations
+            </div>
           </el-form-item>
         </el-form>
       </div>
@@ -285,7 +294,8 @@ const defaultIntegration = () => (
       RECORDS_AND_MODELS: false,
       FILES: false,
       PERMISSIONS: false,
-      PUBLISHING: false
+      PUBLISHING: false,
+      CUSTOM: false
     }
   }
 )
@@ -457,7 +467,7 @@ export default {
 
       if (this.editingIntegration) {
         // set properties in local state to be referenced in createIntegration fn
-        var ei = this.integrationEdit
+        const ei = this.integrationEdit
         this.integration.displayName = ei.displayName
         this.integration.apiUrl = ei.apiUrl
         this.integration.name = ei.name

--- a/src/components/datasets/DatasetActivity/DatasetActivityDetail/DatasetActivityDetail.vue
+++ b/src/components/datasets/DatasetActivity/DatasetActivityDetail/DatasetActivityDetail.vue
@@ -414,6 +414,19 @@
         <p>{{ eventDetail.detail.newStatus.displayName }}</p>
       </div>
     </div>
+
+    <div
+      v-if="eventDetail.eventType === 'CUSTOM_EVENT'"
+      class="dataset-activity-detail__info"
+    >
+      <div class="info-title">
+        <p>Message:</p>
+      </div>
+      <div class="dataset-activity-detail__info-link">
+        <p>{{ eventDetail.detail.message }}</p>
+      </div>
+    </div>
+
   </div>
 </template>
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -197,9 +197,12 @@ export const ChangelogMessage = Object.freeze({
     plural: 'records deleted',
     singular: 'Record deleted'
   },
-
   CREATE_DATASET: {
     singular: 'Dataset created'
+  },
+  CUSTOM_EVENT: {
+    plural: 'custom events triggered',
+    singular: 'custom event triggered'
   },
 
   PUBLISHING: {


### PR DESCRIPTION
# Description

Add new category for events when users manage integrations. CUSTOM events are triggered by the user by using the POST /dataset/<id>/event endpoint. Now, integrations can be configured to listen to those events. This can be leveraged by external platforms to send messages to other platforms in context of a dataset


## Clickup Ticket

[CLICKUP_TICKET](https://app.clickup.com/t/22gr4ex)


## Type of change

_Delete those that don't apply._
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
Locally created a new integration and selected to track CUSTOM events.
Using the swagger documentation, generated an event and:
1) Checked that the event shows up in the changelog
2) Checked that the event is pushed to the API endpoint described in the integration


# Checklist:

_Delete those that don't apply. Only apply the final commit message using the changelog when merging a feature to `DEVELOPMENT` that will be deployed to all users._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
