### PR TITLE
Upload-conflict UX: dialog, preference, folder-replace shortcut

### DIFF
--- a/src/components/PennsieveUpload/PennsieveUpload.vue
+++ b/src/components/PennsieveUpload/PennsieveUpload.vue
@@ -113,6 +113,7 @@ User archives manifest -> remove activeManifest from memory
     <UploadConflictDialog
       v-model:dialogVisible="conflictDialogVisible"
       :conflicts="conflictList"
+      :target="conflictTarget"
       @resolve="onConflictResolved"
     />
   </div>
@@ -135,6 +136,7 @@ import {
   getUploadConflictPref,
   setUploadConflictPref,
 } from "@/composables/useUploadConflictPref";
+import { useGetToken } from "@/composables/useGetToken";
 
 const store = useStore();
 
@@ -142,6 +144,7 @@ const store = useStore();
 // returns any, cleared when the dialog resolves or the upload proceeds.
 const conflictDialogVisible = ref(false);
 const conflictList = ref([]);
+const conflictTarget = ref(null);
 
 defineExpose({
   onDrop,
@@ -222,13 +225,15 @@ async function startUpload() {
   // upload destination level only (see uploadModule.detectConflicts).
   // The resolved strategy is committed to uploadModule state so the
   // finalize batcher sends it to the server in the body.
-  let conflicts = [];
+  let result = { conflicts: [], target: null };
   try {
-    conflicts = await store.dispatch("uploadModule/detectConflicts");
+    result = await store.dispatch("uploadModule/detectConflicts");
   } catch {
     // Detection is best-effort; server still enforces its own behavior.
-    conflicts = [];
+    result = { conflicts: [], target: null };
   }
+
+  const conflicts = (result && result.conflicts) || [];
 
   if (conflicts.length === 0) {
     store.commit("uploadModule/SET_ON_CONFLICT", "keepBoth");
@@ -246,22 +251,67 @@ async function startUpload() {
   // pref === 'ask' (default) — surface the dialog and let
   // onConflictResolved drive the next step.
   conflictList.value = conflicts;
+  conflictTarget.value = result && result.target;
   conflictDialogVisible.value = true;
 }
 
-function onConflictResolved({ strategy, remember }) {
+async function onConflictResolved({ strategy, remember }) {
   if (strategy === "cancel") {
     // User bailed — leave state as-is, keep the upload dialog open so
     // they can decide to reset or close.
     conflictList.value = [];
+    conflictTarget.value = null;
     return;
   }
-  if (remember) {
+  if (remember && strategy !== "replaceFolder") {
+    // Don't persist the folder-replace shortcut as a default — it's a
+    // one-off decision about a specific folder, not a general
+    // conflict-resolution preference.
     setUploadConflictPref(strategy);
   }
+
+  if (strategy === "replaceFolder") {
+    // Whole-folder replacement: delete the target folder via the
+    // existing pennsieve-api endpoint and wait for it to complete before
+    // uploading. Scala's PackageManager.delete cascades state=DELETING
+    // to all descendants and schedules one DeletePackageJob for the
+    // whole subtree — the jobs service handles the async S3 cleanup.
+    const target = conflictTarget.value;
+    conflictList.value = [];
+    conflictTarget.value = null;
+    try {
+      await deleteFolderForReplace(target);
+    } catch (err) {
+      console.error("Replace-folder failed; falling back to per-file replace:", err);
+      store.commit("uploadModule/SET_ON_CONFLICT", "replace");
+      proceedWithUpload();
+      return;
+    }
+    // Folder is in DELETING state now — its children carry the
+    // __DELETED__ prefix, so the new uploads can't collide with them.
+    store.commit("uploadModule/SET_ON_CONFLICT", "keepBoth");
+    proceedWithUpload();
+    return;
+  }
+
   store.commit("uploadModule/SET_ON_CONFLICT", strategy);
   conflictList.value = [];
+  conflictTarget.value = null;
   proceedWithUpload();
+}
+
+async function deleteFolderForReplace(target) {
+  if (!target || !target.nodeId || target.packageType !== "Collection") {
+    throw new Error("deleteFolderForReplace: target is not a folder");
+  }
+  const token = await useGetToken();
+  const apiUrl = store.state.config.apiUrl;
+  const url = `${apiUrl}/packages/${target.nodeId}?api_key=${token}`;
+  const resp = await fetch(url, { method: "DELETE" });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(`DELETE /packages/${target.nodeId} failed (${resp.status}): ${text}`);
+  }
 }
 
 function proceedWithUpload() {

--- a/src/components/PennsieveUpload/PennsieveUpload.vue
+++ b/src/components/PennsieveUpload/PennsieveUpload.vue
@@ -109,6 +109,12 @@ User archives manifest -> remove activeManifest from memory
         </bf-button>
       </template>
     </el-dialog>
+
+    <UploadConflictDialog
+      v-model:dialogVisible="conflictDialogVisible"
+      :conflicts="conflictList"
+      @resolve="onConflictResolved"
+    />
   </div>
 </template>
 
@@ -124,8 +130,18 @@ import IconPDF from "../icons/IconPDF.vue";
 import IconTimeseries from "../icons/IconTimeseries.vue";
 import IconUpload from "../icons/IconUpload.vue";
 import { fileIcon } from "../../mixins/file-icon/file-icon.js";
+import UploadConflictDialog from "./UploadConflictDialog/UploadConflictDialog.vue";
+import {
+  getUploadConflictPref,
+  setUploadConflictPref,
+} from "@/composables/useUploadConflictPref";
 
 const store = useStore();
+
+// Conflict-dialog state. Populated by startUpload when detectConflicts
+// returns any, cleared when the dialog resolves or the upload proceeds.
+const conflictDialogVisible = ref(false);
+const conflictList = ref([]);
 
 defineExpose({
   onDrop,
@@ -201,7 +217,54 @@ function onDrop(acceptedFiles: File[]) {
   store.dispatch("uploadModule/addManifestFiles", acceptedFiles);
 }
 
-function startUpload() {
+async function startUpload() {
+  // Pre-flight conflict check. Collisions are detected at the immediate
+  // upload destination level only (see uploadModule.detectConflicts).
+  // The resolved strategy is committed to uploadModule state so the
+  // finalize batcher sends it to the server in the body.
+  let conflicts = [];
+  try {
+    conflicts = await store.dispatch("uploadModule/detectConflicts");
+  } catch {
+    // Detection is best-effort; server still enforces its own behavior.
+    conflicts = [];
+  }
+
+  if (conflicts.length === 0) {
+    store.commit("uploadModule/SET_ON_CONFLICT", "keepBoth");
+    proceedWithUpload();
+    return;
+  }
+
+  const pref = getUploadConflictPref();
+  if (pref === "replace" || pref === "keepBoth") {
+    store.commit("uploadModule/SET_ON_CONFLICT", pref);
+    proceedWithUpload();
+    return;
+  }
+
+  // pref === 'ask' (default) — surface the dialog and let
+  // onConflictResolved drive the next step.
+  conflictList.value = conflicts;
+  conflictDialogVisible.value = true;
+}
+
+function onConflictResolved({ strategy, remember }) {
+  if (strategy === "cancel") {
+    // User bailed — leave state as-is, keep the upload dialog open so
+    // they can decide to reset or close.
+    conflictList.value = [];
+    return;
+  }
+  if (remember) {
+    setUploadConflictPref(strategy);
+  }
+  store.commit("uploadModule/SET_ON_CONFLICT", strategy);
+  conflictList.value = [];
+  proceedWithUpload();
+}
+
+function proceedWithUpload() {
   store
     .dispatch("uploadModule/getManifestNodeId")
     .then(() => store.dispatch("uploadModule/syncManifest"))

--- a/src/components/PennsieveUpload/UploadConflictDialog/UploadConflictDialog.vue
+++ b/src/components/PennsieveUpload/UploadConflictDialog/UploadConflictDialog.vue
@@ -32,6 +32,12 @@
         </li>
       </ul>
 
+      <p v-if="offerFolderReplace" class="folder-replace-hint" data-cy="folderReplaceHint">
+        Every file in the target folder is being replaced. You can delete
+        the whole folder and upload fresh — cheaper than per-file replace
+        at scale.
+      </p>
+
       <label class="remember-choice">
         <input
           type="checkbox"
@@ -56,6 +62,14 @@
         @click="onChoose('keepBoth')"
       >
         Keep both
+      </bf-button>
+      <bf-button
+        v-if="offerFolderReplace"
+        class="secondary"
+        data-cy="replaceFolderConflict"
+        @click="onChoose('replaceFolder')"
+      >
+        Replace folder
       </bf-button>
       <bf-button
         data-cy="replaceConflict"
@@ -87,6 +101,10 @@ const props = defineProps({
   // Array of { incomingName, existingPackage } — shape produced by
   // uploadModule's detectConflicts action.
   conflicts: { type: Array, default: () => [] },
+  // { nodeId, id, packageType, existingFileCount, totalIncoming } —
+  // from detectConflicts. Used to decide whether to offer the
+  // folder-replace shortcut. null when no target info is available.
+  target: { type: Object, default: null },
 });
 
 const emit = defineEmits(["update:dialogVisible", "resolve"]);
@@ -124,6 +142,22 @@ const hiddenCount = computed(() =>
   Math.max(0, total.value - displayNames.value.length)
 );
 
+// Offer "Replace folder" only when deleting the parent folder would
+// replace exactly the set the user intends to upload. Guard against
+// the dataset-root case (deleting the dataset is a very different
+// operation and not what "replace folder" should mean).
+const offerFolderReplace = computed(() => {
+  const t = props.target;
+  if (!t || t.packageType !== "Collection") return false;
+  if (typeof t.existingFileCount !== "number") return false;
+  if (typeof t.totalIncoming !== "number") return false;
+  return (
+    total.value > 0 &&
+    total.value === t.existingFileCount &&
+    total.value === t.totalIncoming
+  );
+});
+
 function onChoose(strategy) {
   emit("resolve", { strategy, remember: rememberChoice.value });
   emit("update:dialogVisible", false);
@@ -157,6 +191,15 @@ function onCancel() {
   color: var(--text-muted, #6a737d);
   font-style: italic;
   font-size: 13px;
+}
+.folder-replace-hint {
+  margin: 0 0 16px;
+  padding: 10px 12px;
+  background: var(--info-bg, #f1f7fd);
+  border-left: 3px solid var(--info-accent, #4a90e2);
+  border-radius: 2px;
+  font-size: 13px;
+  line-height: 1.4;
 }
 .remember-choice {
   display: inline-flex;

--- a/src/components/PennsieveUpload/UploadConflictDialog/UploadConflictDialog.vue
+++ b/src/components/PennsieveUpload/UploadConflictDialog/UploadConflictDialog.vue
@@ -1,0 +1,169 @@
+<template>
+  <el-dialog
+    :modelValue="dialogVisible"
+    @update:modelValue="$emit('update:dialogVisible', $event)"
+    data-cy="uploadConflictDialog"
+    class="upload-conflict-dialog"
+    :show-close="false"
+    width="520px"
+  >
+    <template #header>
+      <bf-dialog-header
+        data-cy="uploadConflictTitle"
+        :title="title"
+      />
+    </template>
+
+    <dialog-body>
+      <p class="conflict-summary">
+        {{ summary }}
+      </p>
+
+      <ul class="conflict-list">
+        <li
+          v-for="name in displayNames"
+          :key="name"
+          class="conflict-list-item"
+        >
+          {{ name }}
+        </li>
+        <li v-if="hiddenCount > 0" class="conflict-list-more">
+          …and {{ hiddenCount }} more
+        </li>
+      </ul>
+
+      <label class="remember-choice">
+        <input
+          type="checkbox"
+          data-cy="rememberConflictChoice"
+          v-model="rememberChoice"
+        />
+        Remember my choice
+      </label>
+    </dialog-body>
+
+    <template #footer>
+      <bf-button
+        class="secondary"
+        data-cy="cancelConflictUpload"
+        @click="onCancel"
+      >
+        Cancel
+      </bf-button>
+      <bf-button
+        class="secondary"
+        data-cy="keepBothConflict"
+        @click="onChoose('keepBoth')"
+      >
+        Keep both
+      </bf-button>
+      <bf-button
+        data-cy="replaceConflict"
+        @click="onChoose('replace')"
+      >
+        Replace
+      </bf-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup>
+// UploadConflictDialog surfaces name-collision resolution at upload time.
+//
+// Emits:
+//  - update:dialogVisible(boolean)
+//  - resolve({ strategy: 'replace'|'keepBoth'|'cancel', remember: boolean })
+//
+// The parent component owns the conflict list + the target folder; this
+// component is pure-UI. "Remember my choice" persistence to
+// localStorage is also the parent's responsibility — we just return the
+// flag alongside the decision.
+import { computed, ref, watch } from "vue";
+import BfButton from "../../shared/bf-button/BfButton.vue";
+import BfDialogHeader from "../../shared/bf-dialog-header/BfDialogHeader.vue";
+
+const props = defineProps({
+  dialogVisible: { type: Boolean, default: false },
+  // Array of { incomingName, existingPackage } — shape produced by
+  // uploadModule's detectConflicts action.
+  conflicts: { type: Array, default: () => [] },
+});
+
+const emit = defineEmits(["update:dialogVisible", "resolve"]);
+
+const rememberChoice = ref(false);
+
+// Reset the remember checkbox each time the dialog re-opens so the
+// previous session's box state doesn't silently persist.
+watch(
+  () => props.dialogVisible,
+  (open) => {
+    if (open) rememberChoice.value = false;
+  }
+);
+
+const total = computed(() => props.conflicts.length);
+
+const title = computed(() => {
+  const noun = total.value === 1 ? "file" : "files";
+  return `${total.value} ${noun} already exist${total.value === 1 ? "s" : ""}`;
+});
+
+const summary = computed(() => {
+  const noun = total.value === 1 ? "file" : "files";
+  return `Choose how to handle ${total.value} incoming ${noun} that collide with existing packages. Replace soft-deletes the current package and uploads the new one in its place. Keep both appends " (N)" to the new upload's name.`;
+});
+
+// Cap at 5 — longer lists get a "…and N more" line rather than a
+// scrolling block. The dialog is for a decision, not a review.
+const displayNames = computed(() =>
+  props.conflicts.slice(0, 5).map((c) => c.incomingName)
+);
+
+const hiddenCount = computed(() =>
+  Math.max(0, total.value - displayNames.value.length)
+);
+
+function onChoose(strategy) {
+  emit("resolve", { strategy, remember: rememberChoice.value });
+  emit("update:dialogVisible", false);
+}
+
+function onCancel() {
+  emit("resolve", { strategy: "cancel", remember: false });
+  emit("update:dialogVisible", false);
+}
+</script>
+
+<style lang="scss" scoped>
+.conflict-summary {
+  margin: 0 0 12px;
+  line-height: 1.4;
+}
+.conflict-list {
+  margin: 0 0 16px;
+  padding-left: 18px;
+  max-height: 160px;
+  overflow-y: auto;
+}
+.conflict-list-item {
+  font-family: var(--mono-font, monospace);
+  font-size: 13px;
+  line-height: 1.6;
+}
+.conflict-list-more {
+  list-style: none;
+  margin-left: -18px;
+  color: var(--text-muted, #6a737d);
+  font-style: italic;
+  font-size: 13px;
+}
+.remember-choice {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  user-select: none;
+}
+</style>

--- a/src/components/datasets/files/BfDatasetFiles.vue
+++ b/src/components/datasets/files/BfDatasetFiles.vue
@@ -533,7 +533,7 @@ export default {
         if (!isEmpty(channel)) {
           channel.bind(
             "upload-event",
-            function () {
+            function (payload) {
               // Pusher's job here is purely "a file landed in Postgres,
               // refresh the dataset table." It fires for uploads from any
               // source (this browser session, a different session, the
@@ -541,6 +541,26 @@ export default {
               // driven by the finalize API response (see uploadModule.js)
               // — nothing on this Pusher event touches it.
               //
+              // onConflict=replace adds a `replaced_package_id` field on
+              // each UploadMessageItem for the replaced predecessor. Drop
+              // those rows from the table immediately so the user doesn't
+              // see the old (now trashed) and new packages side by side
+              // during the debounce window before the silent refetch.
+              if (Array.isArray(payload)) {
+                const replacedIds = new Set();
+                for (const item of payload) {
+                  if (item && item.replaced_package_id != null) {
+                    replacedIds.add(Number(item.replaced_package_id));
+                  }
+                }
+                if (replacedIds.size > 0 && Array.isArray(this.files)) {
+                  this.files = this.files.filter((f) => {
+                    const id =
+                      f && f.content ? Number(f.content.id) : null;
+                    return id == null || !replacedIds.has(id);
+                  });
+                }
+              }
               // Silent refetch + leading/maxWait debounce keep the table
               // current during a burst without the per-second flash.
               this.debouncedSilentFetch();

--- a/src/composables/useUploadConflictPref.js
+++ b/src/composables/useUploadConflictPref.js
@@ -1,0 +1,32 @@
+// Persists the user's upload-conflict preference to localStorage.
+//
+// Values: 'ask' (default, surface the dialog on conflict) | 'replace' |
+// 'keepBoth'. An invalid or missing value falls back to 'ask'.
+//
+// localStorage is intentionally the MVP storage — no server-side user-
+// preferences API exists today and adding one is out of scope for
+// shipping the conflict-resolution UX. The preference is per-browser
+// per-origin; users who change machines will re-see the dialog once
+// until they pick "Remember my choice" again. Acceptable for v1.
+const KEY = "pennsieve.uploadConflictPref";
+const VALID = new Set(["ask", "replace", "keepBoth"]);
+
+export function getUploadConflictPref() {
+  try {
+    const v = localStorage.getItem(KEY);
+    return VALID.has(v) ? v : "ask";
+  } catch {
+    // Private-browsing / disabled-storage fallback
+    return "ask";
+  }
+}
+
+export function setUploadConflictPref(v) {
+  if (!VALID.has(v)) return;
+  try {
+    localStorage.setItem(KEY, v);
+  } catch {
+    // no-op: private browsing or quota; the in-dialog choice still
+    // applies to the current upload.
+  }
+}

--- a/src/store/uploadModule.js
+++ b/src/store/uploadModule.js
@@ -391,6 +391,84 @@ export const actions = {
         }
     },
 
+    // detectConflicts compares the names of files the user just dropped
+    // against the immediate children of the upload destination, returning
+    // a list of conflict descriptors the caller can feed into the conflict
+    // dialog.
+    //
+    // Scope intentionally limited to the immediate target folder (no
+    // whole-tree recursion) for MVP:
+    //   - covers the common case (drop files into a single folder)
+    //   - the nested "drop a tree into an existing tree" case is handled
+    //     adequately today by the server's auto-rename fallback and the
+    //     folder-replace shortcut (future task)
+    //   - recursive check on a 100k-file tree is expensive on both sides
+    //     and not worth the complexity for v1
+    //
+    // Returns [{ incomingName, existingPackage }] — empty array on no
+    // conflicts or when no target is set. Folder-type children are not
+    // considered conflicts because folders get-or-create by name server-
+    // side; only file-type collisions matter for onConflict.
+    detectConflicts: async ({state, rootState}) => {
+        if (state.manifestFiles.length === 0) return []
+
+        const target = state.uploadDestination && state.uploadDestination.file
+        if (!target) return []
+
+        const currentRoute = router.currentRoute.value
+        const datasetId = currentRoute.params.datasetId
+        const pkgType = target.content && target.content.packageType
+
+        // Dataset root → /datasets/{id}; folder → /packages/{fileId}.
+        // Mirror BfDatasetFiles filesUrl so we hit a cached response if
+        // possible.
+        const baseUrl = pkgType === 'DataSet' ? 'datasets' : 'packages'
+        const idForUrl = pkgType === 'DataSet' ? datasetId : (target.content && target.content.id)
+        if (!idForUrl) return []
+
+        const token = await useGetToken()
+        // limit=1000 is generous for the MVP use case; the conflict-check
+        // only cares about child *names* at one level. Folders with more
+        // than that fall back silently to the server's on-write conflict
+        // resolution (auto-rename or the batch's onConflict choice).
+        const url = `${rootState.config.apiUrl}/${baseUrl}/${idForUrl}?includeAncestors=false&limit=1000&offset=0&api_key=${token}`
+        let children = []
+        try {
+            const resp = await fetch(url)
+            if (!resp.ok) return []
+            const data = await resp.json()
+            children = Array.isArray(data.children) ? data.children : []
+        } catch (err) {
+            // Network or auth blip — don't block the upload. The server
+            // still enforces its own resolution; the user just doesn't get
+            // the pre-flight dialog this time.
+            return []
+        }
+
+        // Only collide against file-type children. Folder (Collection) names
+        // are allowed to coexist with file names at the same level.
+        const existingFileNames = new Map()
+        for (const child of children) {
+            const pt = child && child.content && child.content.packageType
+            const nm = child && child.content && child.content.name
+            if (pt && pt !== 'Collection' && nm) {
+                existingFileNames.set(nm, child)
+            }
+        }
+
+        const conflicts = []
+        for (const incoming of state.manifestFiles) {
+            const nm = incoming.name || (incoming.file && incoming.file.name)
+            if (nm && existingFileNames.has(nm)) {
+                conflicts.push({
+                    incomingName: nm,
+                    existingPackage: existingFileNames.get(nm),
+                })
+            }
+        }
+        return conflicts
+    },
+
     // Define the packageId where files should be uploaded
     // This can be a folder-package-id or a dataset-package-id
     setUploadDestination: async ({rootState, commit}, targetPackage) => {

--- a/src/store/uploadModule.js
+++ b/src/store/uploadModule.js
@@ -80,7 +80,15 @@ const initialState = () => ({
     uploadComplete: false,
     uploadProgress: { total: 0, loaded: 0 },
     currentTargetPackage: {},
-    totalFilesInBatch: 0
+    totalFilesInBatch: 0,
+    // Conflict-resolution strategy for the current upload batch. Sent with
+    // each /upload/manifest/files/finalize call as onConflict. Values:
+    // "keepBoth" (default, auto-rename new upload to " (N)" on collision),
+    // "replace" (soft-delete predecessor + provenance link), "fail" (abort
+    // with 409 listing conflicts). "" is treated as keepBoth server-side.
+    // Set by the drop flow from either the user's remembered preference or
+    // the dialog choice; cleared on upload reset.
+    onConflict: "",
 })
 
 export const state = initialState()
@@ -159,6 +167,9 @@ export const mutations = {
     SET_MANIFEST_NODE_ID(state, nodeId) {
         state.manifestNodeId = nodeId
     },
+    SET_ON_CONFLICT(state, strategy) {
+        state.onConflict = strategy || ""
+    },
     SET_UPLOAD_FILE_MAP(state,uploadFileMap) {
         state.uploadFileMap = uploadFileMap
     },
@@ -200,6 +211,7 @@ export const mutations = {
         state.storageCredsExpiresAt = 0
         state.storageBucket = ""
         state.storageKeyPrefix = ""
+        state.onConflict = ""
     },
     REMOVE_COMPLETED_FILE(state, key) {
         const fileEntry = state.uploadFileMap.get(key)
@@ -615,6 +627,11 @@ export const actions = {
                 size: b.size,
                 sha256: b.sha256,
             })),
+        }
+        // Omit onConflict when empty so pre-v0.6 upload-service-v2 instances
+        // (should any still exist) see the legacy body byte-for-byte.
+        if (state.onConflict) {
+            body.onConflict = state.onConflict
         }
 
         try {

--- a/src/store/uploadModule.js
+++ b/src/store/uploadModule.js
@@ -393,27 +393,38 @@ export const actions = {
 
     // detectConflicts compares the names of files the user just dropped
     // against the immediate children of the upload destination, returning
-    // a list of conflict descriptors the caller can feed into the conflict
-    // dialog.
+    // a descriptor the caller can feed into the conflict dialog.
     //
     // Scope intentionally limited to the immediate target folder (no
     // whole-tree recursion) for MVP:
     //   - covers the common case (drop files into a single folder)
     //   - the nested "drop a tree into an existing tree" case is handled
-    //     adequately today by the server's auto-rename fallback and the
-    //     folder-replace shortcut (future task)
+    //     adequately today by the server's auto-rename fallback
     //   - recursive check on a 100k-file tree is expensive on both sides
     //     and not worth the complexity for v1
     //
-    // Returns [{ incomingName, existingPackage }] — empty array on no
-    // conflicts or when no target is set. Folder-type children are not
-    // considered conflicts because folders get-or-create by name server-
-    // side; only file-type collisions matter for onConflict.
+    // Return shape:
+    //   {
+    //     conflicts: [{ incomingName, existingPackage }],
+    //     target:    { nodeId, id, packageType, existingFileCount, totalIncoming }
+    //   }
+    //
+    // target metadata lets the dialog decide whether to offer the
+    // folder-replace shortcut: when every incoming file conflicts AND
+    // every existing file is being replaced AND the target is a folder
+    // (not the dataset root), deleting the folder and re-uploading is
+    // cheaper than per-file replacement — one DeletePackageJob cascades
+    // to the whole subtree server-side.
+    //
+    // Folder-type children are not considered conflicts because folders
+    // get-or-create by name server-side; only file collisions matter for
+    // onConflict.
     detectConflicts: async ({state, rootState}) => {
-        if (state.manifestFiles.length === 0) return []
+        const empty = { conflicts: [], target: null }
+        if (state.manifestFiles.length === 0) return empty
 
         const target = state.uploadDestination && state.uploadDestination.file
-        if (!target) return []
+        if (!target) return empty
 
         const currentRoute = router.currentRoute.value
         const datasetId = currentRoute.params.datasetId
@@ -424,7 +435,7 @@ export const actions = {
         // possible.
         const baseUrl = pkgType === 'DataSet' ? 'datasets' : 'packages'
         const idForUrl = pkgType === 'DataSet' ? datasetId : (target.content && target.content.id)
-        if (!idForUrl) return []
+        if (!idForUrl) return empty
 
         const token = await useGetToken()
         // limit=1000 is generous for the MVP use case; the conflict-check
@@ -435,14 +446,14 @@ export const actions = {
         let children = []
         try {
             const resp = await fetch(url)
-            if (!resp.ok) return []
+            if (!resp.ok) return empty
             const data = await resp.json()
             children = Array.isArray(data.children) ? data.children : []
         } catch (err) {
             // Network or auth blip — don't block the upload. The server
             // still enforces its own resolution; the user just doesn't get
             // the pre-flight dialog this time.
-            return []
+            return empty
         }
 
         // Only collide against file-type children. Folder (Collection) names
@@ -466,7 +477,17 @@ export const actions = {
                 })
             }
         }
-        return conflicts
+
+        return {
+            conflicts,
+            target: {
+                nodeId: target.content && target.content.nodeId,
+                id: target.content && target.content.id,
+                packageType: pkgType,
+                existingFileCount: existingFileNames.size,
+                totalIncoming: state.manifestFiles.length,
+            },
+        }
     },
 
     // Define the packageId where files should be uploaded


### PR DESCRIPTION
## Summary

Frontend side of the replace-on-conflict upload flow. Backend chain already merged:
- pennsieve-api migration (v0 → schema with \`replaces_package_id\`)
- pennsieve-go-core v1.16.0 (\`AddPackagesWithConflict\`)
- upload-service-v2#89 (finalize accepts \`onConflict\`, publishes DeletePackageJob, emits \`replaced_package_id\` via Pusher)
- pennsieve-go v1.6.0 + pennsieve-agent (CLI \`--on-conflict\` flag)

## What lands here (5 commits)

1. **Plumb \`onConflict\` through the finalize body** — uploadModule gains \`state.onConflict\` + \`SET_ON_CONFLICT\` mutation; body at \`uploadModule.js:finalize\` includes the field when set (omitted otherwise → server defaults to \`keepBoth\`).

2. **\`detectConflicts\` action** — queries the immediate children of the upload destination (\`GET /datasets/{id}\` or \`GET /packages/{id}\`), returns \`{ conflicts, target }\` where target carries enough metadata for the dialog to decide whether to offer the folder-replace shortcut. Scope is intentionally immediate-level only — whole-tree recursion is a 100k-file hazard not worth the complexity for v1.

3. **\`UploadConflictDialog\` + localStorage preference + \`startUpload\` integration** — new Vue component (modeled on \`BfMoveDialog\`). Renders conflict count, first 5 names, "…and N more". Three buttons: **Replace** / **Keep both** / **Cancel**. "Remember my choice" persists to localStorage via a composable (\`pennsieve.uploadConflictPref\`). Default: \`ask\`.

4. **Pusher \`upload-event\` handles \`replaced_package_id\`** — when the server emits the field on \`UploadMessageItem\`, remove that row from \`this.files\` immediately so the old and new packages don't appear side by side during the silent-refetch window.

5. **Folder-replace shortcut** — when every incoming file collides with every file already in the target folder (and the target is a \`Collection\`, not the dataset root), surface a fourth button: **Replace folder**. Calls \`DELETE /packages/{folderNodeId}\`, waits, then uploads with \`onConflict=keepBoth\`. Scala's \`PackageManager.delete\` cascades state=DELETING through the subtree and schedules one \`DeletePackageJob\` for the whole tree — much cheaper than per-file replacement at scale.

## Targeting

Branching from and PR'ing back into \`feature_dataset_files_upload_ux\` so the conflict diff stays isolated from the rest of the upload-UX refactor. When that branch promotes to dev/main, this rides along.

## Test plan

- [ ] Drop 3 files into empty folder → no dialog, upload proceeds (onConflict=keepBoth).
- [ ] Drop 3 files where 1 collides → dialog with 1 name; choose Replace → finalize body has \`onConflict: "replace"\`; choose Keep both → body has \`onConflict: "keepBoth"\`; choose Cancel → upload dialog stays open.
- [ ] "Remember my choice" checked + Replace → pref saved; next drop with conflicts skips the dialog.
- [ ] Drop identical file set to a folder that already has exactly those files → dialog shows **Replace folder** button; click → folder enters DELETING, new uploads land fresh.
- [ ] Pusher \`upload-event\` with \`replaced_package_id\` → that row disappears from DatasetFiles table.
- [ ] Agent + SDK paths still work (no regression to non-UI callers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)