### PR TITLE
Feature/prevent logouts

### DIFF
--- a/src/mixins/request/index.js
+++ b/src/mixins/request/index.js
@@ -98,7 +98,7 @@ export default {
       } // logout
       else if (status === 401) {
         // debugger
-        return this.handleLogout()
+        EventBus.$emit('ajaxError', err)
       } // unauthorized
       // else if (status === 403) {
       //   return this.$router.replace({name: 'datasets-list'})

--- a/src/mixins/request/index.js
+++ b/src/mixins/request/index.js
@@ -95,16 +95,7 @@ export default {
             }
           })
         })
-      } // logout
-      else if (status === 401) {
-        // debugger
-        EventBus.$emit('ajaxError', err)
-      } // unauthorized
-      // else if (status === 403) {
-      //   return this.$router.replace({name: 'datasets-list'})
-        // }
-      else {
-        // emit ajaxError
+      } else {
         EventBus.$emit('ajaxError', err)
       }
     }


### PR DESCRIPTION
# Description

I removed the case where the API returns a 401 and the user is logged out. I could not produce a scenario where it was not preferable to return a AJAX error toast with the specific error, rather than logging the user out. 

## Clickup Ticket

[https://app.clickup.com/t/862jwhtg8](https://app.clickup.com/t/862jwhtg8)


## Type of change

_Delete those that don't apply._

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

I tested this feature locally by recreating a situation where the API returns a 401. 

