### PR TITLE
rename legacy metadata service routes

### DIFF
--- a/src/components/SearchAllData/SearchFilter/SearchFilter.vue
+++ b/src/components/SearchAllData/SearchFilter/SearchFilter.vue
@@ -631,7 +631,7 @@ export default {
     },
 
     async autocomplete (prefix) {
-      const url = `${this.config.api2Url}/metadata/query/autocomplete?dataset_id=${this.$route.params.datasetId}`
+      const url = `${this.config.api2Url}/metadata_legacy/query/autocomplete?dataset_id=${this.$route.params.datasetId}`
 
       let requestFilters = this.filterParams.filter(value => {
         return value.value != ''

--- a/src/store/filesModule.js
+++ b/src/store/filesModule.js
@@ -57,7 +57,7 @@ export const actions = {
 
     const currentRoute = router.currentRoute.value
     const datasetId = currentRoute.params.datasetId
-    const endpoint = `${rootState.config.api2Url}/metadata/package`
+    const endpoint = `${rootState.config.api2Url}/metadata_legacy/package`
 
     const apiKey = rootState.userToken || Cookies.get('user_token')
     const queryParams = getPackageMetadataQueryParams(state.datasetManifestParams, datasetId, packageId)

--- a/src/store/metadataModule.js
+++ b/src/store/metadataModule.js
@@ -187,7 +187,7 @@ export const actions = {
       let datasetId = rootState.dataset.content.id
 
 
-      const url = `${rootState.config.api2Url}/metadata/query?dataset_id=${datasetId}`
+      const url = `${rootState.config.api2Url}/metadata_legacy/query?dataset_id=${datasetId}`
 
       let filters = state.filterParams.filter(value => {
         return value.value != ''


### PR DESCRIPTION
## Motivation
Deprecate the old metadata service routes that conflict with new metadata service routes

### Related PRS
- https://github.com/Pennsieve/pennsieve-go-api/pull/109
- https://github.com/Pennsieve/model-service-serverless/pull/10