### PR TITLE
fix/pagination

### DIFF
--- a/src/components/datasets/files/BfDatasetFiles.vue
+++ b/src/components/datasets/files/BfDatasetFiles.vue
@@ -282,7 +282,7 @@ export default {
   },
   mounted: function() {
     if (this.getFilesUrl && !this.files.length) {
-      this.getFilesUrl
+      this.fetchFiles()
     }
     this.$el.addEventListener('dragenter', this.onDragEnter.bind(this))
     EventBus.$on('add-uploaded-file', this.onAddUploadedFile.bind(this))

--- a/src/components/datasets/files/BfDatasetFiles.vue
+++ b/src/components/datasets/files/BfDatasetFiles.vue
@@ -15,7 +15,7 @@
       <bf-stage
         class="bf-stage-file"
         slot="stage"
-        v-loading="files.length > 0 && isLoading"
+        v-loading="isLoading"
         element-loading-background="transparent"
       >
         <div>


### PR DESCRIPTION
PR for a small fix - I had changed a this.fetchFiles() to this.getFilesUrl, and it worked except on initial mount (the files didn't load unless you hard refreshed). So this is just changing it back to fetchFiles() on mounted. 

Also removed a length check I had put on the isLoading property, it isn't needed. 
