### PR TITLE
BUG: Restore Request Sending Wrong Dataset ID

### DIFF
--- a/src/components/DeletedFiles/DeletedFiles.vue
+++ b/src/components/DeletedFiles/DeletedFiles.vue
@@ -376,7 +376,7 @@ export default {
         })
     },
     /**
-     * method moves selection(s) back to the datasets file storage (unmarked as deleted)
+     * Method calls the restore endpoint which moves selection(s) back to the datasets file storage (unmarked as deleted).
      * @param {String} destination}
      * @param {Array} items
      */

--- a/src/components/DeletedFiles/DeletedFiles.vue
+++ b/src/components/DeletedFiles/DeletedFiles.vue
@@ -381,10 +381,6 @@ export default {
      * @param {Array} items
      */
     moveBackToFiles: function() {
-      const id =
-        this.$route.name === 'dataset-files'
-          ? this.$route.params.datasetId
-          : this.$route.params.fileId
       const nodeIds = this.selectedDeletedFiles.map(item => item.node_id)
       const options = {
         method: 'POST',
@@ -395,7 +391,12 @@ export default {
         },
         body: JSON.stringify({ nodeIds })
       }
-      fetch(`${this.config.api2Url}/packages/restore?dataset_id=${id}`, options)
+      fetch(
+        `${this.config.api2Url}/packages/restore?dataset_id=${
+          this.$route.params.datasetId
+        }`,
+        options
+      )
         .then(response => {
           if (response.ok) {
             this.onRestoreItems(response.json())


### PR DESCRIPTION
Updated the code so we are sending the `datasetId` instead of the `fileId` when the restore endpoint is called in all cases. 

Previously we were sending `datasetId` when restore was called on the main files page (`dataset-files` route) and the `fileId` on all other routes (which included when the endpoint was called when the user is interacting with the undelete modal). I removed this so now we are always sending the datasetId to the restore endpoint. 

Tested undelete functionality locally after the change and it is working as expected. 
