### PR TITLE
Improve user login experience

### DIFF
--- a/src/components/shared/BfLogInDialog/BfLogInDialog.vue
+++ b/src/components/shared/BfLogInDialog/BfLogInDialog.vue
@@ -465,15 +465,24 @@ export default {
           this.logInForm.password
         )
         // this.handleLoginSuccess(user)
+        EventBus.$emit('toast', {
+          detail: {
+            type: 'info',
+            msg: `Login successful. Loading Workspace, please wait.`,
+            duration: 5000
+          }
+        })
         this.$emit('succesfulLogin', user)
       } catch (error) {
         EventBus.$emit('toast', {
           detail: {
-            msg: `There was an error with your login attempt. Please try again.`
+            type: 'error',
+            msg: `Incorrect username or password. Please try again.`
           }
         })
       }
       this.isLoggingIn = false
+      this.closeLogInDialog()
     },
 
     async initiateFederatedLogin(provider) {
@@ -486,6 +495,7 @@ export default {
         this.isLoggingIn = false
         EventBus.$emit('toast', {
           detail: {
+            type: 'error',
             msg: `There was an error with your federated login attempt. Please try again.`
           }
         })


### PR DESCRIPTION
# Description

When a user successfully authenticates, the `isLoggingIn` flag is cleared (making the Sign In button clickable) and the Login dialog is closed. In addition, a 'toast' message is sent indicating that authentication was successful and letting the users know that the workspace is being loaded.

## Clickup Ticket

[Improve Responsiveness of the Pennsieve Login Experience](https://app.clickup.com/t/2w40ufb)


## Type of change

_Delete those that don't apply._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

locally


# Checklist:

_Delete those that don't apply. Only apply the final commit message using the changelog when merging a feature to `DEVELOPMENT` that will be deployed to all users._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
