### PR TITLE
Pusher refresh + manifest status UX: throttle, silent refresh, FailedOrphan

### DIFF
--- a/src/components/FilesTable/FilesTable.vue
+++ b/src/components/FilesTable/FilesTable.vue
@@ -83,6 +83,7 @@
       v-loading="withinDeleteMenu ? false : tableLoading"
       :border="true"
       :data="data"
+      :row-key="rowKey"
       class="modern-table"
       :default-sort="{ prop: 'content.name', order: 'ascending' }"
       @selection-change="handleTableSelectionChange"
@@ -329,6 +330,13 @@ export default {
   },
   methods: {
     ...mapActions("filesModule", ["openOffice365File"]),
+
+    // row-key lets el-table diff rows across data updates instead of
+    // rebuilding every <tr>. Keyed on the package node id so Pusher-driven
+    // silent merges reuse DOM nodes (no flicker, selections preserved).
+    rowKey(row) {
+      return row?.content?.id;
+    },
 
     handleCloseModal: function () {
       this.$refs.table.clearSelection();

--- a/src/components/datasets/DatasetActivity/UploadManifestFiles/ManifestFileFilterMenu.vue
+++ b/src/components/datasets/DatasetActivity/UploadManifestFiles/ManifestFileFilterMenu.vue
@@ -58,10 +58,14 @@ export default {
     statusOptions: {
       type: Array,
       default: () => {
+        // Labels are space-stripped by the URL builder in UploadManifestFiles
+        // to form the backend enum value. Keep them matching the manifestFile
+        // status enum: "Failed Orphan" -> "FailedOrphan".
         return [
           "All",
           "In Progress",
           "Failed",
+          "Failed Orphan",
         ]
       }
     }

--- a/src/components/datasets/DatasetActivity/UploadManifestFiles/UploadManifestFile.vue
+++ b/src/components/datasets/DatasetActivity/UploadManifestFiles/UploadManifestFile.vue
@@ -28,7 +28,7 @@
         :sm="5"
         class="member-col col-spacer"
       >
-      {{ item.status}}
+      {{ statusLabel }}
       </el-col>
       <el-col
         :sm="2"
@@ -84,6 +84,16 @@ export default {
 
     fileIconStr: function() {
       return this.toPackageType(this.item.file_type)
+    },
+
+    // Human-friendly display names for the raw manifestFile status enum.
+    // Unknown values fall through to the raw value so we never hide an
+    // actual backend state from the operator.
+    statusLabel: function() {
+      const map = {
+        FailedOrphan: "Failed (Missing)",
+      }
+      return map[this.item.status] || this.item.status
     }
   },
 

--- a/src/components/datasets/files/BfDatasetFiles.vue
+++ b/src/components/datasets/files/BfDatasetFiles.vue
@@ -498,25 +498,16 @@ export default {
         if (!isEmpty(channel)) {
           channel.bind(
             "upload-event",
-            function (data) {
-              for (let x in data) {
-                this.updateFileStatus({
-                  key: data[x].upload_id.String,
-                  status: "complete",
-                });
-              }
-
-              // Silent refetch: same endpoint as a user-driven navigation,
-              // but we don't toggle the loading spinner, reset selections,
-              // or reset the current folder. Combined with el-table's
-              // row-key, this lets sizes tick up in place without the
-              // per-second table flash.
+            function () {
+              // Pusher's job here is purely "a file landed in Postgres,
+              // refresh the dataset table." It fires for uploads from any
+              // source (this browser session, a different session, the
+              // agent). The browser upload flow's own state machine is
+              // driven by the finalize API response (see uploadModule.js)
+              // — nothing on this Pusher event touches it.
               //
-              // The throttling options (leading: true + maxWait) ensure:
-              //   - the first event in a burst refreshes immediately,
-              //   - subsequent events within the window are coalesced,
-              //   - sustained bursts still produce at most one refresh
-              //     per second rather than being held off until events stop.
+              // Silent refetch + leading/maxWait debounce keep the table
+              // current during a burst without the per-second flash.
               this.debouncedSilentFetch();
             }.bind(this)
           );
@@ -600,7 +591,6 @@ export default {
   methods: {
     ...mapActions("uploadModule", [
       "resetUpload",
-      "updateFileStatus",
       "setCurrentTargetPackage",
     ]),
     ...mapActions("datasetsModule", ["createDatasetManifest"]),

--- a/src/components/datasets/files/BfDatasetFiles.vue
+++ b/src/components/datasets/files/BfDatasetFiles.vue
@@ -506,20 +506,18 @@ export default {
                 });
               }
 
-              // Refetch on every upload event. We can't tell from the
-              // payload (which only carries the leaf parent_id) whether an
-              // uploaded file is a descendant of the currently-viewed
-              // folder, and aggregate sizes propagate up the ancestor
-              // chain even for files not directly in this folder.
+              // Silent refetch: same endpoint as a user-driven navigation,
+              // but we don't toggle the loading spinner, reset selections,
+              // or reset the current folder. Combined with el-table's
+              // row-key, this lets sizes tick up in place without the
+              // per-second table flash.
               //
               // The throttling options (leading: true + maxWait) ensure:
-              //   - the first event in a burst fires a refetch immediately
-              //     so the user sees progress,
+              //   - the first event in a burst refreshes immediately,
               //   - subsequent events within the window are coalesced,
-              //   - a sustained burst still produces at most one refetch
-              //     per second (maxWait) rather than being held off until
-              //     events stop.
-              this.debouncedFetchFiles();
+              //   - sustained bursts still produce at most one refresh
+              //     per second rather than being held off until events stop.
+              this.debouncedSilentFetch();
             }.bind(this)
           );
         }
@@ -531,13 +529,14 @@ export default {
   },
 
   created() {
-    // Throttled refetch wrapped around lodash.debounce with leading + maxWait
-    // so that the first event in a burst refetches immediately and sustained
-    // bursts still produce at most one refetch per second. Used by the
-    // upload-event Pusher handler to coalesce the hundreds of events a
-    // large direct-to-storage upload produces.
-    this.debouncedFetchFiles = debounce(
-      () => this.fetchFiles(this.filesUrl),
+    // Throttled silent refetch used by the upload-event Pusher handler to
+    // coalesce the hundreds of events a large direct-to-storage upload
+    // produces. Leading + maxWait mean the first event in a burst refreshes
+    // immediately and sustained bursts still produce at most one refresh
+    // per second, without the spinner / selection reset the full navigation
+    // refetch causes.
+    this.debouncedSilentFetch = debounce(
+      () => this.silentlyFetchFiles(),
       1000,
       { leading: true, trailing: true, maxWait: 1000 }
     );
@@ -922,6 +921,56 @@ export default {
       }
 
       return subtype ? subtype : defaultType;
+    },
+
+    /**
+     * Pusher-driven silent refresh of the file list. Same endpoint as
+     * fetchFiles, but:
+     *   - no `filesLoading` toggle (no spinner overlay flash),
+     *   - no `resetSelectedFiles` (user's checkbox state preserved),
+     *   - no `SET_CURRENT_FOLDER` commit (no breadcrumb churn),
+     *   - no ancestors / route-driven scroll reset.
+     *
+     * el-table's row-key is keyed on content.id, so when we replace
+     * `this.files` the table reuses DOM nodes for unchanged rows and only
+     * repaints the columns whose values actually changed (e.g. `storage`).
+     */
+    silentlyFetchFiles: function () {
+      if (!this.filesUrl) return;
+      // If the user has paginated past the first page, skip the silent
+      // refresh: filesUrl encodes the current offset, and a silent re-merge
+      // at offset>0 would either duplicate the already-loaded tail or miss
+      // the leading pages. Pagination is rare (>500 files in one folder);
+      // the worst case is that live sizes don't tick for those users until
+      // they navigate.
+      if (this.offset > 0) return;
+
+      useGetToken()
+        .then((token) => {
+          const fullUrl = `${this.filesUrl}&api_key=${token}`;
+          return useSendXhr(fullUrl).then((response) => {
+            const newFiles = response.children.map((file) => {
+              if (!file.storage) {
+                file.storage = 0;
+              }
+              file.icon =
+                file.icon || this.getFilePropertyVal(file.properties, "icon");
+              file.subtype = this.getSubType(file);
+              return file;
+            });
+            this.files = newFiles;
+            this.sortedFiles = this.returnSort(
+              "content.name",
+              this.files,
+              this.sortDirection
+            );
+          });
+        })
+        .catch((response) => {
+          // Silent refresh failures shouldn't nuke the user's current view.
+          // Log for visibility but don't surface the error toast.
+          console.warn("silentlyFetchFiles failed", response);
+        });
     },
 
     /**

--- a/src/components/datasets/files/BfDatasetFiles.vue
+++ b/src/components/datasets/files/BfDatasetFiles.vue
@@ -286,6 +286,7 @@ import PsButtonDropdown from "@/components/shared/ps-button-dropdown/PsButtonDro
 import IconAnnotation from "@/components/icons/IconAnnotation.vue";
 import { useGetToken } from "@/composables/useGetToken";
 import { useSendXhr } from "@/mixins/request/request_composable";
+import debounce from "lodash.debounce";
 
 export default {
   name: "BfDatasetFiles",
@@ -498,7 +499,6 @@ export default {
           channel.bind(
             "upload-event",
             function (data) {
-              let curFolderId = this.file.content.intId;
               for (let x in data) {
                 this.updateFileStatus({
                   key: data[x].upload_id.String,
@@ -506,12 +506,20 @@ export default {
                 });
               }
 
-              for (let x in data) {
-                if ((data[x].parent_id.Int64 = curFolderId)) {
-                  this.fetchFiles(this.filesUrl);
-                  break;
-                }
-              }
+              // Refetch on every upload event. We can't tell from the
+              // payload (which only carries the leaf parent_id) whether an
+              // uploaded file is a descendant of the currently-viewed
+              // folder, and aggregate sizes propagate up the ancestor
+              // chain even for files not directly in this folder.
+              //
+              // The throttling options (leading: true + maxWait) ensure:
+              //   - the first event in a burst fires a refetch immediately
+              //     so the user sees progress,
+              //   - subsequent events within the window are coalesced,
+              //   - a sustained burst still produces at most one refetch
+              //     per second (maxWait) rather than being held off until
+              //     events stop.
+              this.debouncedFetchFiles();
             }.bind(this)
           );
         }
@@ -520,6 +528,19 @@ export default {
     },
 
     $route: "handleRouteChange",
+  },
+
+  created() {
+    // Throttled refetch wrapped around lodash.debounce with leading + maxWait
+    // so that the first event in a burst refetches immediately and sustained
+    // bursts still produce at most one refetch per second. Used by the
+    // upload-event Pusher handler to coalesce the hundreds of events a
+    // large direct-to-storage upload produces.
+    this.debouncedFetchFiles = debounce(
+      () => this.fetchFiles(this.filesUrl),
+      1000,
+      { leading: true, trailing: true, maxWait: 1000 }
+    );
   },
 
   mounted: function () {


### PR DESCRIPTION
## Summary

Cleanup for the upload UX in the web app, surfaced while working through a direct-to-storage upload test session.

### Commits

1. **Throttle upload-event refetches** (`d023b94`)
   Wraps the `upload-event` Pusher handler's refetch in `debounce(1000, {leading, trailing, maxWait: 1000})` so a large direct-to-storage upload (thousands of Pusher events) produces at most one refetch per second instead of one per event. Drops the ad-hoc `parent_id === currentFolder` filter that was missing aggregate-size updates in ancestor folders.

2. **Silent Pusher refresh** (`84c083a`)
   Even after throttling to 1 Hz, the refetch still flashed the loading spinner, cleared the user's checkbox selections, and replaced `this.files` wholesale (rebuilding every `<tr>` every second). Routes Pusher-driven refreshes through a new `silentlyFetchFiles` that skips:
   - `filesLoading = true` (no overlay spinner),
   - `resetSelectedFiles()` (checkboxes preserved),
   - `SET_CURRENT_FOLDER` commit (no breadcrumb churn),
   - the error toast (logs silently on failure).

   Also adds `:row-key="content.id"` to `el-table` so Element Plus diffs rows by package node id instead of rebuilding every `<tr>`. Storage sizes tick up in place, no flash, selections persist. `fetchFiles` is unchanged and still drives navigation / initial load / folder changes.

3. **Surface FailedOrphan in the manifest-files activity table** (`af09102`)
   pennsieve-go-core v1.15.2 added a terminal `FailedOrphan` status for manifest_files rows whose bytes never arrived. The activity table's filter dropdown was hardcoded to `["All", "In Progress", "Failed"]` and rows rendered raw status text. Adds a "Failed Orphan" filter option (space-stripped to `"FailedOrphan"` by the existing URL builder) and a `statusLabel` computed prop that maps `FailedOrphan → "Failed (Missing)"`, falling back to the raw value for unknown statuses so new backend states aren't hidden.

## Test plan

- [x] Tested #1 and #2 locally with a large direct-to-storage upload: table no longer flashes, sizes increment in place, checkbox selections survive across Pusher events.
- [ ] QA: verify initial folder load, navigation, and breadcrumb clicks still work normally (full-spinner fetchFiles path unchanged).
- [ ] QA: in Dataset Activity → upload manifest, verify "Failed Orphan" filter shows correct rows and the row label reads "Failed (Missing)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)