### PR TITLE
Epic next app store release

### DIFF
--- a/src/components/user/code/PublishedAppDetail.vue
+++ b/src/components/user/code/PublishedAppDetail.vue
@@ -67,7 +67,6 @@ const appUuid = computed(() => props.uuid || route.params.uuid)
 
 const backToCodeRoute = computed(() => ({
   name: 'my-code',
-  query: { tab: 'published', app: appUuid.value },
 }))
 
 /* Helpers */
@@ -537,7 +536,7 @@ const confirmDelete = async () => {
       <!-- Back link -->
       <div class="app-breadcrumb">
         <router-link :to="backToCodeRoute" class="back-link">
-          &larr; Back to Published Applications
+          &larr; Back to My Repos
         </router-link>
       </div>
 


### PR DESCRIPTION
- Default compute type dropdown to standard + lambda (matching RunMonitor)
- Add tooltip on compute type explaining lambda requirement
- Show application version in RunDetail browse mode
- Use app isPrivate field for repo card visibility tag
- Resolve team/workspace names in permissions edit mode
- Hide deployments section in ApplicationDetail
- Remove debug logs