### PR TITLE
Hide Published tab without org context, sort published repos to top, …

### DIFF
--- a/src/components/user/code/CodeRepoListItem.vue
+++ b/src/components/user/code/CodeRepoListItem.vue
@@ -28,6 +28,13 @@
             {{ repo.language }}
           </span>
         </div>
+        <router-link
+          v-if="matchedApp"
+          :to="{ name: 'published-app-details', params: { uuid: matchedApp.uuid } }"
+          class="app-details-link"
+        >
+          View application details &rarr;
+        </router-link>
       </div>
 
       <div class="publishing-box">
@@ -62,13 +69,6 @@
             </span>
           </div>
         </div>
-        <router-link
-          v-if="matchedApp"
-          :to="{ name: 'published-app-details', params: { uuid: matchedApp.uuid } }"
-          class="app-details-link"
-        >
-          View application details &rarr;
-        </router-link>
       </div>
     </div>
 
@@ -373,8 +373,8 @@ export default {
 
 .app-details-link {
   display: inline-block;
-  margin-top: 8px;
-  font-size: 12px;
+  margin-top: 10px;
+  font-size: 13px;
   font-weight: 500;
   color: theme.$purple_2;
   text-decoration: none;

--- a/src/components/user/code/PublishedAppDetail.vue
+++ b/src/components/user/code/PublishedAppDetail.vue
@@ -7,6 +7,8 @@ import { ElMessage } from 'element-plus'
 import BfStage from '@/components/layout/BfStage/BfStage.vue'
 import BfButton from '@/components/shared/bf-button/BfButton.vue'
 import EventBus from '@/utils/event-bus'
+import { useGetToken } from '@/composables/useGetToken'
+import { useSendXhr } from '@/mixins/request/request_composable'
 
 const props = defineProps({
   uuid: {
@@ -46,8 +48,10 @@ const editWorkspaces = ref([])
 const isSavingPermissions = ref(false)
 const showAddUserDialog = ref(false)
 const showAddTeamDialog = ref(false)
+const showAddWorkspaceDialog = ref(false)
 const selectedAddUserId = ref(null)
 const selectedAddTeamId = ref(null)
+const selectedAddWorkspaceId = ref(null)
 
 const teams = computed(() => store.state.teams || [])
 
@@ -308,6 +312,15 @@ const availableAddableTeams = computed(() => {
   return teams.value.filter((t) => t.team?.id && !taken.has(t.team.id))
 })
 
+const availableAddableWorkspaces = computed(() => {
+  const taken = new Set(editWorkspaces.value.map((w) => w.entityId))
+  return organizations.value.filter(
+    (o) => o.organization?.id &&
+      !taken.has(o.organization.id) &&
+      o.organization.name?.toLowerCase() !== 'welcome'
+  )
+})
+
 const openAddUserDialog = () => {
   selectedAddUserId.value = null
   showAddUserDialog.value = true
@@ -337,6 +350,26 @@ const confirmAddTeam = () => {
   })
   showAddTeamDialog.value = false
 }
+
+const openAddWorkspaceDialog = () => {
+  selectedAddWorkspaceId.value = null
+  showAddWorkspaceDialog.value = true
+}
+
+const confirmAddWorkspace = () => {
+  if (!selectedAddWorkspaceId.value) return
+  const org = organizations.value.find(
+    (o) => o.organization?.id === selectedAddWorkspaceId.value
+  )
+  editWorkspaces.value.push({
+    entityId: selectedAddWorkspaceId.value,
+    organizationId: selectedAddWorkspaceId.value,
+    organizationName: org?.organization?.name,
+  })
+  showAddWorkspaceDialog.value = false
+}
+
+const removeEditWorkspace = (idx) => editWorkspaces.value.splice(idx, 1)
 
 const savePermissions = async () => {
   if (!appUuid.value) return
@@ -391,9 +424,32 @@ const loadDetail = async (uuid) => {
   isLoading.value = true
   permissionsLoading.value = true
   try {
+    // Ensure org members and teams are loaded — getPrimaryData() in main.js
+    // may not have run if the user navigated here via a userRoute (e.g. my-workspace).
+    // Fall back to preferredOrganization / first org when activeOrganization is not set.
+    const orgId = store.state.activeOrganization?.organization?.id
+      || store.state.profile?.preferredOrganization
+      || store.state.organizations?.[0]?.organization?.id
+    const needsMembers = orgId && !store.state.orgMembers?.length
+    const needsTeams = orgId && !store.state.teams?.length
+    const orgDataPromise = (needsMembers || needsTeams)
+      ? useGetToken().then((token) => {
+          const base = `${store.state.config.apiUrl}/organizations/${orgId}`
+          return Promise.all([
+            needsMembers
+              ? useSendXhr(`${base}/members?api_key=${token}`).then((r) => store.dispatch('updateOrgMembers', r))
+              : Promise.resolve(),
+            needsTeams
+              ? useSendXhr(`${base}/teams?api_key=${token}`).then((r) => store.dispatch('updateTeams', r))
+              : Promise.resolve(),
+          ])
+        }).catch((err) => console.warn('Failed to load org data:', err))
+      : Promise.resolve()
+
     const [detailResult, permsResult] = await Promise.allSettled([
       store.dispatch('analysisModule/fetchApplication', uuid),
       store.dispatch('analysisModule/fetchApplicationPermissions', uuid),
+      orgDataPromise,
     ])
 
     if (detailResult.status === 'fulfilled' && detailResult.value) {
@@ -755,6 +811,36 @@ const confirmDelete = async () => {
                 >&times;</button>
               </div>
             </div>
+
+            <div class="edit-subsection">
+              <div class="edit-subsection-header">
+                <h4>Workspaces ({{ editWorkspaces.length }})</h4>
+                <bf-button
+                  class="secondary small"
+                  @click="openAddWorkspaceDialog"
+                  :disabled="availableAddableWorkspaces.length === 0"
+                >+ Add Workspace</bf-button>
+              </div>
+              <div v-if="editWorkspaces.length === 0" class="edit-empty">
+                No workspaces
+              </div>
+              <div
+                v-else
+                v-for="(ws, i) in editWorkspaces"
+                :key="ws.entityId"
+                class="edit-permission-row"
+              >
+                <span class="edit-permission-label">
+                  {{ ws.organizationName || ws.entityId }}
+                </span>
+                <button
+                  class="remove-perm-btn"
+                  type="button"
+                  @click="removeEditWorkspace(i)"
+                  title="Remove"
+                >&times;</button>
+              </div>
+            </div>
           </div>
         </template>
       </div>
@@ -868,6 +954,42 @@ const confirmDelete = async () => {
             type="primary"
             :disabled="!selectedAddTeamId"
             @click="confirmAddTeam"
+          >Add</el-button>
+        </div>
+      </template>
+    </el-dialog>
+
+    <!-- Add Workspace Permission Dialog -->
+    <el-dialog
+      v-model="showAddWorkspaceDialog"
+      title="Add Workspace"
+      width="480px"
+      :close-on-click-modal="true"
+    >
+      <div class="add-perm-dialog">
+        <p>Grant a workspace access to this application:</p>
+        <el-select
+          v-model="selectedAddWorkspaceId"
+          placeholder="Select a workspace"
+          size="default"
+          filterable
+          class="add-perm-select"
+        >
+          <el-option
+            v-for="o in availableAddableWorkspaces"
+            :key="o.organization.id"
+            :label="o.organization.name"
+            :value="o.organization.id"
+          />
+        </el-select>
+      </div>
+      <template #footer>
+        <div class="dialog-footer">
+          <el-button @click="showAddWorkspaceDialog = false">Cancel</el-button>
+          <el-button
+            type="primary"
+            :disabled="!selectedAddWorkspaceId"
+            @click="confirmAddWorkspace"
           >Add</el-button>
         </div>
       </template>

--- a/src/components/user/code/UserGithubCode.vue
+++ b/src/components/user/code/UserGithubCode.vue
@@ -176,7 +176,7 @@
                 </div>
               </el-tab-pane>
 
-              <el-tab-pane label="Published Applications" name="published">
+              <el-tab-pane v-if="hasOrgContext" label="Published Applications" name="published">
                 <published-apps-list />
               </el-tab-pane>
             </el-tabs>
@@ -270,6 +270,10 @@ export default {
     hasGithubProfile() {
       return this.githubProfile && this.githubProfile.login
     },
+
+    hasOrgContext() {
+      return !!this.$store.state.activeOrganization?.organization?.id
+    },
     
     // Use store state for repositories
     repositories() {
@@ -298,12 +302,20 @@ export default {
 
     filteredRepositories() {
       const q = this.reposSearchQuery.trim().toLowerCase()
-      if (!q) return this.repositories
-      return this.repositories.filter((repo) => {
-        const name = (repo.full_name || repo.name || '').toLowerCase()
-        const desc = (repo.description || '').toLowerCase()
-        const lang = (repo.language || '').toLowerCase()
-        return name.includes(q) || desc.includes(q) || lang.includes(q)
+      let repos = this.repositories
+      if (q) {
+        repos = repos.filter((repo) => {
+          const name = (repo.full_name || repo.name || '').toLowerCase()
+          const desc = (repo.description || '').toLowerCase()
+          const lang = (repo.language || '').toLowerCase()
+          return name.includes(q) || desc.includes(q) || lang.includes(q)
+        })
+      }
+      // Sort published repos to the top
+      return repos.slice().sort((a, b) => {
+        const aPublished = a.publishing_to_appstore ? 1 : 0
+        const bPublished = b.publishing_to_appstore ? 1 : 0
+        return bPublished - aPublished
       })
     },
 
@@ -327,9 +339,6 @@ export default {
   },
 
   mounted() {
-    console.log('Store state keys:', Object.keys(this.$store.state))
-    console.log('Store codeRepos state:', this.$store.state.codeRepos)
-    console.log('Store modules:', this.$store._modules)
     if (this.$route.query.tab === 'published') {
       this.activeTab = 'published'
     }

--- a/src/main.js
+++ b/src/main.js
@@ -157,7 +157,7 @@ router.beforeEach(async (to, from, next) => {
     
     // Check if this is a user-specific route (no organization context needed)
     const isUserRoute = userRoutes.indexOf(to.name) >= 0
-    
+
     if (to.name === 'home' && token && savedOrgId) {
         // Special case for 'home' page; if previously logged in, and session stored, then
         // forward to dataset listing page for the organization.
@@ -226,8 +226,7 @@ router.beforeEach(async (to, from, next) => {
             // Profile exists - just check if org context needs updating
             const routeOrgId = to.params.orgId
             const currentActiveOrgId = store.getters.activeOrganization?.organization?.id
-            
-            // Only check/switch org if the route has an orgId and it's different from current
+
             if (routeOrgId && routeOrgId !== currentActiveOrgId) {
                 // Use the same clearing logic as useSwitchWorkspace
                 const { useComputeResourcesStore } = await import('@/stores/computeResourcesStore')

--- a/src/store/analysisModule.js
+++ b/src/store/analysisModule.js
@@ -239,10 +239,14 @@ export const actions = {
     try {
       const userToken = await useGetToken();
 
-      const orgId = rootState.activeOrganization?.organization?.id;
-      const url = orgId
-        ? `${rootState.config.api2Url}/applications/store?organization_id=${orgId}`
-        : `${rootState.config.api2Url}/applications/store`;
+      // /applications/store requires organization_id. On user routes (My Workspace)
+      // there is no activeOrganization, so fall back to preferredOrganization
+      // or the first org so we can still populate app data for repo cards.
+      const orgId = rootState.activeOrganization?.organization?.id
+        || rootState.profile?.preferredOrganization
+        || rootState.organizations?.[0]?.organization?.id;
+      if (!orgId) return;
+      const url = `${rootState.config.api2Url}/applications/store?organization_id=${orgId}`;
       const resp = await fetch(url, {
         method: "GET",
         headers: {


### PR DESCRIPTION
…add workspace permissions

  - Hide "Published Applications" tab on My Code page when no workspace context is active 
  - Sort repos with App Store publishing enabled to the top of My Repositories list       
  - Move "View application details" link to the left side of repo cards, under the        
  public/private indicator                                                                
  - Fix Add User/Add Team buttons being disabled on app detail page when navigating from  
  My Workspace                                                                          
  - Add ability to add/remove workspace permissions on published applications