### PR TITLE
fix payload when linking orcid id to user profile

### DIFF
--- a/src/components/my-settings/MySettingsContainer.vue
+++ b/src/components/my-settings/MySettingsContainer.vue
@@ -785,7 +785,10 @@ export default {
               .sendXhr(self.getORCIDApiUrl, {
                 method: "POST",
                 body: {
-                  authorizationCode: this.oauthCode,
+                  authorizationCode: {
+                    source: "orcid-redirect-response",
+                    code: this.oauthCode
+                  }
                 },
               })
               .then((response) => {


### PR DESCRIPTION
Fix the Window Event Listener in **MySettingsContainer** - created in the `openORCID()` function - to send a slightly modified JSON payload to the Pennsieve API. The endpoint **POST** `/user/orcid` expects the payload to be:

```
{
  "authorizationCode": {
      "source": "orcid-redirect-response",
      "code": authCode
    }
}
```

The `authCode` is provided by ORCID after the user authenticates and authorizes access to their profile. This code is then used by the Pennsieve API to fetch an access token, which is stored on the user's Pennsieve User profile.