### PR TITLE
redirect dataset url to dataset overview url

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -306,7 +306,13 @@ const router = createRouter({
           props: true,
           meta: { hideSecondaryNav: true},
         },
-
+        {
+          name: 'dataset-overview-redirect',
+          path: ':datasetId',
+          redirect: {
+            name: 'dataset-overview'
+          }
+        },
         {
           name: 'dataset-overview',
           path: ':datasetId/overview',


### PR DESCRIPTION
Request from users to match previous behaviour.

redirect https://app.pennsieve.io/{orgid}/datasets/{datasetId}
to https://app.pennsieve.io/{orgid}/datasets/{datasetId}/overview