### PR TITLE
add collections history to router

### DIFF
--- a/src/router/Dataset/SecondaryPageHeaderFiles.vue
+++ b/src/router/Dataset/SecondaryPageHeaderFiles.vue
@@ -1,0 +1,67 @@
+<script setup>
+import { ref, computed } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import BfRafter from "../../components/shared/bf-rafter/BfRafter.vue";
+import IconArrowLeft from "../../components/icons/IconArrowLeft.vue";
+import LockedBanner from "../../components/datasets/LockedBanner/LockedBanner.vue";
+import { getPreviousCollection } from "../index.js"; 
+
+const route = useRoute();
+const router = useRouter();
+
+function backToFiles(){
+    const { datasetId } = route.params;
+  const previousCollection = getPreviousCollection(); // ✅ Get stored collection ID
+
+  if (previousCollection) {
+    router.push({
+      name: "collection-files",
+      params: { datasetId, fileId: previousCollection },
+    });
+  } else {
+    router.push({
+      name: "dataset-files",
+      params: { datasetId },
+    });
+  }
+}
+
+</script>
+
+<template>
+  <locked-banner slot="banner" />
+
+  <bf-rafter slot="heading">
+    <template #breadcrumb v-if="route.meta.showBackToFiles">
+      <a @click="backToFiles()" class="link-to-files">
+        <IconArrowLeft :height="10" :width="10" />
+        Back to Files
+      </a>
+    </template>
+
+    <template #heading>
+      <div class="title-wrapper">
+        <h1 class="flex-heading">
+          Files
+        </h1>
+      </div>
+    </template>
+  </bf-rafter>
+</template>
+
+<style scoped lang="scss">
+@import "../../assets/_variables.scss";
+
+.flex-heading {
+  background-color: $purple_1;
+}
+
+.el-collapse-item__header {
+  background: $purple_2;
+}
+
+.link-to-files {
+  color: $white;
+  cursor: pointer;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -18,6 +18,7 @@ const BfDatasetList = () => import('../components/datasets/dataset-list/BfDatase
 const DatasetListHeader = () => import('./Datasets/DatasetListHeader.vue')
 const DatasetOverview = () => import('../components/datasets/DatasetOverview/DatasetOverview.vue')
 const SecondaryPageHeader = () => import('./Dataset/SecondaryPageHeader.vue')
+const SecondaryPageHeaderFiles = () => import('./Dataset/SecondaryPageHeaderFiles.vue')
 const DatasetActivityHeader = () => import('./Dataset/DatasetActivityHeader.vue')
 const BfDatasetFiles = () => import('../components/datasets/files/BfDatasetFiles.vue')
 const FileDetails = () => import('../components/datasets/files/FileDetails/FileDetails.vue')
@@ -120,6 +121,11 @@ const InstanceEdit = () => import('../components/datasets/explore/ConceptInstanc
  * 404
  */
 const PS404 = () => import('../components/PS-404/PS-404.vue')
+/**
+ * for page navigation
+ * if more navigation history is needed, this functionality should be moved to its own store. 
+ */
+let previousCollection = null;
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -317,7 +323,7 @@ const router = createRouter({
           name: 'dataset-files-wrapper',
           path: ':datasetId/files',
           components: {
-            stageHeader: SecondaryPageHeader,
+            stageHeader: SecondaryPageHeaderFiles,
             stage: DatasetFilesView
           },
           props: {
@@ -861,5 +867,22 @@ const router = createRouter({
   ],
 });
 
-export default router;
+/**
+ * Store last visited collection ID
+ */
+router.beforeEach((to, from, next) => {
+  if (from.params.fileId && from.params.fileId.startsWith("N:collection:")) {
+    previousCollection = from.params.fileId; 
+  }
+  next();
+});
 
+/**
+ * function to get most recent collection id
+ */
+export function getPreviousCollection() {
+  return previousCollection;
+}
+
+
+export default router;


### PR DESCRIPTION
TICKET
https://app.clickup.com/t/86899pdc1

reverted changes to SecondaryPageHeader.vue because it is used in several other places. I don't want to accidentally break something.

new component: SecondaryPageHeader.vue

Router:
add SecondaryPageHeader.vue to navigation
add variable and functionality to get and store last collection in navigation.
