### PR TITLE
Throttle upload-event refetches to avoid refresh storm

### DIFF
--- a/src/components/datasets/files/BfDatasetFiles.vue
+++ b/src/components/datasets/files/BfDatasetFiles.vue
@@ -286,6 +286,7 @@ import PsButtonDropdown from "@/components/shared/ps-button-dropdown/PsButtonDro
 import IconAnnotation from "@/components/icons/IconAnnotation.vue";
 import { useGetToken } from "@/composables/useGetToken";
 import { useSendXhr } from "@/mixins/request/request_composable";
+import debounce from "lodash.debounce";
 
 export default {
   name: "BfDatasetFiles",
@@ -498,7 +499,6 @@ export default {
           channel.bind(
             "upload-event",
             function (data) {
-              let curFolderId = this.file.content.intId;
               for (let x in data) {
                 this.updateFileStatus({
                   key: data[x].upload_id.String,
@@ -506,12 +506,20 @@ export default {
                 });
               }
 
-              for (let x in data) {
-                if ((data[x].parent_id.Int64 = curFolderId)) {
-                  this.fetchFiles(this.filesUrl);
-                  break;
-                }
-              }
+              // Refetch on every upload event. We can't tell from the
+              // payload (which only carries the leaf parent_id) whether an
+              // uploaded file is a descendant of the currently-viewed
+              // folder, and aggregate sizes propagate up the ancestor
+              // chain even for files not directly in this folder.
+              //
+              // The throttling options (leading: true + maxWait) ensure:
+              //   - the first event in a burst fires a refetch immediately
+              //     so the user sees progress,
+              //   - subsequent events within the window are coalesced,
+              //   - a sustained burst still produces at most one refetch
+              //     per second (maxWait) rather than being held off until
+              //     events stop.
+              this.debouncedFetchFiles();
             }.bind(this)
           );
         }
@@ -520,6 +528,19 @@ export default {
     },
 
     $route: "handleRouteChange",
+  },
+
+  created() {
+    // Throttled refetch wrapped around lodash.debounce with leading + maxWait
+    // so that the first event in a burst refetches immediately and sustained
+    // bursts still produce at most one refetch per second. Used by the
+    // upload-event Pusher handler to coalesce the hundreds of events a
+    // large direct-to-storage upload produces.
+    this.debouncedFetchFiles = debounce(
+      () => this.fetchFiles(this.filesUrl),
+      1000,
+      { leading: true, trailing: true, maxWait: 1000 }
+    );
   },
 
   mounted: function () {


### PR DESCRIPTION
The upload-event Pusher handler refetched the current folder on every event, guarded by a filter that had a bug:

    if ((data[x].parent_id.Int64 = curFolderId)) {

The `=` is an assignment (not `===`), so the condition was always truthy and every upload event forced a full fetchFiles call. The bug was hidden under the old sync-finalize path (~40 events per 10k-file upload) but became visible once finalize moved to async SQS-backed imports (~400 events per 10k-file upload) — the UI refresh-stormed.

Two changes:

1. Drop the parent-id filter entirely. The Pusher payload only carries the leaf parent_id, so the client can't tell if an uploaded file is a descendant of the currently-viewed folder, and aggregate sizes propagate up the ancestor chain whether or not the file is a direct child. Always refetching is correct; cost is controlled by throttling instead.

2. Route the refetch through a throttled lodash.debounce wrapper (leading: true, maxWait: 1000). First event in a burst refetches immediately so the user sees progress; sustained bursts produce at most one refetch per second; a trailing call covers the tail.

updateFileStatus still fires per event (in-memory, cheap) so per-file status updates in the UI stay live.