### PR TITLE
Fix/undelete checkboxes

### DIFF
--- a/src/components/BfUpload/BfUpload.scss
+++ b/src/components/BfUpload/BfUpload.scss
@@ -32,7 +32,6 @@
   display: flex;
   flex: 1;
   flex-direction: column;
-  
   overflow: hidden;
 }
 

--- a/src/components/BfUpload/BfUpload.scss
+++ b/src/components/BfUpload/BfUpload.scss
@@ -32,7 +32,6 @@
   display: flex;
   flex: 1;
   flex-direction: column;
-
   overflow: hidden;
 }
 

--- a/src/components/BfUpload/BfUpload.scss
+++ b/src/components/BfUpload/BfUpload.scss
@@ -32,6 +32,7 @@
   display: flex;
   flex: 1;
   flex-direction: column;
+
   overflow: hidden;
 }
 

--- a/src/components/BfUpload/BfUpload.scss
+++ b/src/components/BfUpload/BfUpload.scss
@@ -32,6 +32,7 @@
   display: flex;
   flex: 1;
   flex-direction: column;
+  
   overflow: hidden;
 }
 

--- a/src/components/DeletedFiles/DeletedFiles.vue
+++ b/src/components/DeletedFiles/DeletedFiles.vue
@@ -24,7 +24,7 @@
               @navigate-breadcrumb="handleNavigateBreadcrumb"
             />
           </div>
-          <table-wrapper>
+          <table-wrapper class="table-wrapper">
             <files-table
               v-if="hasFiles"
               :data="files"
@@ -523,14 +523,15 @@ Need to reach into packages list instead of pulling stuff from url
   margin: -295px 0 0 -350px;
   width: 700px;
 }
-bf-upload-body {
-  height: 200px;
-  overflow-y: auto;
-}
-table-wrapper {
+
+.table-wrapper {
   overflow-y: scroll;
   display: block;
-  height: 660px;
+  max-height: 450px;
   margin-top: 1px;
+}
+
+.bf-upload-body {
+  border-bottom: 1px solid $gray_2;
 }
 </style>

--- a/src/components/DeletedFiles/DeletedFiles.vue
+++ b/src/components/DeletedFiles/DeletedFiles.vue
@@ -374,7 +374,9 @@ export default {
         this.$route.name === 'dataset-files'
           ? this.$route.params.datasetId
           : this.$route.params.fileId
-      const nodeIds = this.selectedDeletedFiles.map(item => item.node_id)
+      const nodeIds = this.selectedDeletedFiles
+        // .filter(item => item.state !== 'READY')
+        .map(item => item.node_id)
       const options = {
         method: 'POST',
         headers: {

--- a/src/components/DeletedFiles/DeletedFiles.vue
+++ b/src/components/DeletedFiles/DeletedFiles.vue
@@ -24,7 +24,7 @@
               @navigate-breadcrumb="handleNavigateBreadcrumb"
             />
           </div>
-          <table-wrapper class="table-wrapper">
+          <div class="table-container">
             <files-table
               v-if="hasFiles"
               :data="files"
@@ -36,7 +36,7 @@
               @selection-change="deleteSetSelectedFiles"
               @click-file-label="onClickLabelDelete"
             />
-          </table-wrapper>
+          </div>
         </div>
       </div>
 
@@ -524,7 +524,7 @@ Need to reach into packages list instead of pulling stuff from url
   width: 700px;
 }
 
-.table-wrapper {
+.table-container {
   overflow-y: scroll;
   display: block;
   max-height: 450px;
@@ -533,5 +533,6 @@ Need to reach into packages list instead of pulling stuff from url
 
 .bf-upload-body {
   border-bottom: 1px solid $gray_2;
+  border-radius: 5px;
 }
 </style>

--- a/src/components/DeletedFiles/DeletedFiles.vue
+++ b/src/components/DeletedFiles/DeletedFiles.vue
@@ -374,9 +374,7 @@ export default {
         this.$route.name === 'dataset-files'
           ? this.$route.params.datasetId
           : this.$route.params.fileId
-      const nodeIds = this.selectedDeletedFiles
-        // .filter(item => item.state !== 'READY')
-        .map(item => item.node_id)
+      const nodeIds = this.selectedDeletedFiles.map(item => item.node_id)
       const options = {
         method: 'POST',
         headers: {

--- a/src/components/FilesTable/FilesTable.vue
+++ b/src/components/FilesTable/FilesTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="files-table">
+  <div class="files-table" :class="withinDeleteMenu && 'undelete-modal'">
     <div v-if="selection.length > 0" class="selection-menu-wrap mb-16">
       <el-checkbox
         id="check-all"
@@ -427,9 +427,13 @@ export default {
   flex: 1 1 auto;
   min-width: 0;
   min-height: calc(100vh - 200px);
+  &.undelete-modal {
+    min-height: calc(100vh - 500px);
+  }
   border: 1px solid $gray_2;
   border-radius: 4px;
 }
+
 .el-table {
   width: 100%;
 }

--- a/src/components/FilesTable/FilesTable.vue
+++ b/src/components/FilesTable/FilesTable.vue
@@ -82,7 +82,13 @@
       @sort-change="onSortChange"
       @row-click="onRowClick"
     >
-      <el-table-column type="selection" align="center" fixed width="50" />
+      <el-table-column
+        type="selection"
+        align="center"
+        :selectable="withinDeleteMenu ? canSelectRow : null"
+        fixed
+        width="50"
+      />
       <el-table-column
         v-if="searchAllDataMenu"
         prop="datasetName"
@@ -266,6 +272,10 @@ export default {
       this.$refs.table.toggleRowSelection(row, selected)
     },
 
+    canSelectRow: row => {
+      return row.state === 'DELETED'
+    },
+
     /**
      * Checkbox display logic
      * @param {Object} store
@@ -413,7 +423,8 @@ export default {
 
       return `${tableRow.row.state !== 'DELETED' &&
         this.withinDeleteMenu &&
-        'disable-select'} file-row-${trimmedId}`
+        'disable-select'} ${tableRow.row.state === 'READY' &&
+        'allow-file-navigation'} file-row-${trimmedId}`
     }
   }
 }
@@ -519,11 +530,7 @@ export default {
     pointer-events: none;
   }
 
-  .disable-select span {
-    display: none;
-  }
-
-  .disable-select button {
+  .allow-file-navigation button {
     pointer-events: auto;
   }
 

--- a/src/components/FilesTable/FilesTable.vue
+++ b/src/components/FilesTable/FilesTable.vue
@@ -430,7 +430,8 @@ export default {
   border: 1px solid $gray_2;
   border-radius: 4px;
   &.undelete-modal {
-    min-height: calc(100vh - 530px);
+    min-height: calc(100vh - 400px);
+    border-bottom: none;
   }
 }
 

--- a/src/components/FilesTable/FilesTable.vue
+++ b/src/components/FilesTable/FilesTable.vue
@@ -445,7 +445,6 @@ export default {
     border-bottom: none;
   }
 }
-
 .el-table {
   width: 100%;
 }

--- a/src/components/FilesTable/FilesTable.vue
+++ b/src/components/FilesTable/FilesTable.vue
@@ -427,11 +427,11 @@ export default {
   flex: 1 1 auto;
   min-width: 0;
   min-height: calc(100vh - 200px);
-  &.undelete-modal {
-    min-height: calc(100vh - 500px);
-  }
   border: 1px solid $gray_2;
   border-radius: 4px;
+  &.undelete-modal {
+    min-height: calc(100vh - 530px);
+  }
 }
 
 .el-table {

--- a/src/components/datasets/files/BfDatasetFiles.vue
+++ b/src/components/datasets/files/BfDatasetFiles.vue
@@ -12,7 +12,7 @@
       </div>
     </bf-rafter>
     <div>
-      <div v-if="hasFiles" class="actions-container">
+      <div v-if="!isLoading" class="actions-container">
         <button class="undelete-button actions-item" @click="NavToDeleted">
           <svg-icon class="mr-8" icon="icon-trash" height="22" width="22" />
           <div>Restore Deleted</div>
@@ -75,7 +75,7 @@
           @click-file-label="onClickLabel"
         />
         <file-metadata-info
-          v-if="hasFiles"
+          v-if="!isLoading"
           :selectedFiles="selectedFiles"
           :ancestors="ancestors"
           :folder="file"

--- a/src/components/datasets/files/Metadata/FileMetadataInfo.vue
+++ b/src/components/datasets/files/Metadata/FileMetadataInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <bf-page v-show="true">
+  <bf-page>
     <div class="file-meta-data-info">
       <div class="header"><div>Details</div></div>
       <template v-if="showFileFolderInfo">


### PR DESCRIPTION
# Description

This PR contains: 

- some styling improvements
- disable select when item in the file explorer is not in DELETED state 
- disable navigation click on file when it's not in READY or DELETED state 

This should clear up a defect that was logged where you can click through a folder with files that are currently deleting (or restoring) and see missing folder contents, and another defect where you could select and attempt to restore a folder that was never deleted (i.e. in READY state).

## Clickup Ticket

[Clickup Ticket](https://app.clickup.com/t/860qh0gae)

## Type of change

_Delete those that don't apply._

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

locally on dummy data 


# Checklist:

_Delete those that don't apply. Only apply the final commit message using the changelog when merging a feature to `DEVELOPMENT` that will be deployed to all users._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have pushed the final commit message using the [changelog format](https://github.com/Pennsieve/pennsieve-app/wiki/CHANGELOG)
