### PR TITLE
fix: don't close login dialog on authentication failure

### DIFF
--- a/src/components/shared/BfLogInDialog/BfLogInDialog.vue
+++ b/src/components/shared/BfLogInDialog/BfLogInDialog.vue
@@ -473,6 +473,7 @@ export default {
           }
         })
         this.$emit('succesfulLogin', user)
+        this.closeLogInDialog()
       } catch (error) {
         EventBus.$emit('toast', {
           detail: {
@@ -480,9 +481,9 @@ export default {
             msg: `Incorrect username or password. Please try again.`
           }
         })
+        this.logInForm.password = ''
       }
       this.isLoggingIn = false
-      this.closeLogInDialog()
     },
 
     async initiateFederatedLogin(provider) {


### PR DESCRIPTION
# Description

If the username or password is incorrect, then authentication with Cognito will fail. The user is notified of the authentication failure by a specific 'toast' message. In this case, the password field of the login is cleared and the dialog is not closed -- this provides the user the ability to type the password again, without having to click "login" and re-enter the username.


## Clickup Ticket

[CLICKUP_TICKET](https://app.clickup.com/t/CLICKUP_TICKET)


## Type of change

_Delete those that don't apply._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


# Checklist:

_Delete those that don't apply. Only apply the final commit message using the changelog when merging a feature to `DEVELOPMENT` that will be deployed to all users._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
