### PR TITLE
Processor Styling and Interval Fetch Updates for Activity Monitor 

### DIFF
--- a/src/components/Analysis/Activity/ActivityMonitor.vue
+++ b/src/components/Analysis/Activity/ActivityMonitor.vue
@@ -66,7 +66,7 @@ const sidePanelVisible = ref(true);
 const isDetailsPanelOpen = ref(false);
 const selectedProcessor = ref({});
 const selectedNode = ref({});
-let intervalId = null; // Variable to store the interval ID
+let intervalId = null;
 
 /*
 Global State

--- a/src/components/Analysis/Activity/ActivityMonitor.vue
+++ b/src/components/Analysis/Activity/ActivityMonitor.vue
@@ -188,7 +188,6 @@ onMounted(async () => {
   const sortedWorkflows = workflowInstances.value.sort(
     (a, b) => new Date(b.startedAt) - new Date(a.startedAt)
   );
-
   // set initial selected workflow activity to show the first instance in the list
   const workflow = Object.keys(selectedWorkflowActivity.value).length
     ? selectedWorkflowActivity.value
@@ -232,6 +231,7 @@ watch(selectedWorkflowActivity, (newVal, oldVal) => {
         },
         position: { x: 130, y: 100 },
         class: getClass(newVal, 0),
+        selected: false,
       },
       {
         id: "2",
@@ -243,6 +243,7 @@ watch(selectedWorkflowActivity, (newVal, oldVal) => {
         },
         position: { x: 150, y: 250 },
         class: getClass(newVal, 1),
+        selected: false,
       },
       {
         id: "3",
@@ -253,6 +254,7 @@ watch(selectedWorkflowActivity, (newVal, oldVal) => {
         },
         position: { x: 170, y: 400 },
         class: getClass(newVal, 2),
+        selected: false,
       },
     ];
   }
@@ -283,7 +285,6 @@ onNodeClick(({ node }) => {
     (x) => x.name === node.data.label
   );
   if (selectedApplication) {
-    selectedNode.value = selectedApplication;
     openDetailsPanel(selectedApplication);
   }
 });

--- a/src/components/Analysis/Activity/ActivityMonitor.vue
+++ b/src/components/Analysis/Activity/ActivityMonitor.vue
@@ -359,15 +359,6 @@ onNodeClick(({ node }) => {
 <style lang="scss">
 @import "../../../assets/_variables.scss";
 
-@keyframes pulse {
-  0% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0.5;
-  }
-}
-
 .modified-stage {
   margin: 0;
 }
@@ -415,7 +406,7 @@ onNodeClick(({ node }) => {
 }
 
 .vue-flow__node.blue-node.animate {
-  border: 3px dotted $status_green; /* Initial border color */
+  border: 3px dotted $status_green;
   animation: border-dotted 4s linear infinite;
 }
 
@@ -427,7 +418,15 @@ onNodeClick(({ node }) => {
   border: 2px solid red;
 }
 
-/* Animation of a dotted line running around the perimeter of the box */
+@keyframes pulse {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.5;
+  }
+}
+
 @keyframes border-dotted {
   0% {
     border-top-color: transparent;
@@ -451,6 +450,12 @@ onNodeClick(({ node }) => {
 
 .vue-flow__node.selected {
   background-color: $gray_2;
+}
+
+.vue-flow__node {
+  &:hover {
+    background-color: $gray_2;
+  }
 }
 
 .activity-monitor {

--- a/src/components/Analysis/Activity/ActivityMonitor.vue
+++ b/src/components/Analysis/Activity/ActivityMonitor.vue
@@ -54,7 +54,7 @@ const initialEdges = [
   },
 ];
 
-/* 
+/*
 Local State
 */
 const isLoading = ref(false);
@@ -66,8 +66,8 @@ const isDetailsPanelOpen = ref(false);
 const selectedProcessor = ref({});
 const selectedNode = ref({});
 
-/* 
-Global State 
+/*
+Global State
 */
 const store = useStore();
 const workflowInstances = computed(
@@ -117,7 +117,7 @@ const getWorkflowStatus = async () => {
   await store.dispatch("analysisModule/fetchWorkflowInstances");
 };
 
-/* 
+/*
 Helpers
 */
 
@@ -283,8 +283,8 @@ onNodeClick(({ node }) => {
           :min-zoom="0.2"
           :max-zoom="4"
         >
-          <template #node-custom="customNodeProps">
-            <CustomNode :node-props="customNodeProps" />
+          <template #customNode="nodeProps">
+            <CustomNode v-bind="nodeProps" />
           </template>
           <Background pattern-color="#aaa" :gap="16" />
           <Controls position="top-left" />

--- a/src/components/Analysis/Activity/ActivityMonitor.vue
+++ b/src/components/Analysis/Activity/ActivityMonitor.vue
@@ -406,8 +406,11 @@ onNodeClick(({ node }) => {
 }
 
 .vue-flow__node.blue-node.animate {
-  border: 3px dotted $status_green;
-  animation: border-dotted 4s linear infinite;
+  animation: border-glow 5s infinite ease-in-out;
+}
+
+.vue-flow__node.pulsing {
+  animation: pulse 1.5s infinite ease-in-out;
 }
 
 .vue-flow__node.green-node {
@@ -421,30 +424,29 @@ onNodeClick(({ node }) => {
 @keyframes pulse {
   0% {
     opacity: 1;
-  }
-  100% {
-    opacity: 0.5;
-  }
-}
-
-@keyframes border-dotted {
-  0% {
-    border-top-color: transparent;
-    border-right-color: transparent;
-    border-bottom-color: transparent;
-    border-left-color: transparent;
-  }
-  25% {
-    border-top-color: $status_green;
+    transform: scale(1);
   }
   50% {
-    border-right-color: $status_green;
-  }
-  75% {
-    border-bottom-color: $status_green;
+    opacity: 0.7;
+    transform: scale(1.05);
   }
   100% {
-    border-left-color: $status_green;
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+@keyframes border-glow {
+  0% {
+    border-color: transparent;
+    box-shadow: 0 0 5px rgba(0, 255, 128, 0.2);
+  }
+  50% {
+    border-color: $status_green;
+    box-shadow: 0 0 15px rgba(0, 255, 128, 0.6);
+  }
+  100% {
+    border-color: transparent;
+    box-shadow: 0 0 5px rgba(0, 255, 128, 0.2);
   }
 }
 

--- a/src/components/Analysis/Activity/ActivityMonitor.vue
+++ b/src/components/Analysis/Activity/ActivityMonitor.vue
@@ -409,10 +409,6 @@ onNodeClick(({ node }) => {
   animation: border-glow 5s infinite ease-in-out;
 }
 
-.vue-flow__node.pulsing {
-  animation: pulse 1.5s infinite ease-in-out;
-}
-
 .vue-flow__node.green-node {
   border: 2px solid $status_green;
 }

--- a/src/components/Analysis/Activity/ActivityMonitor.vue
+++ b/src/components/Analysis/Activity/ActivityMonitor.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, watch, ref, onMounted, onUnmounted } from "vue";
+
 import { useStore } from "vuex";
 
 // Vue Flow Imports

--- a/src/components/Analysis/Activity/ActivityMonitor.vue
+++ b/src/components/Analysis/Activity/ActivityMonitor.vue
@@ -125,6 +125,14 @@ const getLabel = (workflow, type) =>
   workflow?.name ? `${workflow.name}` : `No ${type} Selected`;
 
 /*
+Computed Properties
+*/
+
+const isSelectedWorkflowActivitySet = computed(
+  () => Object.keys(selectedWorkflowActivity.value).length > 0
+);
+
+/*
 Fetch Initial Data
 */
 onMounted(async () => {
@@ -144,46 +152,47 @@ onMounted(async () => {
   );
 
   // set initial selected workflow activity to show the first instance in the list
-  try {
-    await store.dispatch(
-      "analysisModule/setSelectedWorkflowActivity",
-      sortedWorkflows[0]
-    );
-  } catch (err) {
-    console.error(err);
-  } finally {
-    isLoading.value = false;
+  if (sortedWorkflows.length) {
+    try {
+      await store.dispatch(
+        "analysisModule/setSelectedWorkflowActivity",
+        sortedWorkflows[0]
+      );
+    } catch (err) {
+      console.error(err);
+    } finally {
+      isLoading.value = false;
+    }
+    nodes.value = [
+      {
+        id: "1",
+        type: "input",
+        data: {
+          label: getLabel(sortedWorkflows[0]?.workflow[0], "Preprocessor"),
+        },
+        position: { x: 130, y: 100 },
+        class: "light",
+      },
+      {
+        id: "2",
+        type: "",
+        data: {
+          label: getLabel(sortedWorkflows[0]?.workflow[1], "Processor"),
+        },
+        position: { x: 150, y: 250 },
+        class: "light",
+      },
+      {
+        id: "3",
+        type: "output",
+        data: {
+          label: getLabel(sortedWorkflows[0]?.workflow[2], "Postprocessor"),
+        },
+        position: { x: 170, y: 400 },
+        class: "light",
+      },
+    ];
   }
-
-  nodes.value = [
-    {
-      id: "1",
-      type: "input",
-      data: {
-        label: getLabel(sortedWorkflows[0]?.workflow[0], "Preprocessor"),
-      },
-      position: { x: 130, y: 100 },
-      class: "light",
-    },
-    {
-      id: "2",
-      type: "",
-      data: {
-        label: getLabel(sortedWorkflows[0]?.workflow[1], "Processor"),
-      },
-      position: { x: 150, y: 250 },
-      class: "light",
-    },
-    {
-      id: "3",
-      type: "output",
-      data: {
-        label: getLabel(sortedWorkflows[0]?.workflow[2], "Postprocessor"),
-      },
-      position: { x: 170, y: 400 },
-      class: "light",
-    },
-  ];
 
   // Fetch data to get updates
 
@@ -267,12 +276,26 @@ onNodeClick(({ node }) => {
 
 <template>
   <div class="activity-monitor">
-    <h2 v-if="selectedWorkflowActivity" class="vue-flow-title">
-      {{ `Workflow Run: ${selectedWorkflowActivity?.name}` }}
-    </h2>
-    <div v-if="!isLoading && selectedWorkflowActivity" class="graph-browser">
+    <bf-empty-page-state
+      v-if="!isLoading && !isSelectedWorkflowActivitySet"
+      class="empty"
+    >
+      <img
+        src="/src/assets/images/illustrations/illo-collaboration.svg"
+        height="240"
+        width="247"
+        alt="Teams illustration"
+      />
+      <div>
+        <h2>There is no Workflow Activity yet</h2>
+      </div>
+    </bf-empty-page-state>
+    <div
+      v-if="!isLoading && isSelectedWorkflowActivitySet"
+      class="graph-browser"
+    >
       <div class="vue-flow-title">
-        {{ `Workflow Run: ${selectedWorkflowActivity.name || "Loading..."}` }}
+        {{ `Workflow Run: ${selectedWorkflowActivity?.name}` }}
       </div>
       <div class="vue-flow-wrapper">
         <VueFlow

--- a/src/components/Analysis/Activity/ActivityMonitor.vue
+++ b/src/components/Analysis/Activity/ActivityMonitor.vue
@@ -168,7 +168,7 @@ const startFetching = () => {
     clearInterval(intervalId);
   }
   fetchData();
-  intervalId = setInterval(fetchData, 10000);
+  intervalId = setInterval(fetchData, 20000);
 };
 
 onMounted(async () => {

--- a/src/components/Analysis/Activity/ActivityMonitor.vue
+++ b/src/components/Analysis/Activity/ActivityMonitor.vue
@@ -288,6 +288,10 @@ onNodeClick(({ node }) => {
       />
       <div>
         <h2>There is no Workflow Activity yet</h2>
+        <p>
+          Once you run an Analysis Workflow, you can view the status of your
+          workflow here.
+        </p>
       </div>
     </bf-empty-page-state>
     <div

--- a/src/components/Analysis/Activity/ActivityMonitor.vue
+++ b/src/components/Analysis/Activity/ActivityMonitor.vue
@@ -1,5 +1,12 @@
 <script setup>
-import { computed, watch, ref, onMounted, onBeforeUnmount } from "vue";
+import {
+  computed,
+  watch,
+  ref,
+  onMounted,
+  onBeforeUnmount,
+  onUnmounted,
+} from "vue";
 
 import { useStore } from "vuex";
 
@@ -188,9 +195,12 @@ onMounted(async () => {
   );
 
   // set initial selected workflow activity to show the first instance in the list
-  if (sortedWorkflows.length) {
+  const workflow = Object.keys(selectedWorkflowActivity.value).length
+    ? selectedWorkflowActivity.value
+    : sortedWorkflows[0];
+  if (sortedWorkflows.length && !intervalId) {
     try {
-      await getApplicationsStatus(sortedWorkflows[0]);
+      await getApplicationsStatus(workflow);
     } catch (err) {
       console.error(err);
     } finally {
@@ -205,6 +215,10 @@ onBeforeUnmount(() => {
   if (intervalId) {
     clearInterval(intervalId);
   }
+});
+
+onUnmounted(async () => {
+  await store.dispatch("analysisModule/setSelectedWorkflowActivity", null);
 });
 
 /*

--- a/src/components/Analysis/Activity/ActivityMonitor.vue
+++ b/src/components/Analysis/Activity/ActivityMonitor.vue
@@ -66,7 +66,6 @@ const sidePanelVisible = ref(true);
 const isDetailsPanelOpen = ref(false);
 const selectedProcessor = ref({});
 const selectedNode = ref({});
-const data = ref(null); // Reactive reference to hold the fetched data
 let intervalId = null; // Variable to store the interval ID
 
 /*
@@ -161,8 +160,6 @@ const fetchData = async () => {
       "analysisModule/setSelectedWorkflowActivity",
       selectedWorkflowActivity.value
     );
-
-    data.value = `Fetched data at ${new Date().toLocaleTimeString()}`;
   } catch (error) {
     console.error(error);
   }

--- a/src/components/Analysis/Activity/ActivityMonitor.vue
+++ b/src/components/Analysis/Activity/ActivityMonitor.vue
@@ -156,8 +156,6 @@ const isSelectedWorkflowActivitySet = computed(
 Fetch Initial Data
 */
 const fetchData = async () => {
-  console.log(`Fetched data at ${new Date().toLocaleTimeString()}`);
-
   try {
     await store.dispatch(
       "analysisModule/setSelectedWorkflowActivity",

--- a/src/components/Analysis/Activity/ActivityMonitor.vue
+++ b/src/components/Analysis/Activity/ActivityMonitor.vue
@@ -20,23 +20,19 @@ Initial Values
 const initialNodes = [
   {
     id: "1",
-    type: "input",
     data: {},
     position: { x: 130, y: 100 },
-    class: "light",
   },
   {
     id: "2",
     data: {},
     position: { x: 150, y: 250 },
-    class: "light",
   },
   {
     id: "3",
     type: "output",
     data: {},
     position: { x: 170, y: 400 },
-    class: "light",
   },
 ];
 const initialEdges = [
@@ -124,6 +120,36 @@ Helpers
 const getLabel = (workflow, type) =>
   workflow?.name ? `${workflow.name}` : `No ${type} Selected`;
 
+const getClass = (workflow, processorIdx) => {
+  switch (workflow.workflow[processorIdx].status) {
+    case "NOT_STARTED":
+      return "custom-node gray-node";
+    case "STARTED":
+      return "custom-node blue-node";
+    case "SUCCEEDED":
+      return "custom-node green-node";
+    case "FAILED":
+      return "custom-node red-node";
+    default:
+      return "custom-node green-node";
+  }
+};
+
+const statusClass = computed(() => {
+  switch (selectedWorkflowActivity.value) {
+    case "NOT_STARTED":
+      return "custom-node gray-node";
+    case "STARTED":
+      return "custom-node blue-node";
+    case "SUCCEEDED":
+      return "custom-node green-node";
+    case "FAILED":
+      return "custom-node red-node";
+    default:
+      return "custom-node green-node";
+  }
+});
+
 /*
 Computed Properties
 */
@@ -166,30 +192,30 @@ onMounted(async () => {
     nodes.value = [
       {
         id: "1",
-        type: "input",
         data: {
           label: getLabel(sortedWorkflows[0]?.workflow[0], "Preprocessor"),
+          status: sortedWorkflows[0].workflow[0].status,
         },
         position: { x: 130, y: 100 },
-        class: "light",
+        class: getClass(sortedWorkflows[0], 0),
       },
       {
         id: "2",
-        type: "",
         data: {
           label: getLabel(sortedWorkflows[0]?.workflow[1], "Processor"),
+          status: sortedWorkflows[0].workflow[1].status,
         },
         position: { x: 150, y: 250 },
-        class: "light",
+        class: getClass(sortedWorkflows[0], 1),
       },
       {
         id: "3",
-        type: "output",
         data: {
           label: getLabel(sortedWorkflows[0]?.workflow[2], "Postprocessor"),
+          status: sortedWorkflows[0].workflow[2].status,
         },
         position: { x: 170, y: 400 },
-        class: "light",
+        class: getClass(sortedWorkflows[0], 2),
       },
     ];
   }
@@ -214,30 +240,34 @@ watch(selectedWorkflowActivity, (newVal, oldVal) => {
     nodes.value = [
       {
         id: "1",
-        type: "input",
+
         data: {
           label: getLabel(newVal.workflow[0], "Preprocessor"),
+          status: newVal.workflow[0].status,
         },
         position: { x: 130, y: 100 },
-        class: "light",
+        class: getClass(newVal, 0),
       },
       {
         id: "2",
-        type: "",
+
         data: {
           label: getLabel(newVal.workflow[1], "Processor"),
+          status: newVal.workflow[1].status,
+          class: getClass(newVal, 1),
         },
         position: { x: 150, y: 250 },
-        class: "light",
+        class: getClass(newVal, 2),
       },
       {
         id: "3",
-        type: "output",
+
         data: {
           label: getLabel(newVal.workflow[2], "Postprocessor"),
+          status: newVal.workflow[2].status,
         },
         position: { x: 170, y: 400 },
-        class: "light",
+        class: statusClass,
       },
     ];
   }
@@ -305,14 +335,10 @@ onNodeClick(({ node }) => {
         <VueFlow
           :nodes="nodes"
           :edges="edges"
-          class="basic-flow"
           :default-viewport="{ zoom: 1 }"
           :min-zoom="0.2"
           :max-zoom="4"
         >
-          <template #customNode="nodeProps">
-            <CustomNode v-bind="nodeProps" />
-          </template>
           <Background pattern-color="#aaa" :gap="16" />
           <Controls position="top-left" />
         </VueFlow>
@@ -423,6 +449,38 @@ onNodeClick(({ node }) => {
 
   span {
     color: $purple_2;
+  }
+
+  .custom-node {
+    padding: 10px;
+    border-radius: 6px;
+    text-align: center;
+    font-weight: bold;
+    width: 100px;
+  }
+
+  .gray-node {
+    background-color: gray;
+  }
+  .green-node {
+    background-color: $status_green;
+  }
+  .red-node {
+    background-color: red;
+  }
+
+  .blue-node {
+    background-color: blue;
+    animation: pulse 1s infinite alternate;
+  }
+
+  @keyframes pulse {
+    0% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0.5;
+    }
   }
 }
 </style>

--- a/src/components/Analysis/Activity/CustomNode.vue
+++ b/src/components/Analysis/Activity/CustomNode.vue
@@ -1,27 +1,63 @@
-<script setup>
-import { Position, Handle } from '@vue-flow/core'
-import { toRef, ref } from 'vue';
-
-const props = defineProps(['nodeProps'])
-const nodeProps = toRef(props,'nodeProps')
-const type = ref(nodeProps.value.data.type)
-
-
-</script>
-
 <template>
-  <div class="vue-flow__node-default" :class="{input:type==='input', output:type==='output'}">
-    <Handle type="target" :position="Position.Top" />
-    <div>{{ nodeProps.data.label }}</div>
-    <button>View Logs</button>
-    <Handle type="source" :position="Position.Bottom" />
+  <div class="custom-node" :class="statusClass">
+    <slot />
   </div>
 </template>
+
+<script setup>
+import { computed } from "vue";
+import { useVueFlow } from "@vue-flow/core";
+
+const props = defineProps(["id", "data"]);
+const { findNode } = useVueFlow();
+const node = computed(() => findNode(props.id));
+
+const statusClass = computed(() => {
+  switch (node.value?.data?.status) {
+    case "NOT_STARTED":
+      return "gray-node";
+    case "STARTED":
+      return "blue-node";
+    case "SUCCEEDED":
+      return "green-node";
+    case "FAILED":
+      return "red-node";
+    default:
+      return "gray-node";
+  }
+});
+</script>
+
 <style scoped>
-  .input{
-    border-color: #0041d0;
+.custom-node {
+  padding: 10px;
+  border-radius: 6px;
+  text-align: center;
+  font-weight: bold;
+  width: 100px;
+}
+
+.gray-node {
+  background-color: gray;
+}
+.green-node {
+  background-color: green;
+}
+.red-node {
+  background-color: red;
+}
+
+.blue-node {
+  background-color: blue;
+  animation: pulse 1s infinite alternate;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 1;
   }
-  .output{
-    border-color: #ff0072;
+  100% {
+    opacity: 0.5;
   }
+}
 </style>

--- a/src/components/Analysis/Activity/CustomNode.vue
+++ b/src/components/Analysis/Activity/CustomNode.vue
@@ -1,63 +1,27 @@
-<template>
-  <div class="custom-node" :class="statusClass">
-    <slot />
-  </div>
-</template>
-
 <script setup>
-import { computed } from "vue";
-import { useVueFlow } from "@vue-flow/core";
+import { Position, Handle } from '@vue-flow/core'
+import { toRef, ref } from 'vue';
 
-const props = defineProps(["id", "data"]);
-const { findNode } = useVueFlow();
-const node = computed(() => findNode(props.id));
+const props = defineProps(['nodeProps'])
+const nodeProps = toRef(props,'nodeProps')
+const type = ref(nodeProps.value.data.type)
 
-const statusClass = computed(() => {
-  switch (node.value?.data?.status) {
-    case "NOT_STARTED":
-      return "gray-node";
-    case "STARTED":
-      return "blue-node";
-    case "SUCCEEDED":
-      return "green-node";
-    case "FAILED":
-      return "red-node";
-    default:
-      return "gray-node";
-  }
-});
+
 </script>
 
+<template>
+  <div class="vue-flow__node-default" :class="{input:type==='input', output:type==='output'}">
+    <Handle type="target" :position="Position.Top" />
+    <div>{{ nodeProps.data.label }}</div>
+    <button>View Logs</button>
+    <Handle type="source" :position="Position.Bottom" />
+  </div>
+</template>
 <style scoped>
-.custom-node {
-  padding: 10px;
-  border-radius: 6px;
-  text-align: center;
-  font-weight: bold;
-  width: 100px;
-}
-
-.gray-node {
-  background-color: gray;
-}
-.green-node {
-  background-color: green;
-}
-.red-node {
-  background-color: red;
-}
-
-.blue-node {
-  background-color: blue;
-  animation: pulse 1s infinite alternate;
-}
-
-@keyframes pulse {
-  0% {
-    opacity: 1;
+  .input{
+    border-color: #0041d0;
   }
-  100% {
-    opacity: 0.5;
+  .output{
+    border-color: #ff0072;
   }
-}
 </style>

--- a/src/components/Analysis/Activity/WorkflowsListItem.vue
+++ b/src/components/Analysis/Activity/WorkflowsListItem.vue
@@ -167,6 +167,12 @@ export default {
   }
 }
 
+.box {
+  &:hover {
+    border: 2px solid $black;
+  }
+}
+
 .icon {
   display: flex;
   align-items: center;

--- a/src/components/Analysis/Activity/WorkflowsListItem.vue
+++ b/src/components/Analysis/Activity/WorkflowsListItem.vue
@@ -116,10 +116,6 @@ export default {
   computed: {
     ...mapState("analysisModule", ["selectedWorkflowActivity"]),
     computedClass: function () {
-      console.log(
-        "this?.selectedWorkflowActivity",
-        this.selectedWorkflowActivity
-      );
       const workflow = this?.workflow?.uuid;
 
       const selectedWorkflow = this?.selectedWorkflowActivity?.uuid;

--- a/src/components/datasets/files/RunAnalysisDialog/RunAnalysisDialog.vue
+++ b/src/components/datasets/files/RunAnalysisDialog/RunAnalysisDialog.vue
@@ -384,7 +384,6 @@ export default {
       if (isValid) {
         this.processStep += step;
       }
-      console.log("here");
       // When you click Cancel
       if (this.processStep === 0) {
         this.closeDialog();

--- a/src/store/analysisModule.js
+++ b/src/store/analysisModule.js
@@ -388,6 +388,10 @@ const initialState = () => ({
       }
     },
     setSelectedWorkflowActivity: async ({ commit, dispatch, rootState}, workflow) => {
+      if (!workflow) {
+        commit('SET_SELECTED_WORKFLOW_ACTIVITY', {})
+        return;
+      }
       try {
         const url = `${rootState.config.api2Url}/workflows/instances/${workflow.uuid}/status`;
 


### PR DESCRIPTION
Code is currently up in dev. 

1.) Fetching Processor Status data in every 20 seconds - so when user is on the page they do not need to hard refresh to see statuses update. 

2.) Updated styling on statuses

STARTED:
https://github.com/user-attachments/assets/ae47908b-5d30-49ae-89a3-a936ae1e3687

SUCCEEDED
<img width="207" alt="Screenshot 2025-02-10 at 3 22 37 PM" src="https://github.com/user-attachments/assets/778500ad-11eb-4728-bd03-934e606c24a5" />

FAILED
<img width="248" alt="Screenshot 2025-02-10 at 3 22 52 PM" src="https://github.com/user-attachments/assets/ad7ae0ab-770d-4029-8569-80e2643709ce" />

NOT_STARTED
<img width="277" alt="Screenshot 2025-02-10 at 3 23 08 PM" src="https://github.com/user-attachments/assets/8274a169-554d-4c38-9407-5874e44de961" />
    
3.) Processor and Workflow selection and hover states updated for better user experience. 
    
