### PR TITLE
Workflow and UI refinements

### DIFF
--- a/src/components/Analysis/Applications/ApplicationDetail.vue
+++ b/src/components/Analysis/Applications/ApplicationDetail.vue
@@ -380,6 +380,8 @@ watch(
               <div class="version-meta">
                 <span>Released {{ formatDate(version.createdAt) }}</span>
               </div>
+              <!-- Deployments hidden for now -->
+              <!--
               <div
                 v-if="(version.deployments || []).length > 0"
                 class="deployments-list"
@@ -401,6 +403,7 @@ watch(
                   </span>
                 </div>
               </div>
+              -->
             </div>
             <el-pagination
               v-if="versionsPageCount > 1"

--- a/src/components/Analysis/RunMonitor/RunDetail.vue
+++ b/src/components/Analysis/RunMonitor/RunDetail.vue
@@ -324,6 +324,7 @@ const runToNodesAndEdges = (run) => {
         status: d.status || "NOT_STARTED",
         processorType: d.type,
         sourceUrl: d.sourceUrl,
+        version: d.tag || null,
         startedAt: d.startedAt,
         completedAt: d.completedAt,
         ...extra,
@@ -1692,6 +1693,10 @@ onUnmounted(() => {
                 <div v-if="selectedNode.data?.processorType" class="info-row">
                   <span class="info-label">Type</span>
                   <span class="info-value">{{ selectedNode.data.processorType }}</span>
+                </div>
+                <div v-if="selectedNode.data?.version" class="info-row">
+                  <span class="info-label">Version</span>
+                  <span class="info-value">{{ selectedNode.data.version }}</span>
                 </div>
               </div>
 

--- a/src/components/Analysis/WorkflowBuilder/WorkflowBuilder.vue
+++ b/src/components/Analysis/WorkflowBuilder/WorkflowBuilder.vue
@@ -227,9 +227,12 @@ const getUserName = (userId) => {
 };
 
 const getComputeTypesForTarget = (targetType) => {
-  if (!targetType) return [];
+  if (!targetType) return ["standard", "lambda"];
   const tt = targetTypes.value.find((t) => t.targetType === targetType);
-  return tt?.runtimeConfig?.computeTypes || [];
+  // TODO: use API-driven computeTypes once target types return them reliably
+  // return tt?.runtimeConfig?.computeTypes || ["standard", "lambda"];
+  const types = tt?.runtimeConfig?.computeTypes;
+  return types && types.length ? types : ["standard", "lambda"];
 };
 
 const getTargetTypeParams = (targetType) => {
@@ -1273,7 +1276,15 @@ const openNodeSettings = (id) => {
                 <h4 class="sidebar-section-title">Runtime Configuration</h4>
                 <div class="info-card">
                   <div class="info-row">
-                    <span class="info-label">Compute Type</span>
+                    <span class="info-label">
+                      Compute Type
+                      <el-tooltip
+                        content="Application must be set up for Lambda, if selected"
+                        placement="top"
+                      >
+                        <IconInfoSmall :width="20" :height="20" class="compute-type-info-icon" />
+                      </el-tooltip>
+                    </span>
                     <el-select
                       v-model="selectedNode.data.computeType"
                       size="small"
@@ -1402,15 +1413,26 @@ const openNodeSettings = (id) => {
                 <h4 class="sidebar-section-title">Runtime Configuration</h4>
                 <div class="info-card">
                   <div class="info-row">
-                    <span class="info-label">Compute Type</span>
+                    <span class="info-label">
+                      Compute Type
+                      <el-tooltip
+                        content="Application must be set up for Lambda, if selected"
+                        placement="top"
+                      >
+                        <IconInfoSmall :width="20" :height="20" class="compute-type-info-icon" />
+                      </el-tooltip>
+                    </span>
                     <el-select
                       v-model="selectedNode.data.computeType"
                       size="small"
                       class="info-inline-select"
                     >
+                      <!-- TODO: use API-driven computeTypes once applications return them reliably -->
                       <el-option
-                        v-for="ct in selectedNode.data.application
-                          ?.runtimeConfig?.computeTypes || ['standard']"
+                        v-for="ct in (selectedNode.data.application
+                          ?.runtimeConfig?.computeTypes?.length
+                          ? selectedNode.data.application.runtimeConfig.computeTypes
+                          : ['standard', 'lambda'])"
                         :key="ct"
                         :label="ct.charAt(0).toUpperCase() + ct.slice(1)"
                         :value="ct"
@@ -2736,6 +2758,12 @@ const openNodeSettings = (id) => {
   color: theme.$gray_5;
   flex-shrink: 0;
   min-width: 80px;
+
+  .compute-type-info-icon {
+    vertical-align: top;
+    margin-left: 2px;
+    opacity: 0.6;
+  }
 }
 
 .info-value {

--- a/src/components/user/code/CodeRepoListItem.vue
+++ b/src/components/user/code/CodeRepoListItem.vue
@@ -19,10 +19,11 @@
         </div>
         <div class="repo-tags">
           <span
+            v-if="matchedAppRaw && typeof matchedAppRaw.isPrivate === 'boolean'"
             class="tag"
-            :class="repo.private ? 'private' : 'public'"
+            :class="matchedAppRaw.isPrivate ? 'private' : 'public'"
           >
-            {{ repo.private ? 'Private' : 'Public' }}
+            {{ matchedAppRaw.isPrivate ? 'Private' : 'Public' }}
           </span>
           <span v-if="repo.language" class="tag language">
             {{ repo.language }}

--- a/src/components/user/code/PublishedAppDetail.vue
+++ b/src/components/user/code/PublishedAppDetail.vue
@@ -163,6 +163,14 @@ const getWorkspaceName = (workspaceId) => {
   return match?.organization?.name || null
 }
 
+const getTeamName = (teamId) => {
+  if (!teamId) return null
+  const match = teams.value.find(
+    (t) => t.team?.id === teamId || t.team?.intId === teamId
+  )
+  return match?.team?.name || null
+}
+
 const statusKey = (status) => {
   if (!status) return 'gray'
   const s = status.toLowerCase()
@@ -200,13 +208,12 @@ const permissionLabel = (perm) => {
   const type = permissionEntityType(perm)
   const id = permissionEntityId(perm)
   if (type === 'user') return getUserName(id)
-  if (type === 'team') return `Team: ${perm.teamName || id}`
+  if (type === 'team') {
+    const name = perm.teamName || getTeamName(id) || id
+    return `Team: ${name}`
+  }
   if (type === 'workspace' || type === 'organization') {
-    const name =
-      perm.organizationName ||
-      perm.workspaceName ||
-      getWorkspaceName(id) ||
-      id
+    const name = perm.organizationName || perm.workspaceName || getWorkspaceName(id) || id
     return `Workspace: ${name}`
   }
   if (id) return type ? `${type}: ${id}` : id
@@ -800,7 +807,7 @@ const confirmDelete = async () => {
                 class="edit-permission-row"
               >
                 <span class="edit-permission-label">
-                  {{ team.teamName || team.entityId }}
+                  {{ team.teamName || getTeamName(team.entityId) || team.entityId }}
                 </span>
                 <button
                   class="remove-perm-btn"
@@ -830,7 +837,7 @@ const confirmDelete = async () => {
                 class="edit-permission-row"
               >
                 <span class="edit-permission-label">
-                  {{ ws.organizationName || ws.entityId }}
+                  {{ ws.organizationName || getWorkspaceName(ws.entityId) || ws.entityId }}
                 </span>
                 <button
                   class="remove-perm-btn"

--- a/src/store/analysisModule.js
+++ b/src/store/analysisModule.js
@@ -263,7 +263,7 @@ export const actions = {
             runtimeConfig: {
               cpu: rc.cpu || null,
               memory: rc.memory || null,
-              computeTypes: (rc.computeTypes && rc.computeTypes.length ? rc.computeTypes : ["standard"])
+              computeTypes: (rc.computeTypes && rc.computeTypes.length ? rc.computeTypes : ["standard", "lambda"])
                 .map((t) => (t === "ecs" ? "standard" : t)),
             },
           };
@@ -898,7 +898,7 @@ export const actions = {
             runtimeConfig: {
               cpu: rc.cpu || null,
               memory: rc.memory || null,
-              computeTypes: (rc.computeTypes && rc.computeTypes.length ? rc.computeTypes : ["standard"])
+              computeTypes: (rc.computeTypes && rc.computeTypes.length ? rc.computeTypes : ["standard", "lambda"])
                 .map((t) => (t === "ecs" ? "standard" : t)),
             },
           };


### PR DESCRIPTION
- Default compute type dropdown to standard + lambda (matching RunMonitor)
- Add tooltip on compute type explaining lambda requirement
- Show application version in RunDetail browse mode
- Use app isPrivate field for repo card visibility tag
- Resolve team/workspace names in permissions edit mode
- Hide deployments section in ApplicationDetail
- Remove debug logs