### PR TITLE
update dialog close button to remove depricated sync binding

### DIFF
--- a/src/components/Integrations/removeIntegrationDialog.vue
+++ b/src/components/Integrations/removeIntegrationDialog.vue
@@ -87,7 +87,7 @@ export default {
      * Emit event to update the synced property
      */
     close: function() {
-      this.$emit('update:visible', false)
+      this.$emit('close')
     },
     /**
      * Callback after the dialog has closed

--- a/src/components/Publishing/DataUseAgreementSignDialog/DataUseAgreementSignDialog.vue
+++ b/src/components/Publishing/DataUseAgreementSignDialog/DataUseAgreementSignDialog.vue
@@ -111,7 +111,7 @@ export default {
      * Emit event to update the synced property
      */
     close: function() {
-      this.$emit('update:visible', false)
+      this.$emit('close-dialog')
       this.$emit('update:isSigningAgreement', false)
     },
 

--- a/src/components/Publishing/PublishingDatasetListItemActions.vue
+++ b/src/components/Publishing/PublishingDatasetListItemActions.vue
@@ -178,9 +178,10 @@
     </template>
 
     <data-use-agreement-sign-dialog
-      :visible.sync="isDataUseAgreementSignDialogVisible"
+      :visible="isDataUseAgreementSignDialogVisible"
       :data-use-agreement="dataUseAgreement"
       :is-signing-agreement.sync="isSigningAgreement"
+      @close-dialog="closeDataUseAgreementSignDialog"
       @submit="requestAccess"
       @download="downloadAgreement"
     />
@@ -188,12 +189,13 @@
     <reject-request-dialog
       :visible.sync="isRejectRequestDialogVisible"
       @rejectRequest="rejectPublishingRequest"
-      @close-reject-dialog="isRejectRequestDialogVisible=false"
+      @close-dialog="closeRejectDialog"
     />
   </div>
 </template>
 
 <script>
+
 import { mapActions, mapGetters, mapState } from 'vuex';
 import { pathOr, propOr } from 'ramda';
 
@@ -370,7 +372,9 @@ export default {
     openRejectDialog: function() {
       this.isRejectRequestDialogVisible = true
     },
-
+    closeRejectDialog: function(){
+      this.isRejectRequestDialogVisible = false;
+    },
     /**
      * Called when user clicks on REJECT in rejectDialog
      */
@@ -499,7 +503,9 @@ export default {
       this.isSigningAgreement = false
       this.isDataUseAgreementSignDialogVisible = true
     },
-
+    closeDataUseAgreementSignDialog: function(){
+      isDataUseAgreementSignDialogVisible=false;
+    },
     /**
      * Download the agreement
      */

--- a/src/components/Publishing/RejectRequestDialog/RejectRequestDialog.vue
+++ b/src/components/Publishing/RejectRequestDialog/RejectRequestDialog.vue
@@ -106,7 +106,7 @@ export default {
      * Emit event to update the synced property
      */
     close: function () {
-      this.$emit("close-reject-dialog", false);
+      this.$emit("close-dialog");
     },
     resetDialog: function () {
       this.rejectRationale = "";

--- a/src/components/datasets/settings/DatasetSettingsContributors/ContributorDialog/ContributorDialog.vue
+++ b/src/components/datasets/settings/DatasetSettingsContributors/ContributorDialog/ContributorDialog.vue
@@ -330,7 +330,7 @@ export default {
      * Emit event to update the synced property
      */
     close: function() {
-      this.$emit('update:visible', false)
+      this.$emit('close-dialog')
     },
 
     /**

--- a/src/components/datasets/settings/DatasetSettingsContributors/DatasetSettingsContributors.vue
+++ b/src/components/datasets/settings/DatasetSettingsContributors/DatasetSettingsContributors.vue
@@ -90,6 +90,7 @@
         :dialog-visible="isContributorDialogVisible"
         :contributor.sync="editingContributor"
         :org-contributors="orgContributors"
+        @close-dialog = "closeContributorDialog"
         @add-contributor="createContributor"
         @edit-contributor="editContributor"
       />
@@ -356,9 +357,11 @@ export default {
 
     onEditContributorClick: function(contributor) {
       this.editingContributor = contributor
-      this.isContributorDialogVisible = true
+      this.isContributorDialogVisible = true;
     },
-
+    closeContributorDialog: function(){
+      this.isContributorDialogVisible = false;
+    },  
     /**
      * Edit contributor for dataset
      * @param {Object} contributor

--- a/src/components/viewers/SlideViewer/SlideAnnotationDeleteDialog/SlideAnnotationDeleteDialog.vue
+++ b/src/components/viewers/SlideViewer/SlideAnnotationDeleteDialog/SlideAnnotationDeleteDialog.vue
@@ -116,7 +116,7 @@ export default {
      * Emit event to update the synced property
      */
     close: function() {
-      this.$emit('update:visible', false)
+      this.$emit('cancel')
     },
 
     /**

--- a/src/components/viewers/SlideViewer/SlideLayerDeleteDialog/SlideLayerDeleteDialog.vue
+++ b/src/components/viewers/SlideViewer/SlideLayerDeleteDialog/SlideLayerDeleteDialog.vue
@@ -82,7 +82,7 @@ export default {
      * Emit event to update the synced property
      */
     close: function() {
-      this.$emit('update:visible', false)
+      this.$emit('cancel')
     },
 
     /**

--- a/src/components/viewers/SlideViewer/SlideLayerDialog/SlideLayerDialog.vue
+++ b/src/components/viewers/SlideViewer/SlideLayerDialog/SlideLayerDialog.vue
@@ -304,7 +304,7 @@ export default {
      */
     close: function() {
       if (this.isSubmitted) {
-        this.$emit('update:visible', false)
+        this.$emit('cancel')
         this.$emit('update:isCreating', false)
         this.$emit('update:isSubmitted', false)
         this.$emit('update:layer', {})


### PR DESCRIPTION
TICKET: https://app.clickup.com/t/86880en41

.sync used for two way binding is deprecated. emit('update:visible') >>> emit('close-dialog') for most cases. 

