### PR TITLE
add datefns lib to package.json. import into mixins. create new forma…

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "blueimp-md5": "^2.19.0",
     "cropperjs": "^1.6.1",
     "d3": "^7.8.5",
+    "date-fns": "^3.6.0",
     "element-plus": "^2.3.9",
     "fabric": "^5.3.0",
     "flush-promises": "^1.0.2",

--- a/src/components/Integrations/ComputeNodesListItem/ComputeNodesListItem.vue
+++ b/src/components/Integrations/ComputeNodesListItem/ComputeNodesListItem.vue
@@ -20,7 +20,7 @@
           Node
         </div>
         <div class="margin-10">
-          Created Date: {{ this.formatDate(computeNode.createdAt) }}
+          Created Date: {{ this.formatDateFNS(computeNode.createdAt) }}
         </div>
         <div class="margin-10">
           {{ computeNode.description }}

--- a/src/mixins/format-date/index.js
+++ b/src/mixins/format-date/index.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-
+import { format as formatFNS } from "date-fns";
 import { head } from 'ramda'
 
 
@@ -13,7 +13,9 @@ export default {
     formatDate: function(date) {
       return moment.utc(date).format('MMMM D, YYYY')
     },
-
+    formatDateFNS: function(date) {
+      return formatFNS(date, 'MMMM d, yyyy')
+    },
     /**
      * Formats a date range for display
      * @param {Date} date

--- a/yarn.lock
+++ b/yarn.lock
@@ -2800,10 +2800,15 @@
   resolved "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz"
   integrity sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==
 
-"@element-plus/icons-vue@^2.0.6", "@element-plus/icons-vue@^2.1.0":
+"@element-plus/icons-vue@^2.0.6":
   version "2.1.0"
   resolved "https://registry.npmjs.org/@element-plus/icons-vue/-/icons-vue-2.1.0.tgz"
   integrity sha512-PSBn3elNoanENc1vnCfh+3WA9fimRC7n+fWkf3rE5jvv+aBohNHABC/KAR5KWPecxWxDTVT1ERpRbOMRcOV/vA==
+
+"@element-plus/icons-vue@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@element-plus/icons-vue/-/icons-vue-2.3.1.tgz#1f635ad5fdd5c85ed936481525570e82b5a8307a"
+  integrity sha512-XxVUZv48RZAd87ucGS48jPf6pKu0yV5UCg9f4FFwtrYxXOwWuVJo6wOvSLKEoMQKjv8GsX/mhP6UsC1lRwbUWg==
 
 "@esbuild/android-arm64@0.18.20":
   version "0.18.20"
@@ -5134,6 +5139,11 @@ data-urls@^3.0.1:
     abab "^2.0.6"
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
+
+date-fns@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
+  integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
 
 dayjs@^1.11.3:
   version "1.11.10"
@@ -8538,6 +8548,7 @@ word@~0.3.0:
   integrity sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION

Ticket: https://app.clickup.com/t/86895twy7

First step in migrating over to dat fns from moment js

Description:
Use date-fns instead of moment for analysis tab under compute-nodes section.
new function added to format date mixin
