### PR TITLE
Get Pennsieve GitHub App URL from configuration

### DIFF
--- a/src/components/my-settings/MySettingsContainer.vue
+++ b/src/components/my-settings/MySettingsContainer.vue
@@ -204,7 +204,7 @@
             </a>
           </p>
           <bf-button @click="openGitHub">
-            Register your Github Account
+            Register your GitHub Account
           </bf-button>
         </div>
         <div v-else>
@@ -563,6 +563,15 @@ export default {
         : `https://orcid.org/${orcid}`;
     },
 
+    getGitHubAppUrl: function() {
+      const url = pathOr("", ["config", "GitHubAppUrl"])(this);
+
+      if (!url) {
+        return ""
+      }
+      return url
+    },
+
     isEmailButtonDisabled: function () {
       return this.emailButtonDisabled;
     },
@@ -852,7 +861,7 @@ export default {
 
     openGitHub: function() {
       this.oauthWindow = window.open(
-        `https://github.com/apps/pennsieve/installations/new?redirect_uri=${this.windowLocation}`,
+          `${this.getGitHubAppUrl}?redirect_uri=${this.windowLocation}`,
         "_blank",
         "toolbar=no, scrollbars=yes, width=600, height=800, top=200, left=500"
       );

--- a/src/site-config/dev.json
+++ b/src/site-config/dev.json
@@ -36,5 +36,6 @@
     "appId": "47a81ebaf87f4c168177",
     "region": "us2"
   },
+  "GitHubAppUrl": "https://github.com/apps/pennsieve-test/installations/new",
   "reCAPTCHASiteKey": "6Le2Wr0aAAAAAHouFUEmy7UwN6b9wa_PPRGrWxAG"
 }

--- a/src/site-config/prod.json
+++ b/src/site-config/prod.json
@@ -35,5 +35,6 @@
     "appId": "33f0678ef1a028da5b9f",
     "region": "us2"
   },
+  "GitHubAppUrl": "https://github.com/apps/pennsieve/installations/new",
   "reCAPTCHASiteKey": "6Le2Wr0aAAAAAHouFUEmy7UwN6b9wa_PPRGrWxAG"
 }


### PR DESCRIPTION
This PR adds the ability to get the Pennsieve GitHub App URL from configuration. This change permits us to have different configuration for the Non-prod and Production environments. 

Tested locally running the Pennsieve App with: `npm run dev`