### PR TITLE
Forbid commas in dataset names

### DIFF
--- a/src/mixins/sanitize-name/index.js
+++ b/src/mixins/sanitize-name/index.js
@@ -3,19 +3,19 @@
  * @param {String} name
  * @returns {Boolean}
  */
-const containsReservedChars = name => /[\\,/,:,*,?,",<,>,.]/.test(name)
+const containsReservedChars = name => /[\\/:*?"<>.,]/.test(name)
 
 /**
  * Removes reserved characters from a given string
  * @param {String} name
  * @returns {String}
  */
-const sanitizeName = name => name.replace(/[\\,/,:,*,?,",<,>,.]/g, '')
+const sanitizeName = name => name.replace(/[\\/:*?"<>.,]/g, '')
 
 export default {
   data() {
     return {
-      reservedCharsStr: '\\ / : * ? " < > .'
+      reservedCharsStr: '\\ / : * ? " < > . ,'
     }
   },
   methods: {

--- a/src/mixins/sanitize-name/sanitize-name.spec.js
+++ b/src/mixins/sanitize-name/sanitize-name.spec.js
@@ -45,5 +45,10 @@ describe('Sanitize Name Mixin', () => {
     const sanitizedStr5 = cmp.vm.sanitizeName(str5)
     expect('').toBe(sanitizedStr5)
     expect(cmp.vm.containsReservedChars(str5)).toBe(true)
+
+    const str6 = 'a,b,c'
+    const santizedStr6 = cmp.vm.sanitizeName(str6)
+    expect(santizedStr6).toBe(orig)
+    expect(cmp.vm.containsReservedChars(str6)).toBe(true)
   })
 })


### PR DESCRIPTION
# Description

Adds comma to the list of characters forbidden in a dataset name. Removes redundancy from regular expressions used to validate/sanitize dataset names.


## Clickup Ticket

[Include comma as invalid character in dataset name](https://app.clickup.com/t/2t8mcmd)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)



# How Has This Been Tested?

Added case to existing unit test.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added unit tests that prove my fix is effective or that my feature works

