### PR TITLE
Epic next app store release workflow

### DIFF
--- a/src/components/Analysis/RunMonitor/RunDetail.vue
+++ b/src/components/Analysis/RunMonitor/RunDetail.vue
@@ -572,8 +572,8 @@ const initiateWorkflowFromConfig = async (pendingConfig) => {
         nodeConfigs[d.id] = {
           executionTarget: srcCfg?.executionTarget || d.computeType || "standard",
           version: srcCfg?.version || d.tag || latestVersion(matchedApp)?.version || "",
-          cpu: srcCfg?.cpu || "",
-          memory: srcCfg?.memory || "",
+          cpu: srcCfg?.cpu || (d.runtimeConfig?.cpu ? String(d.runtimeConfig.cpu) : ""),
+          memory: srcCfg?.memory || (d.runtimeConfig?.memory ? String(d.runtimeConfig.memory) : ""),
           schemaParams,
           extraParams,
         };

--- a/src/components/Analysis/RunMonitor/RunMonitor.vue
+++ b/src/components/Analysis/RunMonitor/RunMonitor.vue
@@ -994,8 +994,8 @@ const initiateWorkflow = async () => {
         nodeConfigs[d.id] = {
           executionTarget: srcCfg?.executionTarget || d.computeType || "standard",
           version: srcCfg?.version || d.tag || latestVersion(matchedApp)?.version || "",
-          cpu: srcCfg?.cpu || "",
-          memory: srcCfg?.memory || "",
+          cpu: srcCfg?.cpu || (d.runtimeConfig?.cpu ? String(d.runtimeConfig.cpu) : ""),
+          memory: srcCfg?.memory || (d.runtimeConfig?.memory ? String(d.runtimeConfig.memory) : ""),
           schemaParams,
           extraParams,
         };

--- a/src/components/Analysis/WorkflowBuilder/WorkflowBuilder.vue
+++ b/src/components/Analysis/WorkflowBuilder/WorkflowBuilder.vue
@@ -413,10 +413,13 @@ const definitionToNodesAndEdges = (workflow, applications) => {
             ? matchedApplication?.runtimeConfig?.computeTypes?.[0] || "standard"
             : getComputeTypesForTarget(p.targetType)?.[0] || null),
         cpu:
-          String(p.cpu || matchedApplication?.runtimeConfig?.cpu || "") || "",
+          (p.runtimeConfig?.cpu ? String(p.runtimeConfig.cpu) : "") ||
+          (p.cpu ? String(p.cpu) : "") ||
+          (matchedApplication?.runtimeConfig?.cpu ? String(matchedApplication.runtimeConfig.cpu) : ""),
         memory:
-          String(p.memory || matchedApplication?.runtimeConfig?.memory || "") ||
-          "",
+          (p.runtimeConfig?.memory ? String(p.runtimeConfig.memory) : "") ||
+          (p.memory ? String(p.memory) : "") ||
+          (matchedApplication?.runtimeConfig?.memory ? String(matchedApplication.runtimeConfig.memory) : ""),
         application: matchedApplication,
         defaultParams: p.defaultParams || {},
         paramSchema: p.paramSchema || [],

--- a/src/components/user/code/CodeRepoListItem.vue
+++ b/src/components/user/code/CodeRepoListItem.vue
@@ -2,17 +2,7 @@
   <div class="repo-card">
     <div class="repo-header">
       <div class="repo-info">
-        <h3>
-          <a
-            :href="repo.html_url || repo.url"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="repo-name-link"
-            :title="`View ${repo.full_name || repo.name} on GitHub`"
-          >
-            {{ repo.full_name || repo.name }}
-          </a>
-        </h3>
+        <h3>{{ repo.full_name || repo.name }}</h3>
         <div class="repo-subtitle">GitHub Repository</div>
         <div v-if="repo.description" class="repo-description">
           {{ repo.description }}
@@ -29,47 +19,39 @@
             {{ repo.language }}
           </span>
         </div>
-        <router-link
-          v-if="matchedApp"
-          :to="{ name: 'published-app-details', params: { uuid: matchedApp.uuid } }"
-          class="app-details-link"
-        >
-          View application details &rarr;
-        </router-link>
       </div>
 
-      <div class="publishing-box">
-        <div class="publishing-box-header">
-          <span class="publishing-box-title">Publishing Settings</span>
-          <button
-            class="settings-button"
-            type="button"
-            title="Edit publishing settings"
-            @click="handleManageSettings"
-          >
-            <IconSettings :width="20" :height="20" color="currentColor" />
-          </button>
-        </div>
-        <div class="publishing-box-rows">
-          <div
-            class="status-icon-row"
-            :class="repo.publishing_to_discover ? 'enabled' : 'disabled'"
-          >
-            <span class="status-icon-label">Discover</span>
-            <span class="status-icon-state">
-              {{ repo.publishing_to_discover ? 'On' : 'Off' }}
-            </span>
-          </div>
-          <div
-            class="status-icon-row"
-            :class="repo.publishing_to_appstore ? 'enabled' : 'disabled'"
-          >
-            <span class="status-icon-label">App Store</span>
-            <span class="status-icon-state">
-              {{ repo.publishing_to_appstore ? 'On' : 'Off' }}
-            </span>
+      <div class="header-right">
+        <div class="tracking-box">
+          <div class="tracking-statuses">
+            <div
+              class="status-icon-row"
+              :class="repo.publishing_to_discover ? 'enabled' : 'disabled'"
+            >
+              <span class="status-icon-label">Discover</span>
+              <span class="status-icon-state">
+                {{ repo.publishing_to_discover ? 'On' : 'Off' }}
+              </span>
+            </div>
+            <div
+              class="status-icon-row"
+              :class="repo.publishing_to_appstore ? 'enabled' : 'disabled'"
+            >
+              <span class="status-icon-label">App Store</span>
+              <span class="status-icon-state">
+                {{ repo.publishing_to_appstore ? 'On' : 'Off' }}
+              </span>
+            </div>
           </div>
         </div>
+        <button
+          class="settings-button"
+          type="button"
+          title="Edit tracking settings"
+          @click="handleManageSettings"
+        >
+          <IconSettings :width="20" :height="20" color="currentColor" />
+        </button>
       </div>
     </div>
 
@@ -96,6 +78,19 @@
         <IconGitHub :width="14" :height="14" color="currentColor" />
         <span>View on GitHub</span>
       </a>
+      <router-link
+        v-if="matchedApp"
+        :to="{ name: 'published-app-details', params: { uuid: matchedApp.uuid } }"
+        class="card-action-link app-details-link"
+      >
+        View application details &rarr;
+      </router-link>
+      <span
+        v-else-if="repo.publishing_to_appstore && !matchedApp"
+        class="card-action-hint"
+      >
+        Create Github release to add to app store
+      </span>
     </div>
   </div>
 </template>
@@ -132,7 +127,6 @@ export default {
     // Resolved by sourceUrl match — does NOT apply privacy gating, so the
     // template can decide which links to surface.
     matchedAppRaw() {
-      if (!this.repo.publishing_to_appstore) return null
       const candidates = [this.repo.html_url, this.repo.url].filter(Boolean)
       if (candidates.length === 0) return null
       const normalize = (url) =>
@@ -141,10 +135,7 @@ export default {
           .replace(/\/+$/, '')
           .toLowerCase()
       const targets = new Set(candidates.map(normalize))
-      return (
-        this.applications.find((a) => targets.has(normalize(a.sourceUrl))) ||
-        null
-      )
+      return this.applications.find((a) => targets.has(normalize(a.sourceUrl))) || null
     },
 
     // True when there's a matched app, it's private, and the viewer is
@@ -289,74 +280,18 @@ export default {
   }
 }
 
-.publishing-box {
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   flex-shrink: 0;
-  border: 1px solid theme.$gray_2;
-  border-radius: 6px;
-  padding: 14px 16px;
-  min-width: 220px;
-
-  @media (max-width: 768px) {
-    width: 100%;
-  }
-}
-
-.publishing-box-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 8px;
-}
-
-.publishing-box-title {
-  font-size: 11px;
-  font-weight: 600;
-  color: theme.$gray_5;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-}
-
-.publishing-box-rows {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.status-icon-row {
-  display: flex;
-  align-items: center;
-  padding: 6px 12px;
-  border-radius: 4px;
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  white-space: nowrap;
-
-  .status-icon-label {
-    font-weight: 600;
-  }
-
-  .status-icon-state {
-    font-weight: 600;
-    margin-left: auto;
-  }
-
-  &.enabled {
-    background: rgba(theme.$status_green, 0.12);
-    color: theme.$status_green;
-  }
-
-  &.disabled {
-    background: theme.$gray_1;
-    color: theme.$gray_4;
-  }
 }
 
 .settings-button {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
   width: 28px;
   height: 28px;
   border: none;
@@ -372,17 +307,59 @@ export default {
   }
 }
 
-.app-details-link {
-  display: inline-block;
-  margin-top: 10px;
+.tracking-box {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.tracking-box-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: theme.$gray_5;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.tracking-statuses {
+  display: flex;
+  gap: 6px;
+}
+
+.status-icon-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+
+  &.enabled {
+    background: rgba(theme.$status_green, 0.12);
+    color: theme.$status_green;
+  }
+
+  &.disabled {
+    background: theme.$gray_1;
+    color: theme.$gray_4;
+  }
+}
+
+.app-details-link,
+.card-action-hint {
+  margin-left: auto;
+}
+
+.card-action-hint {
   font-size: 13px;
   font-weight: 500;
-  color: theme.$purple_2;
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-  }
+  color: theme.$gray_4;
+  font-style: italic;
 }
 
 .repo-stats {

--- a/src/components/user/code/UserGithubCode.vue
+++ b/src/components/user/code/UserGithubCode.vue
@@ -367,8 +367,8 @@ export default {
           await this.fetchRepositories()
         }
       } catch (err) {
-        if (err.response && err.response.status === 404) {
-          // No GitHub account connected - this is normal
+        if (err && err.status === 404) {
+          // No GitHub account connected — show the "Not Connected" state
           this.githubProfile = null
         } else {
           this.error = 'Failed to load GitHub profile. Please try again.'

--- a/src/components/user/code/UserGithubCode.vue
+++ b/src/components/user/code/UserGithubCode.vue
@@ -300,6 +300,17 @@ export default {
       return this.$store.state.codeReposModule.myReposLoaded
     },
 
+    applications() {
+      return this.$store.state.analysisModule?.applications || []
+    },
+
+    // Set of normalized application sourceUrls for fast lookup
+    appSourceUrls() {
+      const normalize = (url) =>
+        (url || '').replace(/\.git$/, '').replace(/\/+$/, '').toLowerCase()
+      return new Set(this.applications.map((a) => normalize(a.sourceUrl)))
+    },
+
     filteredRepositories() {
       const q = this.reposSearchQuery.trim().toLowerCase()
       let repos = this.repositories
@@ -311,11 +322,17 @@ export default {
           return name.includes(q) || desc.includes(q) || lang.includes(q)
         })
       }
-      // Sort published repos to the top
+      const normalize = (url) =>
+        (url || '').replace(/\.git$/, '').replace(/\/+$/, '').toLowerCase()
+      const appUrls = this.appSourceUrls
+      // Sort repos with a matched application first, then alphabetical
       return repos.slice().sort((a, b) => {
-        const aPublished = a.publishing_to_appstore ? 1 : 0
-        const bPublished = b.publishing_to_appstore ? 1 : 0
-        return bPublished - aPublished
+        const aMatch = [a.html_url, a.url].some((u) => appUrls.has(normalize(u))) ? 1 : 0
+        const bMatch = [b.html_url, b.url].some((u) => appUrls.has(normalize(u))) ? 1 : 0
+        if (bMatch !== aMatch) return bMatch - aMatch
+        const aName = (a.full_name || a.name || '').toLowerCase()
+        const bName = (b.full_name || b.name || '').toLowerCase()
+        return aName.localeCompare(bName)
       })
     },
 


### PR DESCRIPTION
 1. Fix duplicate GitHub register API call from concurrent OAuth listeners —                
  UserIntegrations and UserGithubV2 both mounted useGithubOAuth, causing the register
  endpoint to be called twice. Added a module-level guard so only the instance that opened   
  the popup handles the callback.
  2. Resolve package-lock merge conflicts and comment out deployments list — Cleaned up      
  leftover merge conflict markers in package-lock.json and temporarily hid the deployments
  list in PublishedAppDetail.
  3. Read cpu/memory from runtimeConfig in workflow definitions and fix GitHub 404 handling —
   The definitions API returns cpu/memory nested inside runtimeConfig, but WorkflowBuilder,
  RunDetail, and RunMonitor were reading them as top-level properties. Also fixed
  UserGithubCode to properly detect a 404 (shows "Not Connected" state instead of an error).
  4. Redesign repo cards: tracking layout, app matching, and sort order
    - Removed clickable title link
    - Moved settings cog to upper right, inline with tracking statuses
    - Renamed "Publishing Settings" to inline Discover/App Store status pills
    - "View application details" now shows based on app URL match, not just
  publishing_to_appstore flag
    - Added "Create Github release to add to app store" hint when app store is on but no
  matching application exists
    - Repos sorted by matched application first, then alphabetically