### PR TITLE
Fix: add contributor to dataset

### DIFF
--- a/src/components/datasets/settings/DatasetSettingsContributors/DatasetSettingsContributors.vue
+++ b/src/components/datasets/settings/DatasetSettingsContributors/DatasetSettingsContributors.vue
@@ -114,7 +114,8 @@ import {
   pathEq,
   prop,
   propEq,
-  propOr
+  propOr,
+  mergeLeft
 } from 'ramda'
 
 import BfButton from '@/components/shared/bf-button/BfButton.vue'
@@ -138,8 +139,8 @@ const transformMemberToContributor = (member = {}) => {
   const orcid = pathOr('', ['orcid', 'orcid'], member)
 
   return compose(
-    merge({ orcid, userId }),
-    pick(['firstName', 'lastName', 'email'])
+      mergeLeft({ orcid, userId }),
+      pick(['firstName', 'lastName', 'email'])
   )(member)
 }
 


### PR DESCRIPTION
When trying to add a contributor to a dataset on the Publishing page, it fails with an "undefined" error. 

The issue is that the **DatasetSettingsContributors** component is attempting to combine two objects using the `Ramda.merge()` function, but that function is not imported and was deprecated in v0.28 (see: https://github.com/ramda/ramda/releases/tag/v0.28.0).

Correction: use the `Ramda.mergeLeft()` function to combine the two objects.

[ClickUp ticket](https://app.clickup.com/t/86897e5ce)