### PR TITLE
Orcidupdate/update orcid on publish

### DIFF
--- a/src/components/datasets/settings/DatasetSettingsPublishing/OwnerOrcid.vue
+++ b/src/components/datasets/settings/DatasetSettingsPublishing/OwnerOrcid.vue
@@ -56,6 +56,17 @@
         <div v-else class="orcid-waiting">
           <el-row><div v-loading="loadingOrcid" class="orcid-loader" /></el-row>
         </div>
+        <el-row class="mt-20" v-if="!publishToOrcid">
+              <router-link
+                class="bf-menu-item"
+                :to="{
+                  name: 'my-settings-container',
+                  params: { orgId: this.activeOrganizationId }
+                }"
+              >
+                Allow  Pennsieve to publish works to ORCHID
+          </router-link>
+        </el-row>
       </div>
     </div>
     <delete-orcid
@@ -87,7 +98,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['datasetOwnerHasOrcidId', 'hasOrcidId', 'profile']),
+    ...mapGetters(['datasetOwnerHasOrcidId', 'hasOrcidId', 'publishToOrcid', 'profile']),
 
     ...mapState(['config', 'activeOrganization']),
 
@@ -207,6 +218,9 @@ export default {
   }
 }
 
+.mt-20{
+    margin-top: 20px;
+  }
 p {
   color: black;
 }

--- a/src/components/my-settings/MySettingsContainer.vue
+++ b/src/components/my-settings/MySettingsContainer.vue
@@ -320,10 +320,12 @@
                   />
                 </el-row>
               </div>
-              <el-row v-if="!publishToOrcid">
-                    <bf-button @click="openORCID">
-                      Publish datasets to ORCID
+              <el-row class="mt-20" v-if="!publishToOrcid">
+                <el-tooltip placement="right" content="Authorize Pennsieve to update ORCID with all of your Published Datasets">
+                  <bf-button @click="openORCID">
+                      Update ORCID Publish Preferences
                     </bf-button>
+                </el-tooltip>
                </el-row>
             </div>
           </el-row>

--- a/src/components/my-settings/MySettingsContainer.vue
+++ b/src/components/my-settings/MySettingsContainer.vue
@@ -308,6 +308,7 @@
                   </button>
                 </el-col>
               </div>
+              
               <div
                 v-else
                 class="orcid-waiting"
@@ -319,6 +320,11 @@
                   />
                 </el-row>
               </div>
+              <el-row v-if="!publishToOrcid">
+                    <bf-button @click="openORCID">
+                      Publish datasets to ORCID
+                    </bf-button>
+               </el-row>
             </div>
           </el-row>
         </el-col>
@@ -452,7 +458,7 @@ export default {
       'cognitoUser'
     ]),
 
-    ...mapGetters(['hasOrcidId']),
+    ...mapGetters(['hasOrcidId','publishToOrcid']),
 
     /**
      * Checks whether or not auth is enabled
@@ -476,6 +482,16 @@ export default {
       return `${url}/token?api_key=${userToken}`
     },
     updateProfileUrl: function() {
+      const url = pathOr('', ['config', 'apiUrl'])(this)
+      const userToken = prop('userToken', this)
+
+      if (!url || !userToken) {
+        return ''
+      }
+
+      return `${url}/user?api_key=${userToken}`
+    },
+    getProfileUrl:function(){
       const url = pathOr('', ['config', 'apiUrl'])(this)
       const userToken = prop('userToken', this)
 
@@ -824,7 +840,10 @@ export default {
     updateORCID2: function(){
       this.isDeleteOrcidDialogVisible = false
     },
-
+    updateORCIDPermissions:function(){
+      console.log("call for authorization popup and listen for return");
+      console.log("update permissions for user");
+    },
     /**
      * Open api key dialog
      * @param {String} refName
@@ -891,7 +910,6 @@ export default {
           }
       })
     },
-
     /**
      * Opens deleteORCID modal
      * @param {String} refName

--- a/src/components/my-settings/MySettingsContainer.vue
+++ b/src/components/my-settings/MySettingsContainer.vue
@@ -491,16 +491,6 @@ export default {
 
       return `${url}/user?api_key=${userToken}`
     },
-    getProfileUrl:function(){
-      const url = pathOr('', ['config', 'apiUrl'])(this)
-      const userToken = prop('userToken', this)
-
-      if (!url || !userToken) {
-        return ''
-      }
-
-      return `${url}/user?api_key=${userToken}`
-    },
     updateEmailUrl: function() {
       const url = pathOr('', ['config', 'apiUrl'])(this)
       const userToken = prop('userToken', this)
@@ -839,10 +829,6 @@ export default {
     },
     updateORCID2: function(){
       this.isDeleteOrcidDialogVisible = false
-    },
-    updateORCIDPermissions:function(){
-      console.log("call for authorization popup and listen for return");
-      console.log("update permissions for user");
     },
     /**
      * Open api key dialog

--- a/src/vuex/store.js
+++ b/src/vuex/store.js
@@ -912,6 +912,9 @@ export const getters = {
   hasOrcidId: (state) => {
     return pathOr(false, ['profile', 'orcid', 'orcid'], state)
   },
+  publishToOrcid:(state)=>{
+    return state.profile.orcid.scope && state.profile.orcid.scope[1] && state.profile.orcid.scope[1]==='/activities/update';
+  },
   datasetOwnerHasOrcidId: (state, getters) => {
     const owner = getters.datasetOwner
     return pathOr(false, ['orcid', 'orcid'], owner)

--- a/src/vuex/store.js
+++ b/src/vuex/store.js
@@ -14,6 +14,7 @@ import metadataModule from './modules/metadataModule'
 
 Vue.use(Vuex)
 
+
 // helpers
 const getDataset = pathOr({}, ['detail', 'dataset'])
 const getUploadDestination = propOr({}, 'content')


### PR DESCRIPTION
# Description

Updated the settings & dataset-publishing pages to include options for updated their ORCID permissions. 
If user has orcid linked AND they don't have publishing permissions, they are shown a button that will let them update their permissions. 

## Clickup Ticket

[[CLICKUP_TICKET](https://app.clickup.com/t/CLICKUP_TICKET)](https://app.clickup.com/t/868656hwq)


## Type of change

_Delete those that don't apply._


- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

MysettingsContainer.vue & OwnerOrcid.vue

- Button should not exist if hasOrcidId==false. toggle variable conditional (line 251) to see button disappear
- Button should disappear after updating preferences
- OwnerOrcid.vue redirects user to the settings page. 



# Checklist:

_Delete those that don't apply. Only apply the final commit message using the changelog when merging a feature to `DEVELOPMENT` that will be deployed to all users._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
