### PR TITLE
Make changelog field on Overview view editable

### DIFF
--- a/src/components/datasets/DatasetOverview/DatasetOverview.vue
+++ b/src/components/datasets/DatasetOverview/DatasetOverview.vue
@@ -338,6 +338,7 @@
             Save
           </button>
           <button
+            v-else
             slot="title-aux"
             class="linked-9"
             :disabled="datasetLocked"

--- a/src/components/datasets/DatasetOverview/DatasetOverview.vue
+++ b/src/components/datasets/DatasetOverview/DatasetOverview.vue
@@ -337,6 +337,15 @@
           >
             Save
           </button>
+          <button
+            v-else
+            slot="title-aux"
+            class="linked-9"
+            :disabled="datasetLocked"
+            @click="isEditingMarkdown2 = true"
+          >
+            Update
+          </button>
         </template>
       <markdown-editor
         ref="markdownEditor"

--- a/src/components/datasets/DatasetOverview/DatasetOverview.vue
+++ b/src/components/datasets/DatasetOverview/DatasetOverview.vue
@@ -338,7 +338,6 @@
             Save
           </button>
           <button
-            v-else
             slot="title-aux"
             class="linked-9"
             :disabled="datasetLocked"


### PR DESCRIPTION
# Description

This PR makes it so users can edit the Changelog field at /overview on dataset when the dataset is NOT locked. When the dataset IS locked, only users who are publishers will be able to edit it at /overview. 


## Clickup Ticket

[Changelog - enable publisher's editing abilities](https://app.clickup.com/t/85zt98bbk)


## Type of change

_Delete those that don't apply._

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

locally - going to test the whole feature (FE and BE) with Edmore in dev. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
