### PR TITLE
Remove unnecessary permissions on Metadata tab

### DIFF
--- a/src/components/bf-navigation/BfNavigationSecondary.vue
+++ b/src/components/bf-navigation/BfNavigationSecondary.vue
@@ -127,7 +127,6 @@
       </bf-navigation-item>
 
       <bf-navigation-item
-        v-if="getPermission('manager')"
         :link="{ name: 'metadata' }"
         label="Metadata"
         class="secondary"

--- a/src/components/datasets/dataset-list/BfDatasetList.vue
+++ b/src/components/datasets/dataset-list/BfDatasetList.vue
@@ -1,110 +1,40 @@
 <template>
-    <bf-stage
-      slot="stage"
-    >
-      <template #actions>
-        <div
-          class="search-wrap"
+  <bf-stage slot="stage">
+    <template #actions>
+      <div class="search-wrap">
+        <form
+          class="mb-8 dataset-search-form"
+          @submit.prevent="searchDatasetsByQuery"
         >
-          <form
-            class="mb-8 dataset-search-form"
-            @submit.prevent="searchDatasetsByQuery"
+          <el-input
+            ref="input"
+            v-model="searchQuery"
+            class="dataset-search-input icon-prefix"
+            placeholder="Find Datasets"
+            @keyup.enter.native="searchDatasetsByQuery"
           >
-            <el-input
-              ref="input"
-              v-model="searchQuery"
-              class="dataset-search-input icon-prefix"
-              placeholder="Find Datasets"
-              @keyup.enter.native="searchDatasetsByQuery"
-            >
-              <template #prefix>
-                <IconMagnifyingGlass
-                  :height="24"
-                  :width="24"
-                  color="#71747c"
-                  />
-              </template>
-            </el-input>
-          </form>
-          <p v-if="hasDatasets">
-            {{ searchHeading }}
-          </p>
-        </div>
-
-        <div>
-          <bf-button
-            v-if="hasDatasets && !isWorkspaceGuest"
-            @click="openNewDatasetDialog"
-          >
-            New Dataset
-          </bf-button>
-        </div>
-
-      </template>
-
-      <div class="dataset-list-controls mb-16">
-        <div class="dataset-list-controls-menus">
-          <pagination-page-menu
-            class="mr-24"
-            pagination-item-label="Datasets"
-            :page-size="datasetSearchParams.limit"
-            @update-page-size="updateDatasetSearchLimit"
-          />
-
-          <dataset-filter-menu
-            class="mr-24"
-            @select="onDatasetFilterSelect"
-          />
-
-          <dataset-sort-menu
-            class="mr-24"
-            :order-by="datasetSearchParams.orderBy"
-            @select="onDatasetSortSelect"
-          />
-
-          <button
-            class="button-icon small icon-sort"
-            @click="setSortDir"
-          >
-
-            <IconSort
-              name="icon-sort"
-              color="currentColor"
-              :dir="sortIconDirection"
-              :height="20"
-              :width="20"
-              :class="[ sortIconDirection === 'down' ? 'svg-flip' : '' ]"
-
-            />
-          </button>
-        </div>
-
-        <el-pagination
-          :page-size="datasetSearchParams.limit"
-          :pager-count="5"
-          :current-page="curDatasetSearchPage"
-          layout="prev, pager, next"
-          :total="datasetTotalCount"
-          @current-change="onPaginationPageChange"
-        />
-      </div>
-      <div
-        v-if="hasDatasets && isLoadingDatasetsError === false"
-        class="dataset-list-item-wrap"
-        v-loading="isLoadingDatasets"
-      >
-        <bf-dataset-list-item
-          v-for="dataset in datasets"
-          :key="dataset.content.id"
-          :dataset="dataset"
-          @show-locked-dialog="dialogLockedVisible = true"
-        />
+            <template #prefix>
+              <IconMagnifyingGlass :height="24" :width="24" color="#71747c" />
+            </template>
+          </el-input>
+        </form>
+        <p v-if="hasDatasets">
+          {{ searchHeading }}
+        </p>
       </div>
 
-      <div
-        v-if="hasDatasets && isLoadingDatasetsError === false"
-        class="dataset-list-controls mt-16"
-      >
+      <div>
+        <bf-button
+          v-if="hasDatasets && !isWorkspaceGuest"
+          @click="openNewDatasetDialog"
+        >
+          New Dataset
+        </bf-button>
+      </div>
+    </template>
+
+    <div class="dataset-list-controls mb-16">
+      <div class="dataset-list-controls-menus">
         <pagination-page-menu
           class="mr-24"
           pagination-item-label="Datasets"
@@ -112,428 +42,419 @@
           @update-page-size="updateDatasetSearchLimit"
         />
 
-        <el-pagination
-          :page-size="datasetSearchParams.limit"
-          :pager-count="5"
-          :current-page="curDatasetSearchPage"
-          layout="prev, pager, next"
-          :total="datasetTotalCount"
-          @current-change="onPaginationPageChange"
+        <dataset-filter-menu class="mr-24" @select="onDatasetFilterSelect" />
+
+        <dataset-sort-menu
+          class="mr-24"
+          :order-by="datasetSearchParams.orderBy"
+          @select="onDatasetSortSelect"
         />
+
+        <button class="button-icon small icon-sort" @click="setSortDir">
+          <IconSort
+            name="icon-sort"
+            color="currentColor"
+            :dir="sortIconDirection"
+            :height="20"
+            :width="20"
+            :class="[sortIconDirection === 'down' ? 'svg-flip' : '']"
+          />
+        </button>
       </div>
 
-      <bf-create-new-dataset
-        :datasets="datasets"
-        :integrations="integrations"
-        :dialog-visible="newDatasetDialogOpen"
-        @close-dialog="onCloseCreateDialog"
+      <el-pagination
+        :page-size="datasetSearchParams.limit"
+        :pager-count="5"
+        :current-page="curDatasetSearchPage"
+        layout="prev, pager, next"
+        :total="datasetTotalCount"
+        @current-change="onPaginationPageChange"
+      />
+    </div>
+    <div
+      v-if="hasDatasets && isLoadingDatasetsError === false"
+      class="dataset-list-item-wrap"
+      v-loading="isLoadingDatasets"
+    >
+      <bf-dataset-list-item
+        v-for="dataset in datasets"
+        :key="dataset.content.id"
+        :dataset="dataset"
+        @show-locked-dialog="dialogLockedVisible = true"
+      />
+    </div>
+
+    <div
+      v-if="hasDatasets && isLoadingDatasetsError === false"
+      class="dataset-list-controls mt-16"
+    >
+      <pagination-page-menu
+        class="mr-24"
+        pagination-item-label="Datasets"
+        :page-size="datasetSearchParams.limit"
+        @update-page-size="updateDatasetSearchLimit"
       />
 
-      <bf-empty-page-state v-if="isEmptyOrg && !isWorkspaceGuest">
-        <img
-          src="../../../assets/images/illustrations/illo-datasets.svg"
-          alt="Add datasets illustration"
-        >
+      <el-pagination
+        :page-size="datasetSearchParams.limit"
+        :pager-count="5"
+        :current-page="curDatasetSearchPage"
+        layout="prev, pager, next"
+        :total="datasetTotalCount"
+        @current-change="onPaginationPageChange"
+      />
+    </div>
 
-        <h2 class="bf-empty-state-title">
-          Create a dataset
-        </h2>
-        <p>Datasets are where you store, analyze, and share your data. </p>
-        <bf-button
-          class="new-dataset-button"
-          @click="openNewDatasetDialog"
-        >
-          New Dataset
-        </bf-button>
-      </bf-empty-page-state>
+    <bf-create-new-dataset
+      :datasets="datasets"
+      :integrations="integrations"
+      :dialog-visible="newDatasetDialogOpen"
+      @close-dialog="onCloseCreateDialog"
+    />
 
-      <bf-empty-page-state
-        v-if="isNoResultsFound"
-        class="no-results-found-wrapper"
-      >
-        <img
-          src="../../../assets/images/illustrations/illo-search.svg"
-          height="78"
-          width="99"
-          alt="No results found"
-        >
+    <bf-empty-page-state v-if="isEmptyOrg && !isWorkspaceGuest">
+      <img
+        src="../../../assets/images/illustrations/illo-datasets.svg"
+        alt="Add datasets illustration"
+      />
 
-        <h2>No results found</h2>
-        <p>No results found for "{{ searchQuery }}". Try a different search term.</p>
-      </bf-empty-page-state>
+      <h2 class="bf-empty-state-title">Create a dataset</h2>
+      <p>Datasets are where you store, analyze, and share your data.</p>
+      <bf-button class="new-dataset-button" @click="openNewDatasetDialog">
+        New Dataset
+      </bf-button>
+    </bf-empty-page-state>
 
-<!--      <el-dialog-->
-<!--        class="simple"-->
-<!--        :show-close="false"-->
-<!--        :visible.sync="dialogLockedVisible"-->
-<!--      >-->
-<!--        <bf-dialog-header slot="title" />-->
+    <bf-empty-page-state
+      v-if="isNoResultsFound"
+      class="no-results-found-wrapper"
+    >
+      <img
+        src="../../../assets/images/illustrations/illo-search.svg"
+        height="78"
+        width="99"
+        alt="No results found"
+      />
 
-<!--        <dialog-body>-->
-<!--&lt;!&ndash;          <svg-icon&ndash;&gt;-->
-<!--&lt;!&ndash;            id="icon-kitchen-timer"&ndash;&gt;-->
-<!--&lt;!&ndash;            slot="icon"&ndash;&gt;-->
-<!--&lt;!&ndash;            icon="icon-kitchen-timer"&ndash;&gt;-->
-<!--&lt;!&ndash;            height="42"&ndash;&gt;-->
-<!--&lt;!&ndash;            width="40"&ndash;&gt;-->
-<!--&lt;!&ndash;            color="#2760FF"&ndash;&gt;-->
-<!--&lt;!&ndash;          />&ndash;&gt;-->
-<!--          <h2 slot="heading">-->
-<!--            Good things take time.-->
-<!--          </h2>-->
-
-<!--          <p>This dataset is currently being published to Pennsieve Discover. To make sure everything copies properly, we’ve locked this dataset temporarily until we’re sure everything is correct.</p>-->
-
-<!--          <div class="dialog-simple-buttons">-->
-<!--            <bf-button @click="dialogLockedVisible = false">-->
-<!--              Got it-->
-<!--            </bf-button>-->
-<!--          </div>-->
-<!--        </dialog-body>-->
-<!--      </el-dialog>-->
-
-<!--      <OnboardingCarousel v-if="gettingStartedOpen"/>-->
-    </bf-stage>
+      <h2>No results found</h2>
+      <p>
+        No results found for "{{ searchQuery }}". Try a different search term.
+      </p>
+    </bf-empty-page-state>
+  </bf-stage>
 </template>
 
 <script>
-import {mapActions, mapGetters, mapState} from 'vuex'
-import {propOr,} from 'ramda'
-import BfRafter from '../../shared/bf-rafter/BfRafter.vue'
-import BfButton from '../../shared/bf-button/BfButton.vue'
-import BfEmptyPageState from '../../shared/bf-empty-page-state/BfEmptyPageState.vue'
-import DialogBody from '../../shared/dialog-body/DialogBody.vue'
-import BfDialogHeader from '../../shared/bf-dialog-header/BfDialogHeader.vue'
-import BfDatasetListItem from './dataset-list-item/BfDatasetListItem.vue'
-import BfCreateNewDataset from './bf-create-new-dataset/BfCreateNewDataset.vue'
-import DatasetFilterMenu from '../DatasetFilterMenu/DatasetFilterMenu.vue'
-import DatasetSortMenu from '../DatasetSortMenu/DatasetSortMenu.vue'
-import PaginationPageMenu from '../../shared/PaginationPageMenu/PaginationPageMenu.vue'
+import { mapActions, mapGetters, mapState } from "vuex";
+import { propOr } from "ramda";
+import BfRafter from "../../shared/bf-rafter/BfRafter.vue";
+import BfButton from "../../shared/bf-button/BfButton.vue";
+import BfEmptyPageState from "../../shared/bf-empty-page-state/BfEmptyPageState.vue";
+import DialogBody from "../../shared/dialog-body/DialogBody.vue";
+import BfDialogHeader from "../../shared/bf-dialog-header/BfDialogHeader.vue";
+import BfDatasetListItem from "./dataset-list-item/BfDatasetListItem.vue";
+import BfCreateNewDataset from "./bf-create-new-dataset/BfCreateNewDataset.vue";
+import DatasetFilterMenu from "../DatasetFilterMenu/DatasetFilterMenu.vue";
+import DatasetSortMenu from "../DatasetSortMenu/DatasetSortMenu.vue";
+import PaginationPageMenu from "../../shared/PaginationPageMenu/PaginationPageMenu.vue";
 
-import Sorter from '../../../mixins/sorter'
-import Request from '../../../mixins/request'
-import UserAccountAge from '../../../mixins/user-account-age'
-import OnboardingCarousel from '../../onboarding-carousel/OnboardingCarousel.vue'
+import Sorter from "../../../mixins/sorter";
+import Request from "../../../mixins/request";
+import UserAccountAge from "../../../mixins/user-account-age";
+import OnboardingCarousel from "../../onboarding-carousel/OnboardingCarousel.vue";
 import IconArrowRight from "../../icons/IconArrowRight.vue";
 import IconSort from "../../icons/IconSort.vue";
 import IconMagnifyingGlass from "../../icons/IconMagnifyingGlass.vue";
 
-  export default {
-    name: 'BfDatasetList',
+export default {
+  name: "BfDatasetList",
 
-    components: {
-      IconMagnifyingGlass,
-      IconArrowRight,
-      BfRafter,
-      BfButton,
-      BfDatasetListItem,
-      BfCreateNewDataset,
-      BfEmptyPageState,
-      DialogBody,
-      BfDialogHeader,
-      DatasetFilterMenu,
-      DatasetSortMenu,
-      PaginationPageMenu,
-      OnboardingCarousel,
-      IconSort
+  components: {
+    IconMagnifyingGlass,
+    IconArrowRight,
+    BfRafter,
+    BfButton,
+    BfDatasetListItem,
+    BfCreateNewDataset,
+    BfEmptyPageState,
+    DialogBody,
+    BfDialogHeader,
+    DatasetFilterMenu,
+    DatasetSortMenu,
+    PaginationPageMenu,
+    OnboardingCarousel,
+    IconSort,
+  },
+
+  mixins: [Request, Sorter, UserAccountAge],
+
+  props: {
+    orgId: {
+      type: String,
+      default: "",
     },
+  },
 
-    mixins: [
-      Request,
-      Sorter,
-      UserAccountAge
-    ],
-
-    props: {
-      orgId: {
-        type: String,
-        default: ''
-      }
-    },
-
-    data: function() {
-      return {
-        newDatasetDialogOpen: false,
-        dialogLockedVisible: false,
-        sortBy: 'content.name',
-        sortOptions: [
-          {
-            label: 'Sort by Name',
-            value: 'content.name'
-          },
-          {
-            label: 'Sort by Last Updated',
-            value: 'content.updatedAt'
-          }
-        ],
-        carouselDialog: '',
-        searchQuery: '',
-        filterName: ''
-      }
-    },
-
-    computed: {
-      ...mapState([
-        'isLoadingDatasets',
-        'isLoadingDatasetsError',
-        'onboardingEvents',
-        'datasetFilters',
-        'gettingStartedOpen',
-        'activeOrganization',
-        'datasets'
-      ]),
-
-      ...mapState('integrationsModule', [
-        'integrations'
-      ]),
-
-      ...mapState('datasetModule', [
-        'datasetSearchParams',
-        'datasetTotalCount'
-      ]),
-
-      ...mapGetters([
-        'activeOrganization',
-        'userToken',
-        'config',
-        'teams',
-        'hasFeature'
-      ]),
-
-      ...mapGetters('datasetModule', [
-        'curDatasetSearchPage'
-      ]),
-
-      /**
-       * Compute dataset icon sort direction
-       * @returns {String}
-       */
-      sortIconDirection: function () {
-        return this.datasetSearchParams.orderDirection === 'Asc' ? 'up' : 'down'
-      },
-
-      /**
-       * Compute the search heading
-       * @returns {String}
-       */
-      searchHeading: function () {
-        const start = this.datasetSearchParams.offset + 1
-        const pageRange = this.datasetSearchParams.limit * this.curDatasetSearchPage
-        const end = pageRange < this.datasetTotalCount
-          ? pageRange
-          : this.datasetTotalCount
-        const query = this.datasetSearchParams.query
-
-        let searchHeading = `Displaying ${start}-${end} of ${this.datasetTotalCount} results`
-
-        return query === ''
-          ? searchHeading
-          : `${searchHeading} for “${query}”`
-      },
-
-      isEmptyOrg: function() {
-        return  !this.isLoadingDatasets &&
-          this.isLoadingDatasetsError === false &&
-          this.datasets.length === 0 &&
-          !this.searchQuery
-      },
-
-      isNoResultsFound: function() {
-        return !this.isLoadingDatasets &&
-          (this.datasets.length === 0
-            || this.isLoadingDatasetsError === true
-          ) &&
-          this.searchQuery
-      },
-
-      /**
-       * Computes if datasets exist
-       * @returns {Boolean}
-       */
-      hasDatasets: function() {
-        return this.datasets.length > 0
-      },
-
-      /**
-       * Compute page heading
-       */
-      pageHeading: function() {
-        return 'Datasets'
-      },
-
-      isWorkspaceGuest: function() {
-        return propOr(false, 'isGuest', this.activeOrganization)
-      }
-    },
-
-    watch: {
-      hasDatasets: {
-        handler: function(bool) {
-          if (bool) {
-            this.isLoading = false
-          }
+  data: function () {
+    return {
+      newDatasetDialogOpen: false,
+      dialogLockedVisible: false,
+      sortBy: "content.name",
+      sortOptions: [
+        {
+          label: "Sort by Name",
+          value: "content.name",
         },
-        immediate: true
-      },
-      // gettingStartedOpen: {
-      //   handler: function(bool) {
-      //     if (bool) {
-      //       // onboarding carousel
-      //       this.carouselDialog = OnboardingCarousel
-      //     }
-      //   },
-      //   immediate: true
-      // },
-      activeOrganization: {
-        handler: function() {
-          // Clear search query keywords on org switch
-          this.searchQuery = ''
-        }
-      }
+        {
+          label: "Sort by Last Updated",
+          value: "content.updatedAt",
+        },
+      ],
+      carouselDialog: "",
+      searchQuery: "",
+      filterName: "",
+    };
+  },
+
+  computed: {
+    ...mapState([
+      "isLoadingDatasets",
+      "isLoadingDatasetsError",
+      "onboardingEvents",
+      "datasetFilters",
+      "gettingStartedOpen",
+      "activeOrganization",
+      "datasets",
+    ]),
+
+    ...mapState("integrationsModule", ["integrations"]),
+
+    ...mapState("datasetModule", ["datasetSearchParams", "datasetTotalCount"]),
+
+    ...mapGetters([
+      "activeOrganization",
+      "userToken",
+      "config",
+      "teams",
+      "hasFeature",
+    ]),
+
+    ...mapGetters("datasetModule", ["curDatasetSearchPage"]),
+
+    /**
+     * Compute dataset icon sort direction
+     * @returns {String}
+     */
+    sortIconDirection: function () {
+      return this.datasetSearchParams.orderDirection === "Asc" ? "up" : "down";
     },
 
     /**
+     * Compute the search heading
+     * @returns {String}
+     */
+    searchHeading: function () {
+      const start = this.datasetSearchParams.offset + 1;
+      const pageRange =
+        this.datasetSearchParams.limit * this.curDatasetSearchPage;
+      const end =
+        pageRange < this.datasetTotalCount ? pageRange : this.datasetTotalCount;
+      const query = this.datasetSearchParams.query;
+
+      let searchHeading = `Displaying ${start}-${end} of ${this.datasetTotalCount} results`;
+
+      return query === "" ? searchHeading : `${searchHeading} for “${query}”`;
+    },
+
+    isEmptyOrg: function () {
+      return (
+        !this.isLoadingDatasets &&
+        this.isLoadingDatasetsError === false &&
+        this.datasets.length === 0 &&
+        !this.searchQuery
+      );
+    },
+
+    isNoResultsFound: function () {
+      return (
+        !this.isLoadingDatasets &&
+        (this.datasets.length === 0 || this.isLoadingDatasetsError === true) &&
+        this.searchQuery
+      );
+    },
+
+    /**
+     * Computes if datasets exist
+     * @returns {Boolean}
+     */
+    hasDatasets: function () {
+      return this.datasets.length > 0;
+    },
+
+    /**
+     * Compute page heading
+     */
+    pageHeading: function () {
+      return "Datasets";
+    },
+
+    isWorkspaceGuest: function () {
+      return propOr(false, "isGuest", this.activeOrganization);
+    },
+  },
+
+  watch: {
+    hasDatasets: {
+      handler: function (bool) {
+        if (bool) {
+          this.isLoading = false;
+        }
+      },
+      immediate: true,
+    },
+    activeOrganization: {
+      handler: function () {
+        // Clear search query keywords on org switch
+        this.searchQuery = "";
+      },
+    },
+  },
+
+  /**
    * Save dataset filter state
    * @params {Object} to
    * @params {Object} from
    * @params {Function} next
    */
   beforeRouteLeave(to, from, next) {
-    if (this.datasetFilters.filterName === '') {
+    if (this.datasetFilters.filterName === "") {
       const datasetFilters = {
         filterName: this.filterName,
         filterOwner: this.filterOwner,
         filterType: this.filterType,
         sortBy: this.sortBy,
-        sortDirection: this.sortDirection
-      }
+        sortDirection: this.sortDirection,
+      };
 
-      this.setDatasetFilters(datasetFilters)
+      this.setDatasetFilters(datasetFilters);
     }
-    next()
+    next();
   },
 
+  mounted: function () {
+    // Set the local search query to match vuex
+    this.searchQuery = this.datasetSearchParams.query;
+    const { filterOwner, filterType, sortBy, sortDirection } =
+      this.datasetFilters;
 
-    mounted: function() {
-      // Set the local search query to match vuex
-      this.searchQuery = this.datasetSearchParams.query
-      const {
-        filterOwner,
-        filterType,
-        sortBy,
-        sortDirection
-      } = this.datasetFilters
+    this.filterOwner = filterOwner;
+    this.filterType = filterType;
+    this.sortBy = sortBy;
+    this.sortDirection = sortDirection;
+  },
 
-      this.filterOwner = filterOwner
-      this.filterType = filterType
-      this.sortBy = sortBy
-      this.sortDirection = sortDirection
+  methods: {
+    ...mapActions(["setDatasetFilters"]),
+    ...mapActions("datasetModule", [
+      "updateDatasetSearchOrderDirection",
+      "updateDatasetSearchLimit",
+      "updateDatasetSearchQuery",
+      "updateDatasetSearchOnlyMyDatasets",
+      "updateDatasetSearchStatus",
+      "updateDatasetSearchWithRole",
+      "updateDatasetSearchWithCollection",
+      "updateDatasetSearchOrderBy",
+      "updateDatasetOffset",
+    ]),
+
+    onCloseCreateDialog: function () {
+      this.newDatasetDialogOpen = false;
     },
 
-    methods: {
-      ...mapActions([
-        'setDatasetFilters'
-        ]),
-      ...mapActions('datasetModule', [
-        'updateDatasetSearchOrderDirection',
-        'updateDatasetSearchLimit',
-        'updateDatasetSearchQuery',
-        'updateDatasetSearchOnlyMyDatasets',
-        'updateDatasetSearchStatus',
-        'updateDatasetSearchWithRole',
-        'updateDatasetSearchWithCollection',
-        'updateDatasetSearchOrderBy',
-        'updateDatasetOffset'
-      ]),
+    searchDatasetsByQuery: function () {
+      this.updateDatasetSearchQuery(this.searchQuery);
+    },
 
-      onCloseCreateDialog: function() {
-        this.newDatasetDialogOpen = false
-      },
+    /**
+     * Update offset
+     */
+    onPaginationPageChange: function (page) {
+      const offset = (page - 1) * this.datasetSearchParams.limit;
+      this.updateDatasetOffset(offset);
+    },
 
-      searchDatasetsByQuery: function(){
-        this.updateDatasetSearchQuery(this.searchQuery)
-      },
+    /**
+     * Open New Dataset Dialog
+     */
+    openNewDatasetDialog: function () {
+      this.newDatasetDialogOpen = true;
+    },
 
-      /**
-       * Update offset
-       */
-      onPaginationPageChange: function(page) {
-        const offset = (page - 1) * this.datasetSearchParams.limit
-        this.updateDatasetOffset(offset)
-      },
+    /**
+     * Set sort direction
+     */
+    setSortDir: function () {
+      const orderDirection =
+        this.datasetSearchParams.orderDirection === "Asc" ? "Desc" : "Asc";
 
-      /**
-       * Open New Dataset Dialog
-       */
-      openNewDatasetDialog: function() {
-        this.newDatasetDialogOpen = true
-      },
+      this.updateDatasetSearchOrderDirection(orderDirection);
+    },
 
-      /**
-       * Set sort direction
-       */
-      setSortDir: function () {
-        const orderDirection = this.datasetSearchParams.orderDirection === 'Asc'
-          ? 'Desc'
-          : 'Asc'
+    /**
+     * Update dataset filter
+     * @param {Object} filter
+     */
+    onDatasetFilterSelect: function (filter) {
+      const type = propOr("", "type", filter);
+      const value = propOr("", "value", filter);
+      this.filterName = propOr("", "name", filter);
+      this.filterOwner =
+        value === "ALL_DATASETS" ? "all-datasets" : "my-datasets";
 
-        this.updateDatasetSearchOrderDirection(orderDirection)
-      },
+      const datasetFilters = {
+        filterName: this.filterName,
+        filterOwner: this.filterOwner,
+        filterType: this.filterType,
+        sortBy: this.sortBy,
+        sortDirection: this.sortDirection,
+      };
 
-      /**
-       * Update dataset filter
-       * @param {Object} filter
-       */
-      onDatasetFilterSelect: function(filter) {
-        const type = propOr('', 'type', filter)
-        const value = propOr('', 'value', filter)
-        this.filterName = propOr('', 'name', filter)
-        this.filterOwner = value === 'ALL_DATASETS' ? 'all-datasets' : 'my-datasets'
-
-        const datasetFilters = {
-          filterName: this.filterName,
-          filterOwner: this.filterOwner,
-          filterType: this.filterType,
-          sortBy: this.sortBy,
-          sortDirection: this.sortDirection
-        }
-
-        this.setDatasetFilters(datasetFilters)
-        switch (type) {
-          case 'owner':
-            this.updateDatasetFilterByOwner(filter)
-            break
-          case 'role':
-            this.updateDatasetSearchWithRole(filter.value)
-            break
-          case 'collection':
-            this.updateDatasetSearchWithCollection(filter.id)
-            break
-          default:
-            this.updateDatasetSearchStatus(filter.name)
-            break
-        }
-      },
-
-      /**
-       * Update dataset sort
-       * @param {Object} selection
-       */
-      onDatasetSortSelect: function(selection) {
-        this.updateDatasetSearchOrderBy(selection.value)
-      },
-
-      updateDatasetFilterByOwner: function(filter) {
-        const filterVal = propOr('', 'value', filter)
-        const isOnlyMyDatasets = filterVal === 'MY_DATASETS'
-        this.updateDatasetSearchOnlyMyDatasets(isOnlyMyDatasets)
+      this.setDatasetFilters(datasetFilters);
+      switch (type) {
+        case "owner":
+          this.updateDatasetFilterByOwner(filter);
+          break;
+        case "role":
+          this.updateDatasetSearchWithRole(filter.value);
+          break;
+        case "collection":
+          this.updateDatasetSearchWithCollection(filter.id);
+          break;
+        default:
+          this.updateDatasetSearchStatus(filter.name);
+          break;
       }
-    }
-  }
+    },
+
+    /**
+     * Update dataset sort
+     * @param {Object} selection
+     */
+    onDatasetSortSelect: function (selection) {
+      this.updateDatasetSearchOrderBy(selection.value);
+    },
+
+    updateDatasetFilterByOwner: function (filter) {
+      const filterVal = propOr("", "value", filter);
+      const isOnlyMyDatasets = filterVal === "MY_DATASETS";
+      this.updateDatasetSearchOnlyMyDatasets(isOnlyMyDatasets);
+    },
+  },
+};
 </script>
 
 <style scoped lang="scss">
-@import '../../../assets/_variables.scss';
+@import "../../../assets/_variables.scss";
 
 .no-results-found-wrapper {
   img {
@@ -547,7 +468,7 @@ import IconMagnifyingGlass from "../../icons/IconMagnifyingGlass.vue";
   width: 137px;
 }
 
-.bf-empty-state-title{
+.bf-empty-state-title {
   font-size: 16px;
   font-weight: 600;
   text-align: center;
@@ -573,7 +494,7 @@ import IconMagnifyingGlass from "../../icons/IconMagnifyingGlass.vue";
   display: flex;
   flex-wrap: wrap;
   .el-dropdown {
-    flex-shrink: 0
+    flex-shrink: 0;
   }
 }
 </style>

--- a/src/components/datasets/dataset-list/dataset-list-item/BfDatasetListItem.vue
+++ b/src/components/datasets/dataset-list/dataset-list-item/BfDatasetListItem.vue
@@ -1,24 +1,17 @@
 <template>
-  <div class="bf-dataset-list-item" >
-    <el-row
-      type="flex"
-      :gutter="32"
-    >
+  <div class="bf-dataset-list-item">
+    <el-row type="flex" :gutter="32">
       <el-col :sm="14">
         <div class="dataset-info">
           <img
             :src="datasetBanner"
             :alt="datasetBannerAlt"
             class="bf-dataset-list-item-banner-image mr-16"
-          >
+          />
           <div>
             <h2>
               <router-link :to="datasetLink">
-                <IconLockFilled
-                  v-if="datasetLocked"
-                  :height="16"
-                  :width="16"
-                />
+                <IconLockFilled v-if="datasetLocked" :height="16" :width="16" />
                 {{ dataset.content.name }}
               </router-link>
             </h2>
@@ -27,32 +20,27 @@
               class="publish-info mb-8"
             >
               <!-- Published to Pennsieve Discover -->
-              <template v-if="dataset.publication.type !== PublicationType.EMBARGO">
-                <IconDiscover
-                  :height="15"
-                  :width="15"
-                />
+              <template
+                v-if="dataset.publication.type !== PublicationType.EMBARGO"
+              >
+                <IconDiscover :height="15" :width="15" />
                 <p>
                   Published a copy on
                   <strong>{{ publishedDate }}</strong>
-                  <a
-                    :href="discoverLink"
-                    target="_blank"
-                  >
-                    View on Discover
-                  </a>
+                  <a :href="discoverLink" target="_blank"> View on Discover </a>
                 </p>
               </template>
 
               <!-- Embargoed dataset -->
-              <template v-if="dataset.publication.type === PublicationType.EMBARGO">
-                <IconDiscover
-                  :height="15"
-                  :width="15"
-                />
+              <template
+                v-if="dataset.publication.type === PublicationType.EMBARGO"
+              >
+                <IconDiscover :height="15" :width="15" />
                 <p>
                   Embargoed until
-                  <strong>{{ formatDate(dataset.publication.embargoReleaseDate) }}</strong>
+                  <strong>{{
+                    formatDate(dataset.publication.embargoReleaseDate)
+                  }}</strong>
                 </p>
               </template>
             </div>
@@ -61,10 +49,7 @@
               v-if="publishStatus === 'PUBLISH_FAILED'"
               class="publish-info mb-8 error"
             >
-              <IconWarningCircle
-                :height="15"
-                :width="15"
-              />
+              <IconWarningCircle :height="15" :width="15" />
               <p>
                 Dataset failed to publish
                 <router-link
@@ -72,8 +57,8 @@
                   :to="{
                     name: 'dataset-settings',
                     params: {
-                      datasetId: dataset.content.id
-                    }
+                      datasetId: dataset.content.id,
+                    },
                   }"
                   class="ml-8"
                 >
@@ -104,8 +89,8 @@
                   :to="{
                     name: 'dataset-settings',
                     params: {
-                      datasetId: dataset.content.id
-                    }
+                      datasetId: dataset.content.id,
+                    },
                   }"
                 >
                   Add a description
@@ -130,37 +115,25 @@
           </div>
         </div>
       </el-col>
-      <el-col
-        :sm="4"
-        class="list-item-col-spacer"
-      >
+      <el-col :sm="4" class="list-item-col-spacer">
         <div class="bf-dataset-list-item-status">
+          <!-- No Status is coming back from the API for most datasets, but they do for SPARC at least. See SPARC prod. -->
           <tag-pill
+            v-if="!isPublished"
+            class="mt-8"
             :indicator-color="dataset.status.color"
             :label="formatDatasetStatus"
           />
-
           <tag-pill
             v-if="isPublished"
             class="mt-8"
-            :has-indicator="false"
             :indicator-color="publicationStatusColor"
             :label="publicatonStatus"
           >
-
-<!--            <svg-icon-->
-<!--              slot="prefix"-->
-<!--              class="icon-publish-status"-->
-<!--              name="icon-public"-->
-<!--              height="12"-->
-<!--              width="12"-->
-<!--            />-->
           </tag-pill>
         </div>
       </el-col>
-      <el-col
-        :sm="6"
-      >
+      <el-col :sm="6">
         <div class="bf-dataset-list-item-storage">
           <p class="bf-dataset-list-item-stat">
             <strong class="col-label">
@@ -183,72 +156,67 @@ import {
   propEq,
   propOr,
   path,
-  pathOr
-} from 'ramda'
-import {
-  mapActions,
-  mapGetters,
-  mapState
-} from 'vuex'
+  pathOr,
+} from "ramda";
+import { mapActions, mapGetters, mapState } from "vuex";
 
-import BfIconWaiting from '../../../shared/bf-waiting-icon/bf-waiting-icon.vue'
-import TagPill from '../../../shared/TagPill/TagPill.vue'
-import BfStorageMetricsMixin from '../../../../mixins/bf-storage-metrics'
-import FormatDate from '../../../../mixins/format-date'
-import DatasetPublishedData from '../../../../mixins/dataset-published-data'
-import { PublicationType, PublicationStatus, UserFriendlyPublicationStatus, PublicationStatusColor } from '../../../../utils/constants'
+import BfIconWaiting from "../../../shared/bf-waiting-icon/bf-waiting-icon.vue";
+import TagPill from "../../../shared/TagPill/TagPill.vue";
+import BfStorageMetricsMixin from "../../../../mixins/bf-storage-metrics";
+import FormatDate from "../../../../mixins/format-date";
+import DatasetPublishedData from "../../../../mixins/dataset-published-data";
+import {
+  PublicationType,
+  PublicationStatus,
+  UserFriendlyPublicationStatus,
+  PublicationStatusColor,
+} from "../../../../utils/constants";
 import IconLockFilled from "../../../icons/IconLockFilled.vue";
 import IconDiscover from "../../../icons/IconDiscover.vue";
 import IconWarningCircle from "../../../icons/IconWarningCircle.vue";
 
 export default {
-  name: 'BfDatasetListItem',
+  name: "BfDatasetListItem",
 
   components: {
     IconWarningCircle,
     IconDiscover,
     IconLockFilled,
     BfIconWaiting,
-    TagPill
+    TagPill,
   },
 
-  mixins: [
-    BfStorageMetricsMixin,
-    FormatDate,
-    DatasetPublishedData
-  ],
+  mixins: [BfStorageMetricsMixin, FormatDate, DatasetPublishedData],
 
   props: {
     dataset: {
       type: Object,
-      default: () => ({})
+      default: () => ({}),
     },
     showInfo: {
       type: Boolean,
-      default: true
+      default: true,
     },
   },
 
   computed: {
-    ...mapGetters([
-      'hasFeature',
-    ]),
+    ...mapGetters(["hasFeature"]),
 
     ...mapState([
-      'profile',
-      'activeOrganization',
-      'orgMembers',
-      'config',
-      'userToken',
-      'orgDatasetStatuses'
+      "profile",
+      "activeOrganization",
+      "orgMembers",
+      "config",
+      "userToken",
+      "orgDatasetStatuses",
     ]),
 
     /**
      * Returns the dataset status displayName
      * @returns {String}
      */
-    formatDatasetStatus: function() {
-      return pathOr('', ['status', 'displayName'], this.dataset)
+    formatDatasetStatus: function () {
+      return pathOr("", ["status", "displayName"], this.dataset);
     },
 
     /**
@@ -256,15 +224,15 @@ export default {
      * and returns color as appropriate
      * @returns {String}
      */
-    checkDatasetStatus: function() {
-      const status = {
-        'In Review': '#FFB000',
-        'Work in Progress': '#F1F1F3',
-        'No Status': '#F1F1F3',
-        'Completed': '#17BB62'
-      }
-      return status[this.formatDatasetStatus]
-    },
+    // checkDatasetStatus: function () {
+    //   const status = {
+    //     "In Review": "#FFB000",
+    //     "Work in Progress": "#F1F1F3",
+    //     "No Status": "#F1F1F3",
+    //     Completed: "#17BB62",
+    //   };
+    //   return status[this.formatDatasetStatus];
+    // },
 
     /**
      * This returns the font color of the dataset status on the list
@@ -272,22 +240,24 @@ export default {
      * for the rest of the statuses
      * @returns {String}
      */
-    statusFontColor: function() {
-      return this.formatDatasetStatus === 'Work in Progress' ? '#2760FF' : '#404554'
+    statusFontColor: function () {
+      return this.formatDatasetStatus === "Work in Progress"
+        ? "#2760FF"
+        : "#404554";
     },
 
     /**
      * Compute if the dataset is shared
      * @returns {Boolean}
      */
-    isShared: function() {
+    isShared: function () {
       const collaboratorCount = compose(
         sum,
         values,
-        propOr({}, 'collaboratorCounts')
-      )(this.dataset)
+        propOr({}, "collaboratorCounts")
+      )(this.dataset);
 
-      return collaboratorCount > 0
+      return collaboratorCount > 0;
     },
 
     /**
@@ -295,39 +265,39 @@ export default {
      * owner of the dataset
      * @returns {Boolean}
      */
-    isOwner: function() {
-      return this.dataset.owner === this.profile.id
+    isOwner: function () {
+      return this.dataset.owner === this.profile.id;
     },
 
     /**
      * Compute dataset storage display
      * @returns {String}
      */
-    storage: function() {
-      return this.formatMetric(this.dataset.storage)
+    storage: function () {
+      return this.formatMetric(this.dataset.storage);
     },
 
     /**
      * Compute formatted timestamp
      * @returns {String}
      */
-    updated: function() {
-      return this.formatDate(this.dataset.content.updatedAt)
+    updated: function () {
+      return this.formatDate(this.dataset.content.updatedAt);
     },
 
     /**
      * Compute owner of dataset
      * @returns {String}
      */
-    owner: function() {
-      const ownerId = propOr('', 'owner', this.dataset)
-      if (ownerId === propOr('', 'id', this.profile)) {
-        return 'You'
+    owner: function () {
+      const ownerId = propOr("", "owner", this.dataset);
+      if (ownerId === propOr("", "id", this.profile)) {
+        return "You";
       } else {
-        const owner = find(propEq('id', ownerId), this.orgMembers)
-        const firstName = propOr('', 'firstName', owner)
-        const lastName = propOr('', 'lastName', owner)
-        return `${firstName} ${lastName}`
+        const owner = find(propEq("id", ownerId), this.orgMembers);
+        const firstName = propOr("", "firstName", owner);
+        const lastName = propOr("", "lastName", owner);
+        return `${firstName} ${lastName}`;
       }
     },
 
@@ -335,12 +305,12 @@ export default {
      * Get dataset link
      * @returns {Object}
      */
-    datasetLink: function() {
-      const datasetId = path(['content', 'id'], this.dataset)
-      let routeName = 'dataset-overview'
+    datasetLink: function () {
+      const datasetId = path(["content", "id"], this.dataset);
+      let routeName = "dataset-overview";
 
-      const link = { name: routeName, params: { datasetId }}
-      return datasetId ? link : ''
+      const link = { name: routeName, params: { datasetId } };
+      return datasetId ? link : "";
     },
 
     /**
@@ -348,81 +318,84 @@ export default {
      * image or placeholder banner image
      * @returns {String}
      */
-    datasetBanner: function() {
-      return this.dataset.bannerPresignedUrl || '/images/banner-placeholder.jpg'
+    datasetBanner: function () {
+      return (
+        this.dataset.bannerPresignedUrl || "/images/banner-placeholder.jpg"
+      );
     },
 
     /**
      * Compute banner image alt text
      * @returns {String}
      */
-    datasetBannerAlt: function() {
-      const datasetName = pathOr('', ['content', 'name'], this.dataset)
-      return `Banner image for ${datasetName}`
+    datasetBannerAlt: function () {
+      const datasetName = pathOr("", ["content", "name"], this.dataset);
+      return `Banner image for ${datasetName}`;
     },
 
-    datasetLocked: function() {
-      return Boolean(this.dataset.locked)
+    datasetLocked: function () {
+      return Boolean(this.dataset.locked);
     },
 
     /**
      * Compute publication status
      * @returns {String}
      */
-    publicatonStatus: function() {
-      const status = this.dataset.publication.status
+    publicatonStatus: function () {
+      const status = this.dataset.publication.status;
       if (status == PublicationStatus.REQUESTED) {
-        return UserFriendlyPublicationStatus.REQUESTED
+        return UserFriendlyPublicationStatus.REQUESTED;
       } else if (status == PublicationStatus.COMPLETED) {
-        return UserFriendlyPublicationStatus.COMPLETED
+        return UserFriendlyPublicationStatus.COMPLETED;
       } else if (status == PublicationStatus.REJECTED) {
-        return UserFriendlyPublicationStatus.REJECTED
+        return UserFriendlyPublicationStatus.REJECTED;
       } else {
-        return ''
+        return "";
       }
     },
 
     /**
-      * Compute publication status color
-      * @returns {String}
-      */
-    publicationStatusColor: function() {
-      const status = this.dataset.publication.status
+     * Compute publication status color
+     * @returns {String}
+     */
+    publicationStatusColor: function () {
+      console.log(
+        "this.dataset.publication.status",
+        this.dataset.publication.status
+      );
+      const status = this.dataset.publication.status;
       if (status == PublicationStatus.REQUESTED) {
-        return PublicationStatusColor.REQUESTED
+        return PublicationStatusColor.REQUESTED;
       } else if (status == PublicationStatus.COMPLETED) {
-        return PublicationStatusColor.COMPLETED
+        return PublicationStatusColor.COMPLETED;
       } else if (status == PublicationStatus.REJECTED) {
-        return PublicationStatusColor.REJECTED
+        return PublicationStatusColor.REJECTED;
       } else {
-        return '' //	should we return a default color here?
+        return ""; //	should we return a default color here?
       }
     },
 
-
-    PublicationType: function() {
-      return PublicationType
-    }
+    PublicationType: function () {
+      return PublicationType;
+    },
   },
 
   methods: {
-    ...mapActions([
-      'updateDataset'
-    ]),
+    ...mapActions(["updateDataset"]),
 
     /**
      * Show intercom window
      */
-    showIntercom: function() {
+    showIntercom: function () {
       // window.Intercom('show')
-    }
-  }
-}
+    },
+  },
+};
 </script>
 
 <style scoped lang="scss">
-@import '../../../../assets/_variables.scss';
-@import '../../../../assets/_list-item.scss';
+@import "../../../../assets/_variables.scss";
+@import "../../../../assets/_list-item.scss";
 
 .list-item-status-wrapper {
   color: $gray_4;
@@ -453,7 +426,7 @@ export default {
   margin: -2px 4px -2px -2px;
 }
 
-@media only screen and (max-width: 1200px){
+@media only screen and (max-width: 1200px) {
   .list-item-status-wrapper {
     width: 70px;
     height: fit-content;


### PR DESCRIPTION
In this PR: 

- We don't need permissions on the metadata tab, I removed it. 

- I also formatted the code so this PR looks larger than it actually is. 

- Substantive changes are one line doing the permissions removal, and (unrelated to the metadata permissions removal) I hitchhiked a comment onto this PR to help other devs understand why we have a status indicator on the datasets page but more of the datasets you see in dev env are "No Status." In dev it looks broken, I tried to fix it, I realized it wasn't actually broken, the API just returns "No Status" a lot.🕵🏻 TLDR: it's because Sparc datasets have statuses in prod. 

<img width="807" alt="Screenshot 2024-09-15 at 10 18 46 AM" src="https://github.com/user-attachments/assets/5e23f4ca-5a46-462b-88e7-b2ec0483e077">
<img width="1274" alt="Screenshot 2024-09-15 at 10 20 31 AM" src="https://github.com/user-attachments/assets/cd215d71-a15e-45ab-92b6-d657fe458267">
