### PR TITLE
fix styling defects in proposals tab

### DIFF
--- a/src/components/Publishing/PublishingProposalsList/PublishingProposalsList.vue
+++ b/src/components/Publishing/PublishingProposalsList/PublishingProposalsList.vue
@@ -1,6 +1,8 @@
 <template>
-  <div>
-    <form
+  <bf-stage>
+    <template #actions>
+      <div class="actions-wrapper">
+        <form
       class="mb-8 dataset-search-form"
       @submit.prevent="searchProposalsByQuery"
     >
@@ -21,7 +23,11 @@
 
       </el-input>
     </form>
-    <p
+      </div>
+    </template>
+
+    <div>
+      <p
       v-if="hasProposals"
       class="mb-24"
     >
@@ -51,8 +57,8 @@
             :class="[ sortIconDirection === 'down' ? 'svg-flip' : '' ]"
             color="currentColor"
             :dir="sortIconDirection"
-            height="20"
-            width="20"
+            :height="20"
+            :width="20"
           />
         </button>
       </div>
@@ -112,7 +118,8 @@
       />
 
     </div>
-  </div>
+    </div>
+  </bf-stage>
 </template>
 
 <script>
@@ -412,5 +419,12 @@ export default {
 .dataset-search-form {
   max-width: 400px;
   width: 100%;
+}
+.actions-wrapper {
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+  justify-content: space-between;
+
 }
 </style>

--- a/src/components/Publishing/PublishingProposalsList/PublishingProposalsListItem.vue
+++ b/src/components/Publishing/PublishingProposalsList/PublishingProposalsListItem.vue
@@ -68,7 +68,8 @@
           <div
             class="dataset-actions"
           >
-            <p>
+            <div class="button-wrapper">
+              <p>
               <a
                 href="#"
                 @click.prevent="triggerRequest(DatasetProposalAction.ACCEPT)"
@@ -84,6 +85,7 @@
                 Reject Request
               </a>
             </p>
+            </div>
           </div>
         </div>
       </el-col>
@@ -235,6 +237,16 @@ export default {
 .publication-type {
   text-transform: capitalize;
 }
+
+.button-wrapper {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+
+    a {
+      margin-bottom: 12px;
+    }
+  }
 
 @media only screen and (max-width: 1200px){
   .list-item-status-wrapper {


### PR DESCRIPTION
Fixed styling defects observed while testing. Made styling consistent with other tabs on 'Publishing' page

**Before:**
<img width="1503" alt="pre-fix-with-datasets" src="https://github.com/Pennsieve/pennsieve-app/assets/160671504/c255cd7a-d948-4b3f-b3f0-50e7e308e2ae">

**After:**
<img width="1498" alt="post-fix-with-datasets" src="https://github.com/Pennsieve/pennsieve-app/assets/160671504/900981d6-f35d-4738-8022-8d63eb481c12">

<img width="1475" alt="post-fix-wihtout-datasets" src="https://github.com/Pennsieve/pennsieve-app/assets/160671504/5338cb8a-98b8-4fe8-b0e5-e31f35a31dfb">
