### PR TITLE
Add version dropdown to RunMonitor and RunDetail

### DIFF
--- a/src/components/Analysis/RunMonitor/RunDetail.vue
+++ b/src/components/Analysis/RunMonitor/RunDetail.vue
@@ -147,6 +147,50 @@ const getComputeTypesForProcessor = (sourceUrl) => {
   return app?.runtimeConfig?.computeTypes || ["standard", "lambda"];
 };
 
+/* Version helpers — match WorkflowBuilder */
+const normalizeUrl = (url) => {
+  if (!url) return "";
+  return url.replace(/\.git$/, "").replace(/\/$/, "");
+};
+
+const latestVersion = (app) => {
+  const versions = app?.versions || [];
+  if (versions.length === 0) return null;
+  return [...versions].sort(
+    (a, b) =>
+      (new Date(b.createdAt).getTime() || 0) -
+      (new Date(a.createdAt).getTime() || 0),
+  )[0];
+};
+
+const sortedVersions = (app) => {
+  const versions = app?.versions || [];
+  return [...versions].sort(
+    (a, b) =>
+      (new Date(b.createdAt).getTime() || 0) -
+      (new Date(a.createdAt).getTime() || 0),
+  );
+};
+
+const versionOptionLabel = (app, v) => {
+  const latest = latestVersion(app);
+  return latest && v.version === latest.version
+    ? `${v.version} (latest)`
+    : v.version;
+};
+
+const findMatchedApp = (sourceUrl) => {
+  if (!sourceUrl) return null;
+  const normalized = normalizeUrl(sourceUrl);
+  return (
+    availableApplications.value.find(
+      (app) =>
+        normalizeUrl(app.sourceUrl) === normalized ||
+        normalizeUrl(app.source?.url) === normalized
+    ) || null
+  );
+};
+
 const getTargetTypeDefinition = (targetType) => {
   if (!targetType) return null;
   return targetTypes.value.find((t) => t.targetType === targetType) || null;
@@ -523,9 +567,10 @@ const initiateWorkflowFromConfig = async (pendingConfig) => {
           .filter(([key]) => !schemaNames.has(key))
           .map(([key, value]) => ({ key, value: String(value) }));
 
+        const matchedApp = findMatchedApp(d.sourceUrl);
         nodeConfigs[d.id] = {
           executionTarget: srcCfg?.executionTarget || d.computeType || "standard",
-          version: srcCfg?.version || "",
+          version: srcCfg?.version || d.tag || latestVersion(matchedApp)?.version || "",
           cpu: srcCfg?.cpu || "",
           memory: srcCfg?.memory || "",
           schemaParams,
@@ -1041,6 +1086,7 @@ onMounted(async () => {
   await Promise.all([
     store.dispatch("analysisModule/fetchComputeNodes"),
     store.dispatch("analysisModule/fetchTargetTypes"),
+    store.dispatch("analysisModule/fetchApplications", { force: true }),
   ]);
 
   // Check for pending configure mode
@@ -1338,11 +1384,24 @@ onUnmounted(() => {
                 </div>
                 <div class="config-field">
                   <label>Version</label>
-                  <el-input
+                  <el-select
                     v-model="nodeConfigs[selectedNode.id].version"
                     size="small"
+                    style="width: 100%"
                     placeholder="latest"
-                  />
+                    :disabled="sortedVersions(findMatchedApp(selectedNode.data?.sourceUrl)).length <= 1"
+                  >
+                    <el-option
+                      v-for="v in sortedVersions(findMatchedApp(selectedNode.data?.sourceUrl))"
+                      :key="v.version"
+                      :label="versionOptionLabel(findMatchedApp(selectedNode.data?.sourceUrl), v)"
+                      :value="v.version"
+                    />
+                  </el-select>
+                  <span
+                    v-if="sortedVersions(findMatchedApp(selectedNode.data?.sourceUrl)).length <= 1"
+                    class="version-hint"
+                  >No other versions available</span>
                 </div>
 
                 <!-- CPU / Memory (Standard only) -->
@@ -2820,6 +2879,12 @@ onUnmounted(() => {
     font-weight: 600;
     color: theme.$gray_5;
   }
+}
+
+.version-hint {
+  font-size: 11px;
+  color: theme.$gray_4;
+  font-style: italic;
 }
 
 .param-row {

--- a/src/components/Analysis/RunMonitor/RunMonitor.vue
+++ b/src/components/Analysis/RunMonitor/RunMonitor.vue
@@ -136,6 +136,45 @@ const getComputeTypesForProcessor = (sourceUrl) => {
   return app?.runtimeConfig?.computeTypes || ["standard", "lambda"];
 };
 
+/* Version helpers — match WorkflowBuilder */
+const latestVersion = (app) => {
+  const versions = app?.versions || [];
+  if (versions.length === 0) return null;
+  return [...versions].sort(
+    (a, b) =>
+      (new Date(b.createdAt).getTime() || 0) -
+      (new Date(a.createdAt).getTime() || 0),
+  )[0];
+};
+
+const sortedVersions = (app) => {
+  const versions = app?.versions || [];
+  return [...versions].sort(
+    (a, b) =>
+      (new Date(b.createdAt).getTime() || 0) -
+      (new Date(a.createdAt).getTime() || 0),
+  );
+};
+
+const versionOptionLabel = (app, v) => {
+  const latest = latestVersion(app);
+  return latest && v.version === latest.version
+    ? `${v.version} (latest)`
+    : v.version;
+};
+
+const findMatchedApp = (sourceUrl) => {
+  if (!sourceUrl) return null;
+  const normalized = normalizeUrl(sourceUrl);
+  return (
+    availableApplications.value.find(
+      (app) =>
+        normalizeUrl(app.sourceUrl) === normalized ||
+        normalizeUrl(app.source?.url) === normalized
+    ) || null
+  );
+};
+
 const getTargetTypeDefinition = (targetType) => {
   if (!targetType) return null;
   return targetTypes.value.find((t) => t.targetType === targetType) || null;
@@ -951,9 +990,10 @@ const initiateWorkflow = async () => {
           .filter(([key]) => !schemaNames.has(key))
           .map(([key, value]) => ({ key, value: String(value) }));
 
+        const matchedApp = findMatchedApp(d.sourceUrl);
         nodeConfigs[d.id] = {
           executionTarget: srcCfg?.executionTarget || d.computeType || "standard",
-          version: srcCfg?.version || "",
+          version: srcCfg?.version || d.tag || latestVersion(matchedApp)?.version || "",
           cpu: srcCfg?.cpu || "",
           memory: srcCfg?.memory || "",
           schemaParams,
@@ -1542,6 +1582,7 @@ onMounted(async () => {
       store.dispatch("analysisModule/fetchComputeNodes"),
       store.dispatch("analysisModule/fetchWorkflows"),
       store.dispatch("analysisModule/fetchTargetTypes"),
+      store.dispatch("analysisModule/fetchApplications", { force: true }),
       fetchOrgCounters(),
     ]);
   } catch (err) {
@@ -1907,11 +1948,24 @@ onUnmounted(() => {
                 </div>
                 <div class="config-field">
                   <label>Version</label>
-                  <el-input
+                  <el-select
                     v-model="nodeConfigs[selectedNode.id].version"
                     size="small"
+                    style="width: 100%"
                     placeholder="latest"
-                  />
+                    :disabled="sortedVersions(findMatchedApp(selectedNode.data?.sourceUrl)).length <= 1"
+                  >
+                    <el-option
+                      v-for="v in sortedVersions(findMatchedApp(selectedNode.data?.sourceUrl))"
+                      :key="v.version"
+                      :label="versionOptionLabel(findMatchedApp(selectedNode.data?.sourceUrl), v)"
+                      :value="v.version"
+                    />
+                  </el-select>
+                  <span
+                    v-if="sortedVersions(findMatchedApp(selectedNode.data?.sourceUrl)).length <= 1"
+                    class="version-hint"
+                  >No other versions available</span>
                 </div>
 
                 <!-- CPU / Memory (Standard only) -->
@@ -3878,6 +3932,12 @@ onUnmounted(() => {
     font-weight: 600;
     color: theme.$gray_5;
   }
+}
+
+.version-hint {
+  font-size: 11px;
+  color: theme.$gray_4;
+  font-style: italic;
 }
 
 .param-row {


### PR DESCRIPTION
Replace plain text input with el-select dropdown for processor version selection, populated from the app's versions via /applications/store. Defaults to d.tag or latest version. Shows "No other versions available" when only one version exists. Fetches applications on mount to ensure version data is available.