### PR TITLE
Feature add GitHub releases route

### DIFF
--- a/src/components/my-settings/MySettingsContainer.vue
+++ b/src/components/my-settings/MySettingsContainer.vue
@@ -349,7 +349,7 @@
 import { mapActions, mapGetters, mapState } from "vuex";
 import EventBus from "../../utils/event-bus";
 
-import { pathOr, propOr, prop } from "ramda";
+import { pathOr, propOr, prop, has } from "ramda";
 import {Auth} from "@aws-amplify/auth";
 
 

--- a/src/components/releases/github-repos-list-item/gitHubReposListItem.vue
+++ b/src/components/releases/github-repos-list-item/gitHubReposListItem.vue
@@ -1,0 +1,44 @@
+<template>
+  <div id="gitHubReposListItem">
+    <el-row :gutter="20">
+      <el-col id="name" :span="16">{{ repo.name }}</el-col>
+      <el-col id="status" :span="8">disabled</el-col>
+    </el-row>
+    <el-row :gutter="20">
+      <el-col id="description" :span="16">{{ repo.description }}</el-col>
+      <el-col id="actionCTA" :span="8"><button>Enable</button></el-col>
+    </el-row>
+    <el-row :gutter="20">
+      <el-col id="url" :span="16">{{ repo.html_url }}</el-col>
+    </el-row>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'GitHubReposListItem',
+  props: {
+    repo: {
+      type: Object,
+      required: true
+    },
+  },
+};
+</script>
+
+<style scoped>
+  .el-row {
+    margin-bottom: 20px;
+  }
+  .el-row:last-child {
+    margin-bottom: 0;
+  }
+  .el-col {
+    border-radius: 4px;
+  }
+
+  .grid-content {
+    border-radius: 4px;
+    min-height: 36px;
+  }
+</style>

--- a/src/components/releases/github-repos-list-item/gitHubReposListItem.vue
+++ b/src/components/releases/github-repos-list-item/gitHubReposListItem.vue
@@ -1,37 +1,57 @@
 <template>
-  <div id="gitHubReposListItem">
+  <div class="list-item">
     <el-row :gutter="20">
-      <el-col id="name" :span="16">{{ repo.name }}</el-col>
-      <el-col id="status" :span="8">disabled</el-col>
+      <el-col id="name" :span="16"><h3>{{ repo.name }}</h3></el-col>
+      <el-col id="status" class="align-content-center" :span="8">{{ repoBeingTracked ? 'Tracking Enabled' : 'Tracking Disabled' }}</el-col>
     </el-row>
     <el-row :gutter="20">
-      <el-col id="description" :span="16">{{ repo.description }}</el-col>
-      <el-col id="actionCTA" :span="8"><button>Enable</button></el-col>
+      <el-col id="description" :span="16"><p>{{ repo.description }}</p></el-col>
+      <el-col id="actionCTA" class="align-content-center" :span="8"><bf-button>{{ repoBeingTracked ? 'Disable Tracking' : 'Enable Tracking' }}</bf-button></el-col>
     </el-row>
     <el-row :gutter="20">
-      <el-col id="url" :span="16">{{ repo.html_url }}</el-col>
+      <el-col id="url" :span="16">
+        <el-link :href="repo.html_url" target="_blank" :underline="false">
+          GitHub URL<el-icon class="el-icon--right"><Link /></el-icon></el-link>
+      </el-col>
     </el-row>
   </div>
 </template>
 
 <script>
+import { Link } from '@element-plus/icons-vue'
 export default {
   name: 'GitHubReposListItem',
+  components: {
+    Link
+  },
   props: {
     repo: {
       type: Object,
       required: true
     },
+    // currently repoBeingTracked value is not available from the repo object, integrate it when available
+    repoBeingTracked: {
+      type: Boolean,
+      required: true,
+      default: false
+    }
   },
 };
 </script>
 
-<style scoped>
-  .el-row {
-    margin-bottom: 20px;
+<style scoped lang="scss">
+@import '../../../assets/_variables.scss';
+  .list-item {
+    margin-bottom: 24px;
+    padding: 24px;
+    border-bottom: 1px solid lightgray;
+    box-shadow: --el-box-shadow-lighter;
   }
-  .el-row:last-child {
-    margin-bottom: 0;
+  .list-item:hover {
+    background-color: $purple_tint;;
+  }
+  .el-row {
+    min-height: 40px;
   }
   .el-col {
     border-radius: 4px;
@@ -41,4 +61,12 @@ export default {
     border-radius: 4px;
     min-height: 36px;
   }
+  .align-content-center {
+    text-align: center;
+  }
+  h3 {
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 16px;
+}
 </style>

--- a/src/components/releases/github-repos-list/gitHubReposList.vue
+++ b/src/components/releases/github-repos-list/gitHubReposList.vue
@@ -1,0 +1,27 @@
+<template>
+  <div id="gitHubReposList">
+      <GitHubReposListItem
+        v-for="repo in repos"
+        :key="repo.id"
+        :repo="repo"
+      ></GitHubReposListItem>
+  </div>
+</template>
+
+<script>
+import GitHubReposListItem from '../github-repos-list-item/gitHubReposListItem.vue';
+
+export default {
+  name: 'GitHubReposList',
+  components: {
+    GitHubReposListItem,
+  },
+  props: {
+    repos: {
+      type: Array,
+      required: true,
+    },
+  },
+
+};
+</script>

--- a/src/components/releases/github-repositories/GitHubRepositories.vue
+++ b/src/components/releases/github-repositories/GitHubRepositories.vue
@@ -1,19 +1,32 @@
 <template>
-  <bf-stage element-loading-background="transparent">
-
-    <bf-empty-page-state class="empty">
+  <bf-stage>
+    <bf-empty-page-state class="empty" v-if="!repos || repos.length === 0">
       <p>There are no github repositories yet</p>
     </bf-empty-page-state>
+    <GitHubReposList v-else :repos="repos"></GitHubReposList>
   </bf-stage>
 </template>
 
 <script>
 import BfEmptyPageState from '../../shared/bf-empty-page-state/BfEmptyPageState.vue';
+import GitHubReposList from '../github-repos-list/gitHubReposList.vue';
+import { mapState } from 'vuex';
 
 export default {
   name: 'GitHubRepositories',
+  beforeRouteEnter(to, from, next) {
+    next(vm => {
+      vm.$store.dispatch('releasesModule/fetchGitHubRepos');
+    });
+  },
   components: {
+    GitHubReposList,
     BfEmptyPageState,
+  },
+  computed: {
+    ...mapState('releasesModule', {
+      repos: state => state.gitHubRepos,
+    })
   },
 };
 </script>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -13,6 +13,7 @@ import filesModule from "./filesModule";
 import metadataModule from "./metadataModule";
 import uploadModule from "./uploadModule";
 import analysisModule from "./analysisModule";
+import releasesModule from "./releasesModule";
 
 const hashFunction = (key, list) => {
   const obj = {};
@@ -1057,7 +1058,8 @@ export default createStore({
     filesModule,
     uploadModule,
     metadataModule,
-    analysisModule
+    analysisModule,
+    releasesModule
   }
 
 });

--- a/src/store/releasesModule.js
+++ b/src/store/releasesModule.js
@@ -1,4 +1,3 @@
-import {defaultTo, propEq, find } from 'ramda'
 import Cookies from "js-cookie";
 
 const initialState = () => ({
@@ -62,8 +61,9 @@ export const actions = {
       }
     }
     catch (err) {
-      // add error handling - unable to retrieve github repos, try again or something
+      // add error handling - display message or alert indicating the error
       commit('SET_GITHUB_REPOS', null)
+      commit('SET_GITHUB_REPOS_COUNT', 0)
     }
   },
 
@@ -88,8 +88,9 @@ export const actions = {
       }
     }
     catch (err) {
-      // add error handling - unable to retrieve github repos, try again or something
+      // add error handling - display message or alert indicating the error
       commit('SET_EXTERNAL_REPOS', null)
+      commit('SET_EXTERNAL_REPOS_COUNT', 0)
     }
   },
 
@@ -113,7 +114,7 @@ export const actions = {
       }
     }
     catch (err) {
-      // add error handling - could not enable repo tracking, try again or something
+      // add error handling - display message or alert indicating the error
     }
   },
 
@@ -137,15 +138,9 @@ export const actions = {
       }
     }
     catch (err) {
-      // add error handling - could not disable repo tracking, try again or something
+      // add error handling - display message or alert indicating the error
     }
   }
-}
-
-export const getters = {
-  getPublishingInfo: state => (tag) => {
-    return defaultTo({}, find(propEq('tag', tag), state.publishingInfo))
-  },
 }
 
 const releasesModule = {
@@ -153,7 +148,6 @@ const releasesModule = {
   state,
   mutations,
   actions,
-  getters
 }
 
 export default releasesModule

--- a/src/store/releasesModule.js
+++ b/src/store/releasesModule.js
@@ -1,0 +1,159 @@
+import {defaultTo, propEq, find } from 'ramda'
+import Cookies from "js-cookie";
+
+const initialState = () => ({
+  gitHubRepos: null,
+  gitHubReposCount: null,
+  externalRepos: null,
+  externalReposCount: null,
+})
+
+export const state = initialState()
+
+export const mutations = {
+  CLEAR_STATE(state) {
+    //reset all state to initial state
+    const _initialState = initialState()
+    // need to iteratively set keys to preserve reactivity
+    Object.keys(_initialState).forEach(key => state[key] = _initialState[key])
+  },
+  SET_GITHUB_REPOS(state, gitHubRepos) {
+    state.gitHubRepos = gitHubRepos
+  },
+  SET_GITHUB_REPOS_COUNT(state, count) {
+    state.gitHubReposCount = count
+  },
+  SET_EXTERNAL_REPOS(state, externalRepos) {
+    state.externalRepos = externalRepos
+  },
+  SET_EXTERNAL_REPOS_COUNT(state, count) {
+    state.externalReposCount = count
+  },
+  UPDATE_REPO_IN_EXTERNAL_REPOS(state, modifiedRepo) {
+    const index = state.externalRepos.findIndex(repo => repo.id === modifiedRepo.id);
+  
+    if (index !== -1) {
+      state.externalRepos.splice(index, 1, modifiedRepo)
+    }
+  }
+}
+
+export const actions = {
+  updatePublishingInfo: ({commit}, data) => commit('UPDATE_PUBLISHING_INFO', data),
+
+  fetchGitHubRepos: async({ commit, rootState }) => {
+    try {
+      const url = `${rootState.config.api2Url}/repositories/github`
+      const apiKey = rootState.userToken || Cookies.get('user_token')
+      const myHeaders = new Headers()
+      myHeaders.append('Authorization', 'Bearer ' + apiKey)
+      myHeaders.append('Accept', 'application/json')
+      const response = await fetch(url, { headers: myHeaders })
+      if (response.ok) {
+        const responseJson = await response.json()
+        const gitHubRepos = responseJson.repos
+        const gitHubReposCount = responseJson.count
+        commit('SET_GITHUB_REPOS', gitHubRepos)
+        commit('SET_GITHUB_REPOS_COUNT', gitHubReposCount)
+      } else {
+        commit('SET_GITHUB_REPOS', [])
+        commit('SET_GITHUB_REPOS_COUNT', 0)
+        throw new Error(response.statusText)
+      }
+    }
+    catch (err) {
+      // add error handling - unable to retrieve github repos, try again or something
+      commit('SET_GITHUB_REPOS', null)
+    }
+  },
+
+  fetchExternalRepos: async({ commit, rootState }) => {
+    try {
+      const url = `${rootState.config.api2Url}/repositories/external`
+      const apiKey = rootState.userToken || Cookies.get('user_token')
+      const myHeaders = new Headers()
+      myHeaders.append('Authorization', 'Bearer ' + apiKey)
+      myHeaders.append('Accept', 'application/json')
+      const response = await fetch(url, { headers: myHeaders })
+      if (response.ok) {
+        const responseJson = await response.json()
+        const externalRepos = responseJson.repos
+        const externalReposCount = responseJson.count
+        commit('SET_EXTERNAL_REPOS', externalRepos)
+        commit('SET_EXTERNAL_REPOS_COUNT', externalReposCount)
+      } else {
+        commit('SET_EXTERNAL_REPOS', [])
+        commit('SET_EXTERNAL_REPOS_COUNT', 0)
+        throw new Error(response.statusText)
+      }
+    }
+    catch (err) {
+      // add error handling - unable to retrieve github repos, try again or something
+      commit('SET_EXTERNAL_REPOS', null)
+    }
+  },
+
+  enableRepoTracking: async({ commit, rootState, repo }) => {
+    try {
+      const url = `${rootState.config.api2Url}/repository/enable`
+      const apiKey = rootState.userToken || Cookies.get('user_token')
+      const myHeaders = new Headers();
+      myHeaders.append('Authorization', 'Bearer ' + apiKey)
+      myHeaders.append('Accept', 'application/json')
+      const response = await fetch(url, {
+        method: "POST",
+        headers: myHeaders,
+        body: JSON.stringify({origin: repo.origin, url: repo.url, type: repo.type})
+      })
+      if (response.ok) {
+        const updatedRepo = await response.json()
+        commit('UPDATE_REPO_IN_EXTERNAL_REPOS', updatedRepo)
+      } else {
+        throw new Error(response.statusText)
+      }
+    }
+    catch (err) {
+      // add error handling - could not enable repo tracking, try again or something
+    }
+  },
+
+  disableRepoTracking: async({ commit, rootState, repo }) => {
+    try {
+      const url = `${rootState.config.api2Url}/repository/disable`
+      const apiKey = rootState.userToken || Cookies.get('user_token')
+      const myHeaders = new Headers();
+      myHeaders.append('Authorization', 'Bearer ' + apiKey)
+      myHeaders.append('Accept', 'application/json')
+      const response = await fetch(url, {
+        method: "POST",
+        headers: myHeaders,
+        body: JSON.stringify({origin: repo.origin, url: repo.url, type: repo.type})
+      })
+      if (response.ok) {
+        const updatedRepo = await response.json()
+        commit('UPDATE_REPO_IN_EXTERNAL_REPOS', updatedRepo)
+      } else {
+        throw new Error(response.statusText)
+      }
+    }
+    catch (err) {
+      // add error handling - could not disable repo tracking, try again or something
+    }
+  }
+}
+
+export const getters = {
+  getPublishingInfo: state => (tag) => {
+    return defaultTo({}, find(propEq('tag', tag), state.publishingInfo))
+  },
+}
+
+const releasesModule = {
+  namespaced: true,
+  state,
+  mutations,
+  actions,
+  getters
+}
+
+export default releasesModule


### PR DESCRIPTION
## Summary

This PR includes the following changes:
- Created GitHub repos list and list item components and added to the GitHub repositories page
- Created releases module to handle GitHub service API Integration with the UI
- [Click Up link](https://app.clickup.com/t/8688z0xze)

## Task List
- [x] Create UI and integrate GitHub Repositories API
- [ ] Write unit tests for the new module and components

## Screenshots/Recording (if applicable) 

![Screen recording for the GitHub Repositories page UI](https://github.com/user-attachments/assets/c16ea19c-e11c-4248-810c-7507d3767f32)