### PR TITLE
fix ORCID link in dataset publishing page

### DIFF
--- a/src/components/Code/ConfigureRepo.vue
+++ b/src/components/Code/ConfigureRepo.vue
@@ -12,21 +12,21 @@
         :padding="false"
       >
         <checklist-item
-          externalLink="https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release"
+          externalLinkUrl="https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release"
           externalLinkText="Create a Release"
           :is-complete="hasRelease(codeRepo)"
         >
           create at least one release in your repository on GithHub
         </checklist-item>
         <checklist-item
-          externalLink="https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository"
+          externalLinkUrl="https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository"
           externalLinkText="Add a License"
           :is-complete="hasLicense(codeRepo)"
         >
           add a license to your repository on GitHub
         </checklist-item>
         <checklist-item
-          externalLink="https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes"
+          externalLinkUrl="https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes"
           externalLinkText="Add a README"
           :is-complete="hasReadMe(readMe)"
         >

--- a/src/components/datasets/settings/BfPublishingSettings.vue
+++ b/src/components/datasets/settings/BfPublishingSettings.vue
@@ -98,13 +98,9 @@
 
         <checklist-item
           :is-complete="datasetOwnerHasOrcidId"
-          cta="Link ORCID Account"
-          :route="{
-            query: {
-              focusInput: 'orcidId',
-            },
-          }"
-          :show-link="isDatasetOwner"
+          :externalLinkUrl="getROrcidLink()"
+          externalLinkText="Link ORCID Account"
+          :enableLink="isDatasetOwner"
         >
           <template v-if="isDatasetOwner">
             link your ORCID iD to distinguish yourself from other researchers
@@ -428,6 +424,10 @@ export default {
      */
     computeChecklistIcon: function (prop = false) {
       return prop ? "IconDoneCheckCircle" : "IconInfo";
+    },
+
+    getROrcidLink: function() {
+      return this.config.environment === 'prod' ? 'https://discover.pennsieve.io/user/profile' : 'https://discover.pennsieve.net/user/profile'
     },
   },
 };

--- a/src/components/shared/ChecklistItem/ChecklistItem.vue
+++ b/src/components/shared/ChecklistItem/ChecklistItem.vue
@@ -1,30 +1,25 @@
 <template>
   <div class="dataset-discover-checklist-item">
     <div class="icon-link-wrap">
-      <IconDoneCheckCircle
-        v-if="isComplete"
-        class="mr-8 checked"
-        :height="20"
-        :width="20"
-      />
+      <IconDoneCheckCircle v-if="isComplete" class="mr-8 checked" :height="20" :width="20" />
       <IconInfo v-else class="mr-8" :height="20" :width="20" />
 
       <div class="link-wrap mr-8">
-        <router-link
-          v-if="showLink"
-          :to="route"
-          @click.native="$emit('click-link', $event)"
-        >
+        <router-link v-if="cta" :to="route" @click.native="$emit('click-link', $event)">
           {{ cta }}
         </router-link>
-        <strong v-if="!showLink">
-          {{ cta }}
-        </strong>
-        <a :href="externalLinkUrl" target="_blank">
-          <strong v-if="externalLinkText">
+        <template v-if="enableLink">
+          <a :href="externalLinkUrl" target="_blank">
+            <strong>
+              {{ externalLinkText }}
+            </strong>
+          </a>
+        </template>
+        <template v-else>
+          <strong>
             {{ externalLinkText }}
           </strong>
-        </a>
+        </template>
 
         &nbsp; &mdash;
       </div>
@@ -61,11 +56,7 @@ export default {
         return {};
       },
     },
-    showLink: {
-      type: Boolean,
-      default: true,
-    },
-    externalLink: {
+    externalLinkUrl: {
       type: String,
       default: "",
     },
@@ -73,11 +64,10 @@ export default {
       type: String,
       default: "",
     },
-  },
-  computed: {
-    externalLinkUrl: function () {
-      return this.externalLink;
-    },
+    enableLink: {
+      type: Boolean,
+      default: true,
+    }
   },
 };
 </script>


### PR DESCRIPTION
- fix ORCID link URL in dataset publishing page
- previous URL takes to internal route (doesn't exist anymore) in pennsieve app, new URL takes the user to the Profile page in Discover app

Recording of the fix
https://github.com/user-attachments/assets/d2b1fd51-5ac4-447f-94fe-a1dfc6bb3b7a

