### PR TITLE
DatasetFiles drag-drop UX: optimistic rows, eager finalize, parallel uploads

### DIFF
--- a/src/components/FilesTable/FilesTable.vue
+++ b/src/components/FilesTable/FilesTable.vue
@@ -117,7 +117,7 @@
         v-else
         type="selection"
         align="center"
-        :selectable="withinDeleteMenu ? canSelectRow : null"
+        :selectable="isRowSelectable"
         width="50"
       />
 
@@ -358,6 +358,15 @@ export default {
       return row.state === "DELETED";
     },
 
+    // Gate the built-in selection column: placeholder rows (optimistic
+    // upload rows injected by uploadModule) are never selectable, so the
+    // user can't accidentally Delete/Move/Download an in-flight upload.
+    isRowSelectable: function (row) {
+      if (row && row._placeholder) return false;
+      if (this.withinDeleteMenu) return this.canSelectRow(row);
+      return true;
+    },
+
     /**
      * Checkbox display logic
      * @param {Object} store
@@ -519,6 +528,12 @@ export default {
     onRowClick: function (row, column) {
       // Ignore clicks on the checkbox column - onSelect handles those
       if (column?.type === 'selection') {
+        return;
+      }
+
+      // Placeholder rows (optimistic upload rows) are read-only — no
+      // selection, no range-select anchor.
+      if (row && row._placeholder) {
         return;
       }
 

--- a/src/components/PennsieveUpload/PennsieveUpload.vue
+++ b/src/components/PennsieveUpload/PennsieveUpload.vue
@@ -80,7 +80,7 @@ User archives manifest -> remove activeManifest from memory
 
       <div v-if="isUploading || uploadComplete">
         <div
-          v-for="[key, value] in uploadMap"
+          v-for="[key, value] in activeUploadEntries"
           :key="key"
           class="manifest-file-wrapper"
         >
@@ -142,6 +142,20 @@ const uploadFiles = computed(() =>
   store.getters["uploadModule/getManifestFiles"]()
 );
 const uploadMap = computed(() => store.getters["uploadModule/getUploadMap"]());
+
+// Entries from the *current* upload batch only. Finalized entries from a
+// previous batch stay in uploadFileMap so their placeholder rows can
+// remain in the DatasetFiles table until the Pusher-driven silent
+// refresh confirms them — but they shouldn't appear in this dialog when
+// the user starts a new drop. "finalized" = "user's work done for that
+// file"; the dialog is for work-in-progress.
+const activeUploadEntries = computed(() => {
+  const out = [];
+  for (const entry of uploadMap.value) {
+    if (entry[1].status !== "finalized") out.push(entry);
+  }
+  return out;
+});
 const isUploading = computed(() =>
   store.getters["uploadModule/getIsUploading"]()
 );
@@ -157,7 +171,9 @@ const allFilesComplete = computed(() => {
   const map = uploadMap.value;
   if (map.size === 0) return false;
   for (const [, value] of map) {
-    if (value.status !== "processing") {
+    // See BfUploadInfo.vue allFilesComplete — both "processing" and
+    // "finalized" mean the user's work is done; the server is catching up.
+    if (value.status !== "processing" && value.status !== "finalized") {
       return false;
     }
   }

--- a/src/components/bf-download-file/BfDownloadFile.vue
+++ b/src/components/bf-download-file/BfDownloadFile.vue
@@ -83,6 +83,7 @@ import BfStorageMetrics from "../../mixins/bf-storage-metrics";
 import Sorter from "../../mixins/sorter";
 import IconXCircle from "../icons/IconXCircle.vue";
 import { useGetToken } from "@/composables/useGetToken";
+import EventBus from "../../utils/event-bus";
 
 const DEFAULT_ARCHIVE_NAME = "pennsieve-data";
 
@@ -203,6 +204,31 @@ export default {
      *     represents the parent package of those files
      */
     triggerDownload: async function (packageDTOs, fileDTOs) {
+      // Block optimistic upload rows and packages still being processed
+      // server-side. Selection is already gated (FilesTable.isRowSelectable),
+      // but the toolbar + keyboard paths can still route a placeholder
+      // here, and a package freshly finalized may briefly sit in
+      // UPLOADED/PROCESSING before hitting READY.
+      const notReady = (packageDTOs || []).filter(
+        (p) =>
+          (p && p._placeholder) ||
+          (pathOr("", ["content", "state"], p) &&
+            pathOr("", ["content", "state"], p) !== "READY")
+      );
+      if (notReady.length > 0) {
+        EventBus.$emit("toast", {
+          detail: {
+            type: "info",
+            msg:
+              notReady.length === (packageDTOs || []).length
+                ? "Files are still being processed. Download will be available once they're ready."
+                : "Some selected files are still being processed and were skipped.",
+          },
+        });
+        packageDTOs = (packageDTOs || []).filter((p) => !notReady.includes(p));
+        if (packageDTOs.length === 0) return;
+      }
+
       this.packageDTOs = packageDTOs;
       this.fileDTOs = fileDTOs;
       await this.$nextTick();

--- a/src/components/datasets/files/BfDatasetFiles.vue
+++ b/src/components/datasets/files/BfDatasetFiles.vue
@@ -144,7 +144,7 @@
         <div class="table-container" ref="tableContainer" @scroll="handleScroll" v-if="!trashMode">
         <files-table
           ref="filesTable"
-          :data="files"
+          :data="displayFiles"
           :multiple-selected="multipleSelected"
           :table-loading="filesLoading"
           :is-package-attachment-active="isPackageAttachmentActive"
@@ -382,7 +382,13 @@ export default {
       "getPermission",
       "datasetLocked",
     ]),
-    ...mapGetters("uploadModule", ["getIsUploading", "getUploadComplete", "getUploadMap"]),
+    ...mapGetters("uploadModule", [
+      "getIsUploading",
+      "getUploadComplete",
+      "getUploadMap",
+      "getPlaceholdersForFolder",
+      "getManifestFiles",
+    ]),
 
     ...mapGetters("datasetModule", [
       "getPusherChannel",
@@ -390,8 +396,13 @@ export default {
     ]),
 
     showUploadInfo: function () {
-      const hasFiles = this.getUploadMap().size > 0;
-      return hasFiles && (this.getUploadComplete() || this.getIsUploading());
+      // Mount the pill any time there's upload activity, including the
+      // pre-sync window where manifestFiles is populated but
+      // uploadFileMap is still empty. The pill itself no-ops internally
+      // once there's nothing to show.
+      return (
+        this.getUploadMap().size > 0 || this.getManifestFiles().length > 0
+      );
     },
 
     /**
@@ -406,6 +417,30 @@ export default {
      */
     hasFiles: function () {
       return this.files.length > 0;
+    },
+
+    /**
+     * Files list as rendered in the table: server-returned children plus
+     * placeholder rows for in-flight uploads targeting this folder. Dialogs
+     * and other consumers keep using `files` so they never see placeholders.
+     *
+     * Reconciliation: when the server row for an upload appears (same
+     * parent folder + same name), its placeholder is dropped so the two
+     * rows don't stack. The uploadModule entry stays in the map until
+     * cleared; only the visible row is deduped here.
+     */
+    displayFiles: function () {
+      const folderId = this.file && this.file.content && this.file.content.id;
+      if (!folderId) return this.files;
+      const placeholders = this.getPlaceholdersForFolder(folderId);
+      if (!placeholders.length) return this.files;
+      const takenNames = new Set(
+        this.files.map((f) => (f.content && f.content.name) || "")
+      );
+      const survivors = placeholders.filter(
+        (p) => !takenNames.has(p.content.name)
+      );
+      return [...survivors, ...this.files];
     },
 
     filesUrl: function () {
@@ -954,6 +989,16 @@ export default {
               this.files,
               this.sortDirection
             );
+            // Sweep any finalized upload entries whose server row now
+            // exists in this folder, so the aggregate pill drops out of
+            // "Importing..." as soon as the refresh lands.
+            const folderId = this.file && this.file.content && this.file.content.id;
+            if (folderId) {
+              this.$store.dispatch("uploadModule/reconcileFinalizedFiles", {
+                folderId,
+                serverChildren: newFiles,
+              });
+            }
           });
         })
         .catch((response) => {
@@ -1035,6 +1080,12 @@ export default {
      * @param {Object} file
      */
     onClickLabel: function (file) {
+      // Placeholder rows have no server-side identity yet — clicking the
+      // name must not trigger navigation (into a non-existent collection
+      // or to the viewer with a bogus id).
+      if (file && file._placeholder) {
+        return;
+      }
       // Normal file navigation logic
       this.files = [];
       this.offset = 0;

--- a/src/components/datasets/files/bf-file/BfFileLabel.vue
+++ b/src/components/datasets/files/bf-file/BfFileLabel.vue
@@ -22,45 +22,98 @@
       </button>
     </div>
 
+    <!--
+      Placeholder rows render an Apple-style ring: determinate fill during
+      upload (clockwise from 12 o'clock), indeterminate spin during the
+      importing window. Failed placeholders fall through to the regular
+      file icon. Real server rows in processing/uploading states keep the
+      legacy pulsing bf-waiting-icon so nothing else in the app changes.
+    -->
     <div
-      v-if="fileState === 'processing' || fileState === 'uploading'"
+      v-if="isPlaceholder && placeholderStatus !== 'failed'"
+      class="upload-ring-wrap mr-16"
+      :class="{ 'upload-ring-wrap--spin': placeholderStatus === 'importing' }"
+      :aria-label="placeholderStatus === 'importing' ? 'Importing' : 'Uploading'"
+    >
+      <svg class="upload-ring" viewBox="0 0 20 20" width="18" height="18">
+        <circle class="ring-track" cx="10" cy="10" r="8" />
+        <circle
+          class="ring-fill"
+          cx="10"
+          cy="10"
+          r="8"
+          :stroke-dasharray="ringCircumference"
+          :stroke-dashoffset="ringDashOffset"
+        />
+      </svg>
+    </div>
+
+    <div
+      v-else-if="!isPlaceholder && (fileState === 'processing' || fileState === 'uploading')"
       class="icon-waiting mr-16"
     >
       <bf-waiting-icon />
     </div>
 
     <img
-      v-if="fileState !== 'processing' && fileState !== 'uploading'"
+      v-else
       class="svg-icon icon-item mr-16"
+      :class="{ 'icon-item--pin-top': isPlaceholder }"
       :src="fileIcon(icon, file.content.packageType)"
       alt="package icon"
     >
 
-    <template v-if="isRenaming">
-      <input
-        ref="renameInput"
-        class="rename-input"
-        :value="displayName"
-        @keyup.enter="onRenameSubmit"
-        @keyup.escape="onRenameCancel"
-        @blur="onRenameSubmit"
-        @click.stop
-      />
-    </template>
-    <template v-else>
-      <button
-        v-if="isNameLink"
-        class="name"
-        data-cy="moveDialogFileName"
-        :disabled="disabled"
-        @click.stop="onClick('click-name', $event)"
+    <div class="name-column">
+      <template v-if="isRenaming">
+        <input
+          ref="renameInput"
+          class="rename-input"
+          :value="displayName"
+          @keyup.enter="onRenameSubmit"
+          @keyup.escape="onRenameCancel"
+          @blur="onRenameSubmit"
+          @click.stop
+        />
+      </template>
+      <template v-else>
+        <button
+          v-if="isNameLink && !isPlaceholder"
+          class="name"
+          data-cy="moveDialogFileName"
+          :disabled="disabled"
+          @click.stop="onClick('click-name', $event)"
+        >
+          {{ displayName }}
+        </button>
+        <div v-else class="no-link-name placeholder-name">
+          {{ displayName }}
+          <span
+            v-if="isPlaceholder && placeholderFileCount > 0"
+            class="placeholder-file-count"
+          >({{ placeholderFileCount }} files)</span>
+        </div>
+      </template>
+
+      <!-- Placeholder meta row: status label + percentage. The ring in the
+           icon slot carries the visual progress; this line is text-only. -->
+      <div
+        v-if="isPlaceholder"
+        class="placeholder-meta"
       >
-        {{ displayName }}
-      </button>
-      <div v-else class="no-link-name">
-        {{ displayName }}
+        <span
+          v-if="placeholderStatus === 'uploading'"
+          class="status-label"
+        >Uploading {{ progressPct }}%</span>
+        <span
+          v-else-if="placeholderStatus === 'importing'"
+          class="status-label importing"
+        >Importing&hellip;</span>
+        <span
+          v-else-if="placeholderStatus === 'failed'"
+          class="status-label failed"
+        >Upload failed</span>
       </div>
-    </template>
+    </div>
   </div>
 </template>
 
@@ -196,6 +249,40 @@ export default {
     fileState: function() {
       return this.getFileState(this.file)
     },
+
+    // Client-side placeholder flags (see uploadModule
+    // getPlaceholdersForFolder). Real server rows lack the _placeholder
+    // marker, so every computed below collapses to a no-op for them.
+    isPlaceholder: function() {
+      return this.file && this.file._placeholder === true
+    },
+    placeholderStatus: function() {
+      return (this.file && this.file._placeholderStatus) || ''
+    },
+    placeholderFileCount: function() {
+      return (this.file && this.file._placeholderFileCount) || 0
+    },
+    progressPct: function() {
+      const progress = this.file && this.file._progress
+      if (!progress || !progress.total) return 0
+      const pct = Math.floor((progress.loaded / progress.total) * 100)
+      return Math.max(0, Math.min(100, pct))
+    },
+
+    // Ring geometry. Circle r=8 in a 20x20 viewBox; C = 2πr ≈ 50.27. For
+    // the importing (indeterminate) phase we draw a fixed ~25% arc and
+    // let CSS rotate the element, so dashoffset is constant there.
+    ringCircumference: function() {
+      return 50.27
+    },
+    ringDashOffset: function() {
+      if (this.placeholderStatus === 'importing') {
+        // Visible arc length ≈ 25% of circumference.
+        return this.ringCircumference * 0.75
+      }
+      const filled = this.progressPct / 100
+      return this.ringCircumference * (1 - filled)
+    },
     /**
      * Compute package type
      * @returns {String}
@@ -284,7 +371,11 @@ export default {
         'UNAVAILABLE': 'uploading',
         'PENDING': 'processing',
         'ERROR': 'failed',
-        'READY': 'processed'
+        'READY': 'processed',
+        // Client-side placeholder states (see uploadModule
+        // getPlaceholdersForFolder).
+        'UPLOADING': 'uploading',
+        'IMPORTING': 'importing',
       }
       const fileState = path(['content', 'state'], file)
       return states[fileState] ? states[fileState] : ''
@@ -298,7 +389,9 @@ export default {
         'UNAVAILABLE': 'uploading',
         'PENDING': 'processing',
         'ERROR': 'failed',
-        'READY': 'processed'
+        'READY': 'processed',
+        'UPLOADING': 'uploading',
+        'IMPORTING': 'importing',
       }
       const collectionState = path(['content', 'state'], collection)
       return states[collectionState] ? states[collectionState] : ''
@@ -444,6 +537,62 @@ export default {
   width: 24px;
 }
 
+.icon-waiting--pin-top,
+.icon-item--pin-top {
+  align-self: flex-start;
+}
+
+.upload-ring-wrap {
+  align-items: center;
+  align-self: flex-start;
+  display: flex;
+  flex-shrink: 0;
+  height: 24px;
+  justify-content: center;
+  width: 24px;
+}
+
+.upload-ring {
+  display: block;
+  // Start the fill at 12 o'clock; SVG default is 3 o'clock.
+  transform: rotate(-90deg);
+  transform-origin: center;
+}
+
+// Importing phase: slow rotation + subtle opacity pulse, muted color.
+// Reads as "background activity" vs. the active primary-color fill of
+// the uploading phase.
+.upload-ring-wrap--spin .upload-ring {
+  animation: upload-ring-spin 2.4s linear infinite;
+}
+.upload-ring-wrap--spin .ring-fill {
+  animation: upload-ring-pulse 1.8s ease-in-out infinite;
+  stroke: theme.$purple_1;
+}
+
+@keyframes upload-ring-spin {
+  from { transform: rotate(-90deg); }
+  to { transform: rotate(270deg); }
+}
+@keyframes upload-ring-pulse {
+  0%, 100% { opacity: 0.5; }
+  50%      { opacity: 1; }
+}
+
+.ring-track {
+  fill: none;
+  stroke: theme.$gray_2;
+  stroke-width: 2;
+}
+
+.ring-fill {
+  fill: none;
+  stroke: theme.$app-primary-color;
+  stroke-linecap: round;
+  stroke-width: 2;
+  transition: stroke-dashoffset 180ms linear;
+}
+
 .btn-open-file {
   line-height: 1;
   .btn-icon-viewer {
@@ -461,6 +610,41 @@ export default {
     &:hover {
       box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
     }
+  }
+}
+
+.name-column {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+
+.placeholder-name {
+  color: theme.$gray_5;
+}
+
+.placeholder-file-count {
+  color: theme.$gray_4;
+  font-size: 12px;
+  margin-left: 8px;
+}
+
+.placeholder-meta {
+  display: flex;
+  font-size: 11px;
+  line-height: 1;
+  margin-top: 2px;
+}
+
+.status-label {
+  color: theme.$gray_5;
+
+  &.importing {
+    font-style: italic;
+  }
+  &.failed {
+    color: theme.$red_1;
   }
 }
 </style>

--- a/src/components/datasets/files/bf-upload-info/BfUploadInfo.vue
+++ b/src/components/datasets/files/bf-upload-info/BfUploadInfo.vue
@@ -1,115 +1,146 @@
+<!--
+  Compact upload status pill. Per-row placeholder progress in the
+  DatasetFiles table (see uploadModule getPlaceholdersForFolder) is the
+  primary feedback; this pill exists only to give an aggregate for large
+  batches and keep the upload visible when the user has navigated away
+  from the destination folder. Clicking the pill jumps back to the
+  destination.
+-->
 <template>
-  <transition name="dialog-fade">
-    <div class="bf-upload-info">
-      <button class="dismiss-btn" @click="onDismiss" title="Dismiss">
-        <IconRemove />
+  <transition name="pill-fade">
+    <div
+      v-if="hasActivity"
+      class="upload-pill"
+      :class="pillVariantClass"
+      role="status"
+      @click="jumpToDestination"
+    >
+      <bf-waiting-icon v-if="!allDone" class="pill-icon" />
+      <span class="pill-label">{{ pillLabel }}</span>
+      <button
+        class="pill-dismiss"
+        :title="allDone ? 'Dismiss' : 'Cancel'"
+        @click.stop="onDismiss"
+      >
+        <icon-remove :height="14" :width="14" />
       </button>
-      <div v-if="getIsUploading" class="copy">
-        <strong> {{ uploadCopy }}</strong>
-
-        <bf-progress-bar
-          :loaded="getUploadProgress().loaded"
-          :total="getUploadProgress().total"
-          :complete="allFilesComplete"
-        />
-      </div>
-      <div v-else class="copy">
-        {{ uploadCopy }}
-      </div>
-      <div class="upload-details">
-        <button class="show-details" @click="showUpload">Show details</button>
-        <div v-if="getIsUploading && !allFilesComplete">
-          <strong>{{ loadedStr }}</strong>
-          of {{ totalStr }}
-        </div>
-        <div v-else-if="allFilesComplete" class="complete-text">
-          Uploading...
-        </div>
-      </div>
     </div>
   </transition>
 </template>
 
 <script>
-import { mapGetters, mapState } from "vuex";
-import { propOr } from "ramda";
-import BfProgressBar from "../../../shared/bf-progress-bar/bf-progress-bar.vue";
-import BfStorageMetrics from "../../../../mixins/bf-storage-metrics";
-import EventBus from "../../../../utils/event-bus";
+import { mapGetters } from "vuex";
+import BfWaitingIcon from "../../../shared/bf-waiting-icon/bf-waiting-icon.vue";
 import IconRemove from "../../../icons/IconRemove.vue";
 
 export default {
   name: "BfUploadInfo",
 
   components: {
-    BfProgressBar,
+    BfWaitingIcon,
     IconRemove,
-  },
-
-  mixins: [BfStorageMetrics],
-
-  data() {
-    return {};
   },
 
   computed: {
     ...mapGetters("uploadModule", [
-      "getUploadProgress",
-      "getIsUploading",
       "getUploadMap",
+      "getIsUploading",
       "getUploadComplete",
       "getTotalFilesInBatch",
+      "getUploadDestination",
+      "getManifestFiles",
     ]),
 
-    /**
-     * Compute copy based on how many files are being uploaded
-     * @returns {String}
-     */
-    uploadCopy: function () {
-      if (this.getUploadComplete()) {
-        return "";
-      }
-      const totalFiles = this.getTotalFilesInBatch();
-      const file = totalFiles > 1 ? "files" : "file";
-      return `Uploading ${totalFiles} ${file}`;
+    hasActivity() {
+      const mapSize = this.getUploadMap().size;
+      const manifestSize = this.getManifestFiles().length;
+      return mapSize > 0 || manifestSize > 0;
     },
 
-    loadedStr: function () {
-      return this.formatMetric(this.getUploadProgress().loaded);
-    },
-    totalStr: function () {
-      return this.formatMetric(this.getUploadProgress().total);
+    counts() {
+      const c = { total: 0, uploading: 0, importing: 0, failed: 0 };
+      const map = this.getUploadMap();
+      if (map.size === 0) {
+        // Pre-sync phase — every manifest file is waiting to upload.
+        const pre = this.getManifestFiles().length;
+        c.total = pre;
+        c.uploading = pre;
+        return c;
+      }
+      for (const [, v] of map) {
+        c.total += 1;
+        if (v.status === "failed") c.failed += 1;
+        else if (v.status === "processing" || v.status === "finalized")
+          c.importing += 1;
+        else c.uploading += 1;
+      }
+      return c;
     },
 
-    /**
-     * Check if all files have completed uploading (in processing state)
-     * @returns {Boolean}
-     */
-    allFilesComplete: function () {
-      const uploadMap = this.getUploadMap();
-      if (uploadMap.size === 0) return false;
-      for (const [, value] of uploadMap) {
-        if (value.status !== "processing") {
-          return false;
-        }
+    allDone() {
+      const c = this.counts;
+      return c.total > 0 && c.uploading === 0 && c.failed === 0;
+    },
+
+    pillVariantClass() {
+      if (this.counts.failed > 0) return "upload-pill--failed";
+      if (this.allDone) return "upload-pill--done";
+      return "";
+    },
+
+    pillLabel() {
+      const c = this.counts;
+      if (c.failed > 0) {
+        const word = c.failed === 1 ? "upload failed" : "uploads failed";
+        return `${c.failed} ${word}`;
       }
-      return true;
+      if (c.uploading > 0) {
+        const done = c.total - c.uploading;
+        return `Uploading ${done} of ${c.total}\u2026`;
+      }
+      if (c.importing > 0) {
+        return `Importing ${c.importing} of ${c.total}\u2026`;
+      }
+      const word = c.total === 1 ? "file" : "files";
+      return `${c.total} ${word} uploaded`;
+    },
+
+    destinationFolder() {
+      const dest = this.getUploadDestination();
+      return (dest && dest.file) || null;
     },
   },
 
   methods: {
-    /**
-     * Show uploader
-     * @returns {String}
-     */
-    showUpload: function () {
-      EventBus.$emit("open-uploader", false);
+    jumpToDestination() {
+      const folder = this.destinationFolder;
+      if (!folder || !folder.content) return;
+      const packageType = folder.content.packageType;
+      const id = folder.content.id;
+      if (!id) return;
+      if (packageType === "Collection") {
+        this.$router.push({
+          name: "dataset-files",
+          params: {
+            ...this.$route.params,
+            fileId: id,
+          },
+        });
+      } else if (packageType === "DataSet") {
+        this.$router.push({
+          name: "dataset-files",
+          params: {
+            ...this.$route.params,
+            fileId: undefined,
+          },
+        });
+      }
     },
 
-    /**
-     * Dismiss status bar and clear uploaded files in bf-upload
-     */
-    onDismiss: function () {
+    onDismiss() {
+      // resetUpload clears uploadFileMap + manifestFiles + progress totals.
+      // In-flight S3 PUTs continue (they hold their own references), but
+      // the UI stops tracking them.
       this.$store.dispatch("uploadModule/resetUpload");
     },
   },
@@ -119,64 +150,78 @@ export default {
 <style scoped lang="scss">
 @use "../../../../styles/theme";
 
-.bf-upload-info {
+.upload-pill {
+  align-items: center;
   background: theme.$gray_1;
-  border-radius: 4px;
-  box-shadow: 0 0 1px 0 rgba(0, 0, 0, 0.21), 0 0 5px 0 rgba(0, 0, 0, 0.18);
+  border: 1px solid theme.$gray_2;
+  border-radius: 16px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   box-sizing: border-box;
-  font-size: 13px;
-  margin-left: -240px;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 12px;
+  gap: 8px;
   left: 50%;
-  padding: 8px 16px;
-  padding-right: 40px;
+  max-width: 320px;
+  padding: 6px 8px 6px 12px;
   position: absolute;
   top: 8px;
-  width: 480px;
+  transform: translateX(-50%);
   z-index: 10;
 
-  .bf-progress-bar {
-    display: block !important;
-    margin: 4px 0;
-    width: 100% !important;
+  &:hover {
+    background: theme.$gray_0;
   }
 }
-button {
-  color: theme.$app-primary-color;
-  text-decoration: underline;
+
+.upload-pill--failed {
+  border-color: theme.$red_tint;
+  .pill-label {
+    color: theme.$red_1;
+  }
 }
-.dismiss-btn {
-  position: absolute;
-  right: 8px;
-  top: 8px;
+
+.upload-pill--done {
+  border-color: theme.$gray_2;
+}
+
+.pill-icon {
+  flex-shrink: 0;
+}
+
+.pill-label {
+  color: theme.$gray_6;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pill-dismiss {
+  align-items: center;
   background: none;
   border: none;
-  cursor: pointer;
-  padding: 4px;
-  text-decoration: none;
   color: theme.$gray_4;
+  cursor: pointer;
   display: flex;
-  align-items: center;
+  flex-shrink: 0;
+  height: 20px;
   justify-content: center;
+  padding: 0;
+  width: 20px;
 
   &:hover {
     color: theme.$gray_6;
   }
+}
 
-  .svg-icon {
-    width: 16px;
-    height: 16px;
-  }
+.pill-fade-enter-active,
+.pill-fade-leave-active {
+  transition: opacity 180ms ease, transform 180ms ease;
 }
-.upload-details {
-  display: flex;
-  margin-top: 4px;
-}
-.show-details {
-  flex: 1;
-  text-align: left;
-}
-.complete-text {
-  color: theme.$green_1;
-  font-weight: 500;
+.pill-fade-enter-from,
+.pill-fade-leave-to {
+  opacity: 0;
+  transform: translate(-50%, -6px);
 }
 </style>

--- a/src/store/uploadModule.js
+++ b/src/store/uploadModule.js
@@ -11,8 +11,29 @@ import { useGetToken } from "@/composables/useGetToken";
 // Finalize batching matches the agent (pennsieve-agent/pkg/server/upload.go):
 // server accepts up to 250 files per POST /upload/manifest/files/finalize call
 // and we flush once we hit that bound or the flush interval, whichever first.
+//
+// Flush interval is 1s (vs. the agent's 5s). Measured end-to-end delay from
+// S3 PUT → Pusher "upload-event" is 6–22s in dev; ~5s of that was pure idle
+// in this flush interval for small drops. The server-side SQS batching
+// window (upload-service-v2 terraform/sqs.tf:26, currently 5s) is the other
+// compressible leg. 1s here keeps a little headroom for coalescing when
+// many S3 PUTs finish close together, without dominating the latency.
 const FINALIZE_BATCH_SIZE = 250;
-const FINALIZE_FLUSH_MS = 5000;
+const FINALIZE_FLUSH_MS = 1000;
+
+// How many S3 PUTs run at once. Browser + AWS SDK lib-storage already
+// does 4-way parallelism *within* a file (queueSize: 4) for multipart
+// parts; this is cross-file concurrency on top of that. 4 is a balance
+// between bandwidth saturation on a typical connection and not
+// over-subscribing CPU on the checksum-per-part work.
+const UPLOAD_CONCURRENCY = 4;
+
+// Module-level guard to serialize finalize POSTs. Without this, the
+// batch-size trigger and the timer-based flush can both capture the same
+// pendingFinalize entries and fire duplicate requests — the second POST
+// would arrive with an empty batch (CLEAR_FINALIZE_QUEUE already ran) or,
+// worse, race on the `batch` snapshot. Not reactive — just a mutex.
+let finalizeInFlight = false;
 
 // Refresh storage credentials when the remaining TTL drops below 5 minutes —
 // same headroom the agent uses. STS returns ~1h creds.
@@ -336,9 +357,13 @@ export const actions = {
 
             let targetPackage = await state.currentTargetPackage;
 
+            // `file` is the target folder/dataset package — not a dropped
+            // File — so downstream consumers (placeholder-row getter, etc.)
+            // can match by folder id. Same shape `setUploadDestination`
+            // writes on explicit navigation.
             let uploadDestination = {
                 path: helpers.getFileLocation(targetPackage),
-                file: files[0]
+                file: targetPackage,
             }
 
             commit('SET_UPLOAD_DESTINATION', uploadDestination)
@@ -458,9 +483,19 @@ export const actions = {
             credentials: credentialsProvider,
         })
 
-        // Sequential per-file uploads, matching the existing behaviour.
-        // Concurrency is a follow-up — the agent uses a worker pool here.
-        for (const [key, value] of state.uploadFileMap) {
+        // Time-based finalize flush: drains pendingFinalize every
+        // FINALIZE_FLUSH_MS so the server starts creating packages while
+        // later files are still being PUT, rather than waiting for the
+        // whole batch to finish before finalize fires. Critical for the
+        // small-drop case (<250 files), which otherwise skipped eager
+        // flushing entirely.
+        const flushTimer = setInterval(() => {
+            if (state.pendingFinalize.length > 0) {
+                dispatch('flushFinalizeBatch').catch((e) => console.error(e))
+            }
+        }, FINALIZE_FLUSH_MS)
+
+        const uploadOne = async (key, value) => {
             try {
                 commit('SET_FILE_STATUS', { key, status: "uploading" })
 
@@ -518,6 +553,26 @@ export const actions = {
             }
         }
 
+        // Worker pool — pulls from a shared queue so each worker moves on
+        // to the next file as soon as its current PUT finishes. Cross-file
+        // concurrency is cheap here (lib-storage's queueSize handles
+        // within-file part parallelism).
+        const queue = [...state.uploadFileMap]
+        const workerCount = Math.min(UPLOAD_CONCURRENCY, queue.length)
+        const workers = Array.from({ length: workerCount }, async () => {
+            while (queue.length > 0) {
+                const next = queue.shift()
+                if (!next) return
+                await uploadOne(next[0], next[1])
+            }
+        })
+
+        try {
+            await Promise.all(workers)
+        } finally {
+            clearInterval(flushTimer)
+        }
+
         // Final flush for any remainder below the batch threshold.
         if (state.pendingFinalize.length > 0) {
             await dispatch('flushFinalizeBatch')
@@ -527,12 +582,24 @@ export const actions = {
     },
 
     // POST /upload/manifest/files/finalize with the currently-queued files.
-    // Per-file success -> REMOVE_COMPLETED_FILE (clears the row from the
-    // upload UI); per-file failure -> SET_FILE_STATUS=failed so the user
-    // sees which file didn't make it. Request-level failures mark every
-    // queued file as failed so the UI never silently "forgets" them.
+    // Per-file success -> SET_FILE_STATUS=finalized; the placeholder row
+    // stays visible in the "Importing..." state until the server-side
+    // package record shows up in a silent refresh (Pusher `upload-event`
+    // triggers that), at which point displayFiles dedupes by name and the
+    // placeholder drops out. Removing the map entry here instead would
+    // leave a visual gap of several seconds between finalize and Pusher.
+    // Per-file failure -> SET_FILE_STATUS=failed so the user sees which
+    // file didn't make it. Request-level failures mark every queued file
+    // as failed so the UI never silently "forgets" them.
     flushFinalizeBatch: async ({ rootState, state, commit }) => {
+        // Serialize concurrent callers (timer-based flush + batch-size
+        // trigger + final post-loop flush). The second caller returns
+        // immediately; whatever accumulated while the first POST was
+        // in flight gets picked up by the next timer tick or the final
+        // flush after the worker pool drains.
+        if (finalizeInFlight) return
         if (state.pendingFinalize.length === 0) return
+        finalizeInFlight = true
         const batch = state.pendingFinalize.slice()
         commit('CLEAR_FINALIZE_QUEUE')
 
@@ -568,7 +635,7 @@ export const actions = {
                 const mapKey = byUploadId.get(r.uploadId)
                 if (!mapKey) continue
                 if (r.status === 'finalized') {
-                    commit('REMOVE_COMPLETED_FILE', mapKey)
+                    commit('SET_FILE_STATUS', { key: mapKey, status: 'finalized' })
                 } else {
                     commit('SET_FILE_STATUS', { key: mapKey, status: 'failed' })
                     EventBus.$emit('toast', {
@@ -590,6 +657,8 @@ export const actions = {
                     type: 'error',
                 },
             })
+        } finally {
+            finalizeInFlight = false
         }
     },
 
@@ -616,7 +685,11 @@ export const actions = {
         const apiKey = await useGetToken()
         const queryParams = toQueryParams({ dataset_id: datasetId })
 
-        const uploadMap = new Map()
+        // Merge new-batch entries into any finalized carry-overs from a
+        // previous batch (those still need their placeholder rows until
+        // Pusher confirms them). s3_key is a fresh UUID so the new entries
+        // never collide with existing ones.
+        const uploadMap = new Map(state.uploadFileMap)
         const requestFiles = []
         let total = 0
         for (const mf in state.manifestFiles) {
@@ -646,7 +719,11 @@ export const actions = {
         }
 
         commit("SET_UPLOAD_FILE_MAP", uploadMap)
+        // Progress total is the *current batch only*; finalized carry-over
+        // entries' bytes were already counted in the previous batch's total
+        // and subtracted from loaded/total as they got removed.
         state.uploadProgress.total = total
+        state.uploadProgress.loaded = 0
 
         const requestBody = {
             id: state.manifestNodeId,
@@ -688,6 +765,56 @@ export const actions = {
     // Clear all completed files from the upload map
     clearCompletedFiles: async({ commit }) => {
         commit("CLEAR_COMPLETED_FILES")
+    },
+
+    // Remove finalized entries whose target files are now confirmed in the
+    // server-side file listing. Called from the DatasetFiles silent refresh
+    // so the aggregate pill can stop saying "Importing..." the instant the
+    // real package rows show up.
+    //
+    // Scope: only reconciles when the silent refresh is for the destination
+    // folder the upload was dropped into. When files land in a nested
+    // subfolder, matching the synthetic parent folder's first-segment name
+    // against a Collection child on the server clears every upload sitting
+    // under that segment.
+    reconcileFinalizedFiles: ({ state, commit }, { folderId, serverChildren }) => {
+        const dest = state.uploadDestination
+        const destId = dest && dest.file && dest.file.content && dest.file.content.id
+        const destPath = (dest && dest.path) || ''
+        if (!destId || destId !== folderId) return
+        if (!Array.isArray(serverChildren)) return
+
+        const fileNames = new Set()
+        const collectionNames = new Set()
+        for (const row of serverChildren) {
+            const name = row && row.content && row.content.name
+            if (!name) continue
+            if (row.content.packageType === 'Collection') collectionNames.add(name)
+            else fileNames.add(name)
+        }
+
+        const toRemove = []
+        for (const [key, entry] of state.uploadFileMap) {
+            if (entry.status !== 'finalized') continue
+            const fullTargetPath = (entry.config && entry.config.target_path) || ''
+            let rel = fullTargetPath
+            if (destPath && rel.startsWith(destPath)) {
+                rel = rel.slice(destPath.length).replace(/^\//, '')
+            }
+            const name = (entry.config && entry.config.target_name) || (entry.file && entry.file.name) || ''
+            if (!rel) {
+                // Immediate child of destination — match by filename.
+                if (fileNames.has(name)) toRemove.push(key)
+            } else {
+                // Nested — the server has created the top-level folder, so
+                // at least some files in that subtree have landed. Clearing
+                // optimistically lets the pill settle; the user sees the
+                // real folder row and can navigate in for per-file detail.
+                const firstSeg = rel.split('/')[0]
+                if (collectionNames.has(firstSeg)) toRemove.push(key)
+            }
+        }
+        for (const k of toRemove) commit('REMOVE_COMPLETED_FILE', k)
     }
 
 }
@@ -710,6 +837,132 @@ export const getters = {
     },
     getTotalFilesInBatch: state => () => {
         return state.totalFilesInBatch
+    },
+    getUploadDestination: state => () => {
+        return state.uploadDestination
+    },
+    // Returns synthetic "placeholder" rows for a given folder view so the
+    // DatasetFiles table can show a row for each file that's still
+    // uploading/importing (before the server-side package record exists).
+    //
+    // Scope: placeholders are only surfaced when the user is viewing the
+    // destination folder where files were dropped. Uploads landing in a
+    // nested subfolder below the destination are rolled up into one
+    // synthetic folder row per first-segment. Uploads into a sibling folder
+    // of the current view are not shown here (aggregate pill covers that).
+    //
+    // Placeholder row shape intentionally mirrors a server package row
+    // enough that FilesTable/BfFileLabel can render it:
+    //   { content: { id, name, state, packageType }, storage, _placeholder, _placeholderStatus, _progress }
+    // `_placeholder === true` is the marker every consumer (download
+    // gating, viewer gating, selection handling) should check.
+    getPlaceholdersForFolder: state => (folderId) => {
+        const dest = state.uploadDestination
+        const destId = dest && dest.file && dest.file.content && dest.file.content.id
+        const destPath = (dest && dest.path) || ''
+        if (!destId || destId !== folderId) return []
+
+        const nestedGroups = new Map()
+        const immediate = []
+
+        const addRow = ({ key, relPath, name, size, loaded, total, status }) => {
+            const isImporting = status === 'processing' || status === 'finalized'
+            const phStatus = status === 'failed' ? 'failed'
+                : isImporting ? 'importing' : 'uploading'
+            const phState = status === 'failed' ? 'ERROR'
+                : isImporting ? 'IMPORTING' : 'UPLOADING'
+            if (!relPath) {
+                immediate.push({
+                    storage: size,
+                    _placeholder: true,
+                    _placeholderStatus: phStatus,
+                    _progress: { loaded, total },
+                    content: {
+                        id: key,
+                        name,
+                        state: phState,
+                        packageType: 'Unknown',
+                    },
+                })
+            } else {
+                const firstSeg = relPath.split('/')[0]
+                let g = nestedGroups.get(firstSeg)
+                if (!g) {
+                    g = { count: 0, loaded: 0, total: 0, importingCount: 0, failedCount: 0 }
+                    nestedGroups.set(firstSeg, g)
+                }
+                g.count += 1
+                g.loaded += loaded
+                g.total += total
+                if (isImporting) g.importingCount += 1
+                if (status === 'failed') g.failedCount += 1
+            }
+        }
+
+        // Post-sync phase: uploadFileMap has the authoritative entries with
+        // stable s3_key ids and live progress.
+        if (state.uploadFileMap.size > 0) {
+            for (const [key, entry] of state.uploadFileMap) {
+                const fullTargetPath = (entry.config && entry.config.target_path) || ''
+                let rel = fullTargetPath
+                if (destPath && rel.startsWith(destPath)) {
+                    rel = rel.slice(destPath.length).replace(/^\//, '')
+                }
+                const name = (entry.config && entry.config.target_name) || (entry.file && entry.file.name) || ''
+                const size = (entry.file && entry.file.size) || 0
+                addRow({
+                    key,
+                    relPath: rel,
+                    name: sanitizeFileName(name),
+                    size,
+                    loaded: (entry.progress && entry.progress.loaded) || 0,
+                    total: (entry.progress && entry.progress.total) || size,
+                    status: entry.status || 'waiting',
+                })
+            }
+        } else {
+            // Pre-sync phase: syncManifest hasn't committed uploadFileMap yet.
+            // Surface rows from the raw manifestFiles so the user sees
+            // placeholders the instant they drop, not hundreds of ms later.
+            for (let i = 0; i < state.manifestFiles.length; i += 1) {
+                const f = state.manifestFiles[i]
+                const fullPath = (f && f.path) || (f && f.name) || ''
+                const name = (f && f.name) || ''
+                const rel = fullPath.length > name.length
+                    ? fullPath.slice(0, fullPath.length - name.length).replace(/\/$/, '')
+                    : ''
+                const size = (f && f.size) || 0
+                addRow({
+                    key: `pending:${i}:${fullPath}`,
+                    relPath: rel,
+                    name: sanitizeFileName(name),
+                    size,
+                    loaded: 0,
+                    total: size,
+                    status: 'waiting',
+                })
+            }
+        }
+
+        for (const [firstSeg, g] of nestedGroups) {
+            const allImporting = g.importingCount === g.count
+            const anyFailed = g.failedCount > 0
+            immediate.push({
+                storage: g.total,
+                _placeholder: true,
+                _placeholderStatus: anyFailed ? 'failed' : allImporting ? 'importing' : 'uploading',
+                _placeholderFileCount: g.count,
+                _progress: { loaded: g.loaded, total: g.total },
+                content: {
+                    id: `placeholder:folder:${folderId}:${firstSeg}`,
+                    name: firstSeg,
+                    state: anyFailed ? 'ERROR' : allImporting ? 'IMPORTING' : 'UPLOADING',
+                    packageType: 'Collection',
+                },
+            })
+        }
+
+        return immediate
     }
 }
 


### PR DESCRIPTION
## Summary

Three related wins for the DatasetFiles drop-to-upload flow:

1. **Optimistic placeholder rows** — files now appear in the table the moment you drop them, with an Apple-style progress ring (determinate during PUT, muted slow-spin during finalize/Pusher wait). No more 30+ second silent void while the server registers the upload. Placeholders dissolve into the real server row when the Pusher-driven silent refresh lands.
2. **Compact aggregate pill** replaces the 480px top-banner `BfUploadInfo` modal. Stays out of the way once per-row state carries most of the feedback.
3. **Client upload pipeline**:
   - Parallel S3 PUTs (concurrency 4) via a worker pool — a 10-file drop that was ~30s serialized is now ~8s
   - Eager finalize flush: timer-based `flushFinalizeBatch` every `FINALIZE_FLUSH_MS=1s` so finalize POSTs go out while later files are still being PUT
   - `finalizeInFlight` mutex serializes concurrent callers

## Measured

Manifest `5dd24b4d` after these changes: 12s from drop → first file visible (was 33s baseline on manifest `29e4d22d`). Complements server-side improvements landed in upload-service-v2#87 (heartbeat + memory bump) and #88 (SQS batching window 5s → 1s).

## Key details

- `uploadModule.js` `addManifestFiles` was overwriting `uploadDestination.file` with the first dropped File object instead of the target folder package, breaking the placeholder-getter's destination check. Fixed.
- `syncManifest` now merges new-batch entries into the existing `uploadFileMap` so a batch 1's finalized carry-overs aren't wiped by a batch 2 sync.
- `flushFinalizeBatch` on per-file success now sets `status=finalized` instead of evicting; the placeholder stays alive until the server row confirms via `reconcileFinalizedFiles` (called from silent refresh). Prevents the "row disappears 10–15s before server row arrives" gap.
- The `PennsieveUpload` dialog filters `finalized` entries so a previous session's files don't bleed into a new drop's list.
- Per-row gating: `FilesTable.isRowSelectable` drops placeholders; `BfDownloadFile.triggerDownload` rejects both placeholders and non-READY server rows; `onClickLabel` noops on placeholders.
- Nested uploads into subfolders of the drop target roll up into one synthetic `Collection` placeholder row per first-segment name.

## Files changed

- `src/store/uploadModule.js` — getters, placeholder model, parallel pool, eager flush, reconcile
- `src/components/datasets/files/BfDatasetFiles.vue` — `displayFiles` computed, silent-refresh reconcile hook, click gate
- `src/components/datasets/files/bf-file/BfFileLabel.vue` — progress ring + state labels
- `src/components/datasets/files/bf-upload-info/BfUploadInfo.vue` — compact pill rewrite
- `src/components/FilesTable/FilesTable.vue` — selection gating
- `src/components/bf-download-file/BfDownloadFile.vue` — download gating
- `src/components/PennsieveUpload/PennsieveUpload.vue` — dialog filter for active batch

## Test plan

- [ ] Drop 1 file → row appears with 0% ring, fills during PUT, flips to muted spin, then server row replaces it
- [ ] Drop 10 files → rows appear in parallel, not serialized
- [ ] Drop a nested folder → synthetic Collection row at the drop target, real folder replaces on server-side finalize
- [ ] Drop a batch, then drop another — new dialog shows only the new batch (stale finalized entries filtered)
- [ ] Try to download / double-click a placeholder → no-op with appropriate feedback
- [ ] Upload with a filename that collides (auto-renamed to `(1)` by server) — placeholder doesn't dedupe but clears on `resetUpload` timer (separate project to handle cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)