### PR TITLE
Refactor data loading and fix direct linking 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -73,9 +73,6 @@ import AnnouncementBanner from "./components/shared/AnnouncementBanner/Announcem
 
 export default {
   name: "app",
-  created() {
-    this.getActiveOrganization, this.onActiveOrgChange.bind(this);
-  },
 
   components: {
     PennsieveUpload,

--- a/src/App.vue
+++ b/src/App.vue
@@ -104,10 +104,10 @@ export default {
       }
     }, "1000"); // workaround for subscribing to an event that is registed in PennsieveHeader where lifecycle events all run after App.vue lifecycle events.
 
-    // this.$store.watch(
-    //   this.getActiveOrganization,
-    //   this.onActiveOrgChange.bind(this)
-    // );
+    this.$store.watch(
+      this.getActiveOrganization,
+      this.onActiveOrgChange.bind(this)
+    );
     EventBus.$on("reload-datasets", this.fetchDatasets);
 
     const token = Cookies.get("user_token");

--- a/src/App.vue
+++ b/src/App.vue
@@ -73,6 +73,9 @@ import AnnouncementBanner from "./components/shared/AnnouncementBanner/Announcem
 
 export default {
   name: "app",
+  created() {
+    this.getActiveOrganization, this.onActiveOrgChange.bind(this);
+  },
 
   components: {
     PennsieveUpload,
@@ -94,16 +97,17 @@ export default {
     };
   },
   mounted() {
+    console.log("this.sessionTimedOut", this.sessionTimedOut);
     setTimeout(() => {
       if (window.location.href.includes("?redirectTo=")) {
         EventBus.$emit("redirect-detected");
       }
     }, "1000"); // workaround for subscribing to an event that is registed in PennsieveHeader where lifecycle events all run after App.vue lifecycle events.
 
-    this.$store.watch(
-      this.getActiveOrganization,
-      this.onActiveOrgChange.bind(this)
-    );
+    // this.$store.watch(
+    //   this.getActiveOrganization,
+    //   this.onActiveOrgChange.bind(this)
+    // );
     EventBus.$on("reload-datasets", this.fetchDatasets);
 
     const token = Cookies.get("user_token");
@@ -116,39 +120,50 @@ export default {
     /**
      * Watch to compute new dataset list
      */
-    "$route.params.orgId"(to, from) {
-      if (to) {
-        this.onSwitchOrganization({
-          organization: {
-            id: to,
-          },
-        });
-        this.$nextTick(() => {
-          const token = Cookies.get("user_token");
-          if (token) {
-            this.bootUp(token);
+    "$route.params.orgId": {
+      handler: async function (to, from) {
+        const token = Cookies.get("user_token");
+        console.log("this.token", !!token);
+        if (token) {
+          try {
+            await this.bootUp(token);
+          } catch (error) {
+            console.error(error);
+          } finally {
+            if (this.isOrgSynced) {
+              this.onSwitchOrganization({
+                organization: {
+                  id: to,
+                },
+              });
+            }
           }
-        });
-      }
+        }
+      },
     },
     /**
      * Trigger API request when active organization is changed
      */
     activeOrganization: {
       handler: function (val, oldVal) {
+        // console.log("this.isOrgSynced", this.isOrgSynced);
         const oldOrgId = pathOr("NONE", ["organization", "id"], oldVal);
         const newOrgId = pathOr("NONE", ["organization", "id"], val);
 
         // Only fetch Org assets if there is an actual change in organization and if the userToken is set.
         if (this.userToken && oldOrgId !== newOrgId) {
-          this.setActiveOrgSynced()
-            .then(() => this.fetchDatasets())
-            .then(() => this.fetchDatasetPublishedData())
-            .then(() => this.fetchCollections())
-            .then(() => this.fetchIntegrations())
-            .then(() => this.fetchDatasetStatuses())
-            .then(() => this.fetchComputeNodes())
-            .then(() => this.fetchApplications());
+          try {
+            this.setActiveOrgSynced()
+              .then(() => this.fetchDatasets())
+              .then(() => this.fetchDatasetPublishedData())
+              .then(() => this.fetchCollections())
+              .then(() => this.fetchIntegrations())
+              .then(() => this.fetchDatasetStatuses())
+              .then(() => this.fetchComputeNodes())
+              .then(() => this.fetchApplications());
+          } catch (err) {
+            console.error(err);
+          }
         }
       },
       immediate: true,

--- a/src/App.vue
+++ b/src/App.vue
@@ -97,7 +97,6 @@ export default {
     };
   },
   mounted() {
-    console.log("this.sessionTimedOut", this.sessionTimedOut);
     setTimeout(() => {
       if (window.location.href.includes("?redirectTo=")) {
         EventBus.$emit("redirect-detected");
@@ -146,7 +145,6 @@ export default {
      */
     activeOrganization: {
       handler: function (val, oldVal) {
-        // console.log("this.isOrgSynced", this.isOrgSynced);
         const oldOrgId = pathOr("NONE", ["organization", "id"], oldVal);
         const newOrgId = pathOr("NONE", ["organization", "id"], val);
 

--- a/src/main.js
+++ b/src/main.js
@@ -41,6 +41,8 @@ const app = createApp(App)
 app.directive('click-outside', ClickOutside)
 
 app.use(store);
+
+
 app.use(VueClipboard, {
     autoSetContainer: true,
     appendToBody: true,
@@ -58,6 +60,11 @@ app.use(VueReCaptcha, {
 
 app.use(router);
 // app.use(Vue3Sanitize);
+
+// In your main.js or App.vue
+window.addEventListener('beforeunload', () => {
+    store.dispatch('resetState');
+  });
 
 
 app.mount("#app");

--- a/src/mixins/global-message-handler/index.js
+++ b/src/mixins/global-message-handler/index.js
@@ -227,6 +227,7 @@ export default {
       if (!token) {
         return
       }
+      
 
       // add logic to only make organizations request if profile is defined
       let currentPath = this.$router.currentRoute.path
@@ -251,6 +252,7 @@ export default {
           const activeOrg = orgs.organizations[activeOrgIndex]
 
           // handle org switch
+          
           return this.handleRedirects(activeOrg, activeOrgId, preferredOrgId)
 
         })
@@ -420,11 +422,12 @@ export default {
       const newOrgIntId = propOr(1, 'intId', newOrg)
       const activeOrgId = pathOr(0, ['organization', 'id'], this.activeOrganization)
       // Do nothing if the user is trying to switch to the organization that is already active or if no userToken found
-      if (newOrgId === activeOrgId || !this.isOrgSynced) {
+      if (newOrgId === activeOrgId || !this.userToken) {
         return
       }
       // switch org in vue app
       const switchOrgUrl = `${this.config.apiUrl}/session/switch-organization?organization_id=${newOrgIntId}&api_key=${this.userToken}`
+      
       this.sendXhr(switchOrgUrl, { method: 'PUT' })
         .then(response => {
           const updatedOrg = find(pathEq(['organization', 'id'], newOrgId), this.organizations)
@@ -464,7 +467,10 @@ export default {
                   .then(this.getTeams.bind(this))
                   .then(this.getOrgContributors.bind(this))
         })
-        .catch(this.handleXhrError.bind(this))
+        .catch((error) => {
+          console.error(error)
+          this.handleXhrError.bind(this)
+        })
     },
     /**
      * Updates org users object with any missing fields required for sorting

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -41,13 +41,13 @@ const initialFilterState = {
   sortDirection: "asc",
 };
 
-export const state = {
+const initialState = () => ({
   config: site,
   uploadRemaining: 0,
   uploading: false,
   uploadCount: 0,
   hasGravatar: false,
-  organizations: {},
+  organizations: [],
   activeOrganization: {},
   activeOrgSynced: false,
   isLoadingDatasets: true,
@@ -119,9 +119,14 @@ export const state = {
   userToken: '',
   sessionTimer: null,
   isRefreshing: false
-}
+})
+
+export const state = initialState();
 
 export const mutations = {
+    RESET_STATE(state) {
+      Object.assign(state, initialState());
+    },
     SET_IS_REFRESHING(state, data) {
       state.isRefreshing = data
     },
@@ -621,6 +626,9 @@ export const mutations = {
     }
 
 export const actions = {
+  resetState({ commit }) {
+    commit('resetState');
+  },
   setIsRefreshing: ({ commit }, evt) => commit("SET_IS_REFRESHING", evt),
   setSessionTimer:  ({ commit }, evt) => commit("SET_SESSION_TIMER", evt),
   setActiveOrgSynced: ({ commit }) => commit("SET_ACTIVE_ORG_SYNC"),


### PR DESCRIPTION
Handle direct linking when users change workspaces https://app.clickup.com/t/8688w1mkx 

This code is up in dev. To validate: 

1. Log in to Pennsieve
2. Copy a link to a dataset 
3. Switch to different org (not the org with the dataset you have the link copied for)
4. Copy the link into the browser
5. Validate that the link brings you directly to the dataset you are expecting and switches your org to the org associated with the linked dataset. 

Previous behavior before fix: User would be logged out if they tried to directly go to a linked dataset in an org other than the org they had selected. 