### PR TITLE
hotfix for labeling while navigating back to files from record

### DIFF
--- a/src/components/shared/bf-rafter/BfRafter.vue
+++ b/src/components/shared/bf-rafter/BfRafter.vue
@@ -10,7 +10,12 @@
     </template>
     <template v-if="backLinkVisible">
       <div class="link-back" @click.prevent="pageBackRoute">
-        < Back to {{linkBack.name}}
+        <div v-if="isFileRecord">
+          < Back to Files
+        </div>
+        <div v-else>
+          < Back to {{linkBack.name}}
+        </div>
       </div>
     </template>
 
@@ -366,6 +371,10 @@ export default {
 
     backLinkVisible: function() {
       return Object.keys(this.linkBack).length > 0
+    },
+
+    isFileRecord: function() {
+      return this.$route.name == "file-record";
     },
 
     ...mapGetters(['getPermission', 'userToken', 'config']),

--- a/src/components/shared/bf-rafter/BfRafter.vue
+++ b/src/components/shared/bf-rafter/BfRafter.vue
@@ -374,7 +374,7 @@ export default {
     },
 
     isFileRecord: function() {
-      return this.$route.name == "file-record";
+      return this.$route.name === "file-record";
     },
 
     ...mapGetters(['getPermission', 'userToken', 'config']),


### PR DESCRIPTION
# Description

Hotfix for changing rafter labeling to accurately indicate that user is navigating back to a files list from a file record.


## Clickup Ticket

[[CLICKUP_TICKET](https://app.clickup.com/t/CLICKUP_TICKET)](https://app.clickup.com/t/862jw3emn)


## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)



# How Has This Been Tested?

tested locally to verify that it handles records and files cases


