### PR TITLE
AppStore: Enable users to define a target directory when they run an application (frontend)

### DIFF
--- a/src/components/Integrations/AddEditIntegrationDialog.vue
+++ b/src/components/Integrations/AddEditIntegrationDialog.vue
@@ -5,6 +5,7 @@
     :show-close="false"
     @open="onOpen"
     @close="closeDialog"
+    :close-on-click-modal="false"
   >
     <bf-dialog-header slot="title" :title="dialogTitle" />
 
@@ -116,6 +117,16 @@
             <el-input
               v-model="integration.imageUrl"
               placeholder="http://<examplehost>/image.jpg"
+            />
+          </el-form-item>
+          <el-form-item prop="targetPath">
+            <template slot="label">
+              Specify path to folder for output
+              <span class="label-helper">optional</span>
+            </template>
+            <el-input
+              v-model="integration.targetPath"
+              placeholder="folder/nested-folder/deeply-nested-folder"
             />
           </el-form-item>
 
@@ -311,6 +322,7 @@ const defaultIntegration = () => ({
   description: '',
   apiUrl: '',
   imageUrl: '',
+  targetPath: '',
   secret: '',
   isDefault: false,
   isDisabled: false,

--- a/src/components/Integrations/IntegrationsList/IntegrationsList.vue
+++ b/src/components/Integrations/IntegrationsList/IntegrationsList.vue
@@ -182,7 +182,6 @@ export default {
       this.removeIntegrationDialogVisible = true
     },
     onDeleteIntegrationConfirm: function(integration) {
-      console.log('do deletion on ' + integration.id)
       this.removeIntegration(integration.id)
       this.removeIntegrationDialogVisible = false
     },

--- a/src/components/Integrations/IntegrationsList/IntegrationsList.vue
+++ b/src/components/Integrations/IntegrationsList/IntegrationsList.vue
@@ -1,19 +1,12 @@
 <template>
   <bf-page class="integrations-list">
-
-    <bf-stage
-      slot="stage"
-      element-loading-background="transparent"
-    >
+    <bf-stage slot="stage" element-loading-background="transparent">
       <div class="addIntegrationContainer">
-
-
-
         <div class="description">
-
           <p class="mb-16">
-            Webhooks provide mechanisms to notify external applications of events that happen on the Pennsieve platform, such as "File Uploaded", or "Description updated".
-
+            Webhooks provide mechanisms to notify external applications of
+            events that happen on the Pennsieve platform, such as "File
+            Uploaded", or "Description updated".
 
             <a
               href="https://docs.pennsieve.io/docs/preventing-files-from-being-included-during-publishing"
@@ -22,26 +15,16 @@
               What's this?
             </a>
           </p>
-
         </div>
 
         <div class="reg-button">
-          <bf-button
-            v-if="hasAdminRights"
-            @click="openAddIntegration"
-          >
+          <bf-button v-if="hasAdminRights" @click="openAddIntegration">
             Register Webhook
           </bf-button>
         </div>
-
-
-
       </div>
 
-      <div
-        v-if="integrations.length > 0"
-        class="integration-list"
-      >
+      <div v-if="integrations.length > 0" class="integration-list">
         <integration-list-item
           v-for="integration in filteredWebhooks"
           :key="integration.id"
@@ -51,39 +34,32 @@
         />
       </div>
 
-      <bf-empty-page-state
-        v-else
-        class="empty"
-      >
+      <bf-empty-page-state v-else class="empty">
         <img
           src="/static/images/illustrations/illo-collaboration.svg"
           height="240"
           width="247"
           alt="Teams illustration"
-        >
-        <div
-          v-if="hasAdminRights"
-          class="copy"
-        >
+        />
+        <div v-if="hasAdminRights" class="copy">
           <h2>There are no integrations yet</h2>
-          <p>Integrations allow external services to be notified when certain events occur on Pennsieve. These integrations are available to all members within the organization and can be managed at the dataset level under settings.</p>
-          <bf-button
-            class="create-team-button"
-            @click="openAddIntegration"
-          >
+          <p>
+            Integrations allow external services to be notified when certain
+            events occur on Pennsieve. These integrations are available to all
+            members within the organization and can be managed at the dataset
+            level under settings.
+          </p>
+          <bf-button class="create-team-button" @click="openAddIntegration">
             Add Global Integration
           </bf-button>
         </div>
-        <div
-          v-if="!hasAdminRights"
-          class="copy"
-        >
+        <div v-if="!hasAdminRights" class="copy">
           <h2>{{ orgName }} doesn't have any integrations yet.</h2>
-          <p>Contact your administrator to get started working with Integrations.</p>
+          <p>
+            Contact your administrator to get started working with Integrations.
+          </p>
         </div>
       </bf-empty-page-state>
-
-
     </bf-stage>
 
     <add-edit-integration-dialog
@@ -104,8 +80,6 @@
       ref="apiKeyDetails"
       :visible.sync="APIKeyDetailsVisisble"
     />
-
-
   </bf-page>
 </template>
 
@@ -117,15 +91,14 @@ import BfButton from '../../shared/bf-button/BfButton.vue'
 import BfEmptyPageState from '../../shared/bf-empty-page-state/BfEmptyPageState.vue'
 
 import AddEditIntegrationDialog from '../AddEditIntegrationDialog.vue'
-import IntegrationListItem from "../integration-list-item/IntegrationListItem";
-import Sorter from  '../../../mixins/sorter'
-import UserRoles from  '../../../mixins/user-roles'
-import RemoveIntegrationDialog from  '../removeIntegrationDialog'
+import IntegrationListItem from '../integration-list-item/IntegrationListItem'
+import Sorter from '../../../mixins/sorter'
+import UserRoles from '../../../mixins/user-roles'
+import RemoveIntegrationDialog from '../removeIntegrationDialog'
 
-
-import { pathOr, propOr} from 'ramda'
-import DeleteApiKey from "../../my-settings/windows/DeleteApiKey";
-import IntegrationApiKeyDetails from "../integrationApiKeyDetails";
+import { pathOr, propOr } from 'ramda'
+import DeleteApiKey from '../../my-settings/windows/DeleteApiKey'
+import IntegrationApiKeyDetails from '../integrationApiKeyDetails'
 
 export default {
   name: 'IntegrationsList',
@@ -138,13 +111,10 @@ export default {
     BfButton,
     IntegrationListItem,
     AddEditIntegrationDialog,
-    RemoveIntegrationDialog,
+    RemoveIntegrationDialog
   },
 
-  mixins: [
-    Sorter,
-    UserRoles,
-  ],
+  mixins: [Sorter, UserRoles],
 
   props: {
     integrations: {
@@ -164,15 +134,12 @@ export default {
   },
 
   computed: {
-    ...mapGetters([
-      'activeOrganization',
-      'userToken',
-      'config',
-      'hasFeature'
-    ]),
+    ...mapGetters(['activeOrganization', 'userToken', 'config', 'hasFeature']),
 
     filteredWebhooks: function() {
-      let filteredArray =  this.integrations.filter(x=> !x.customTargets || x.customTargets.length == 0)
+      let filteredArray = this.integrations.filter(
+        x => !x.customTargets || x.customTargets.length == 0
+      )
 
       return filteredArray
     },
@@ -182,22 +149,22 @@ export default {
         const isAdmin = propOr(false, 'isAdmin', this.activeOrganization)
         const isOwner = propOr(false, 'isOwner', this.activeOrganization)
         return isAdmin || isOwner
-      } else { return null}
+      } else {
+        return null
+      }
     },
     orgName: function() {
       return pathOr('', ['organization', 'name'], this.activeOrganization)
     }
   },
 
-  watch: {
-
-  },
+  watch: {},
 
   beforeRouteEnter(to, from, next) {
     next(vm => {
-     if (vm.hasFeature('sandbox_org_feature')) {
-      vm.$router.push({name: 'create-org'})
-    }
+      if (vm.hasFeature('sandbox_org_feature')) {
+        vm.$router.push({ name: 'create-org' })
+      }
     })
   },
 
@@ -208,15 +175,14 @@ export default {
       'editIntegration'
     ]),
 
-    ...mapState([
-    ]),
+    ...mapState([]),
 
     openDeleteIntegrationDialog: function(integration) {
       this.$refs.removeIntegrationDialog.setIntegration(integration)
       this.removeIntegrationDialogVisible = true
     },
     onDeleteIntegrationConfirm: function(integration) {
-      console.log("do deletion on " + integration.id)
+      console.log('do deletion on ' + integration.id)
       this.removeIntegration(integration.id)
       this.removeIntegrationDialogVisible = false
     },
@@ -232,7 +198,6 @@ export default {
       return ''
     },
     openEditIntegrationDialog: function(integration) {
-
       this.integrationEdit = integration
       this.addEditIntegrationDialogVisible = true
     },
@@ -247,7 +212,7 @@ export default {
      * Update integration via API
      * @param {Object} Integration
      */
-    onEditIntegrationConfirm: function(integration){
+    onEditIntegrationConfirm: function(integration) {
       let eventTargets = []
       for (const [key, value] of Object.entries(integration.eventTypeList)) {
         if (value) {
@@ -264,7 +229,8 @@ export default {
         imageUrl: integration.imageUrl,
         isDefault: integration.isDefault,
         hasAccess: integration.hasAccess,
-        targetEvents: eventTargets
+        targetEvents: eventTargets,
+        targetPath: integration.targetPath
       }
 
       if (integration.secret) {
@@ -272,7 +238,6 @@ export default {
       }
 
       this.editIntegration(integrationDTO)
-
     },
 
     /**
@@ -280,7 +245,6 @@ export default {
      * @param {Object} integration
      */
     onAddIntegrationConfirm: function(integration) {
-
       let eventTargets = []
       for (const [key, value] of Object.entries(integration.eventTypeList)) {
         if (value) {
@@ -296,8 +260,9 @@ export default {
         isPrivate: !integration.isPublic,
         imageUrl: integration.imageUrl,
         isDefault: integration.isDefault,
-        hasAccess: integration.integrationType === 'viewer'? false: true,
-        targetEvents: eventTargets
+        hasAccess: integration.integrationType === 'viewer' ? false : true,
+        targetEvents: eventTargets,
+        targetPath: integration.targetPath
       }
 
       this.createIntegration(integrationDTO).then(response => {
@@ -307,17 +272,14 @@ export default {
           secret: response.tokenSecret.secret
         }
         this.APIKeyDetailsVisisble = true
-        console.log(response)
-        }
-      )
-    },
+      })
+    }
   }
 }
 </script>
 
 <style scoped lang="scss">
 @import '../../../assets/variables';
-
 
 .addIntegrationContainer {
   display: flex;
@@ -360,12 +322,11 @@ export default {
   }
 
   p {
-    color: #71747C;
+    color: #71747c;
     font-size: 14px;
     line-height: 16px;
     text-align: center;
     margin-bottom: 16px;
   }
-
 }
 </style>

--- a/src/components/datasets/files/custom-actions-dialog/CustomActionsDialog.vue
+++ b/src/components/datasets/files/custom-actions-dialog/CustomActionsDialog.vue
@@ -12,8 +12,8 @@
         <h2>Run the Custom Event on {{ totalFiles }} {{ headline }}</h2>
         <el-select
           v-model="value"
-          placeholder="Select"
-          @change="onSelect(value)"
+          placeholder="Select Application"
+          @change="setApplication(value)"
         >
           <el-option
             v-for="(item, i) in options"
@@ -23,6 +23,11 @@
           ></el-option>
         </el-select>
       </div>
+      <br />
+      <el-input
+        v-model="targetDirectory"
+        placeholder="Target Directory (optional)"
+      />
     </dialog-body>
     <div slot="footer" class="dialog-footer">
       <bf-button
@@ -95,7 +100,8 @@ export default {
       value: '',
       selectedApplication: {},
       isLoading: false,
-      dataIsLoading: true
+      dataIsLoading: true,
+      targetDirectory: ''
     }
   },
 
@@ -160,7 +166,10 @@ export default {
   },
 
   methods: {
-    onSelect: function(value) {
+    /**
+     * Set Application to be run
+     */
+    setApplication: function(value) {
       this.selectedApplication = this.integrations.find(
         integration => integration.name === value
       )
@@ -206,7 +215,9 @@ export default {
         applicationId: this.selectedApplication.id,
         datasetId: pathOr('', ['content', 'id'], this.dataset),
         packageIds: packageIds,
-        params: {} // intentionally passing an empty object - params is a future feature
+        params: {
+          target_path: this.targetDirectory
+        }
       }
       this.sendXhr(url, {
         method: 'POST',
@@ -233,6 +244,9 @@ export default {
             }
           })
           this.closeDialog()
+          this.targetDirectory = ''
+          this.selectedApplication = {}
+          this.value = ''
         })
     }
   }


### PR DESCRIPTION
# Description

This adds the ability to specify a target directory when users are running an application on target folders/files. 

![Screenshot 2024-01-28 at 8 15 59 PM](https://github.com/Pennsieve/pennsieve-app/assets/4977875/e646cd22-ecdb-4c5a-a4d8-6bc72f3894dd)

Payload I am now passing to /integrations endpoint:
`{"applicationId":82,"datasetId":"N:dataset:e2eaa76a-e0e0-4f25-97a8-6fa2bf6dd83f","packageIds":[],"params":{"target_path":"target/path/to/file"}}` 

There is currently no validation on what the FE will allow for the target path - we should discuss validation for a future enhancement - it would be a good idea to add validation on the nested path format to avoid user issues with specifying the path to the target directory. 

## Clickup Ticket

[AppStore: Enable users to define a target directory when they run an application (frontend)](https://app.clickup.com/t/8686wy8yj)


## Type of change

- [X] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Tested Locally 
