### PR TITLE
Fix crash when checkViewerType returns undefined for unmapped package…

### DIFF
--- a/src/components/viewer/ViewerPane/ViewerPane.vue
+++ b/src/components/viewer/ViewerPane/ViewerPane.vue
@@ -258,7 +258,7 @@ export default {
         viewerWrap.innerHTML = "";
       }
 
-      let viewers = this.checkViewerType(activeViewer);
+      let viewers = this.checkViewerType(activeViewer) || ['UnknownViewer'];
 
       // Check for neuroglancer-compatible viewer assets (ome-zarr, etc.)
       const pkgId = pathOr("", ["content", "id"], activeViewer);


### PR DESCRIPTION
… types
When checkViewerType returns undefined (e.g. for mri, rds, or an unrecognized ViewerSupport key), it now falls back to ['UnknownViewer'], which will then  get replaced by Neuroglancer viewers when those assets are available.       