### PR TITLE
Add docs link for NIfTI and OME-TIFF files in viewer

### DIFF
--- a/src/components/viewer/ViewerPane/ViewerPane.vue
+++ b/src/components/viewer/ViewerPane/ViewerPane.vue
@@ -1,5 +1,15 @@
 <template>
   <div class="viewer-pane" v-if="cmpViewer">
+    <div
+      v-if="showConversionHint"
+      class="viewer-info"
+    >
+      Find out more about processing an image for previewing
+      <a
+        href="https://docs.pennsieve.io/page/running-a-file-conversion-workflow-in-pennsieve"
+        target="_blank"
+      >here</a>.
+    </div>
     <div class="viewer-btn-wrapper" v-if="availableViewers.length > 1">
       <button
         v-for="viewer in availableViewers"
@@ -146,6 +156,12 @@ export default {
       apiUrl: siteConfig.apiUrl,
       viewerInstanceId: VIEWER_INSTANCE_ID,
     };
+  },
+
+  computed: {
+    showConversionHint() {
+      return this.isNifti(this.pkg) || this.isOMETiff(this.pkg)
+    },
   },
 
   watch: {
@@ -377,6 +393,22 @@ export default {
   position: relative;
   min-width: 0;
   overflow: auto;
+}
+
+.viewer-info {
+  background: #e8f4fd;
+  border: 1px solid #b8daff;
+  border-radius: 4px;
+  color: #004085;
+  font-size: 13px;
+  margin: 8px 8px 0;
+  padding: 8px 12px;
+
+  a {
+    color: #004085;
+    font-weight: 500;
+    text-decoration: underline;
+  }
 }
 
 .viewer-warning {

--- a/src/mixins/FileTypeMapper/index.js
+++ b/src/mixins/FileTypeMapper/index.js
@@ -534,6 +534,10 @@ export default {
     isLayFile: function(pkg) {
       const fileName = pathOr('', ['content', 'name'], pkg).toLowerCase()
       return fileName.endsWith('.lay')
+    },
+    isNifti: function(pkg) {
+      const fileName = pathOr('', ['content', 'name'], pkg).toLowerCase()
+      return fileName.endsWith('.nii.gz') || fileName.endsWith('.nii')
     }
   }
 


### PR DESCRIPTION
  - Shows an info banner above the viewer when browsing .nii.gz or .ome.tiff files, linking to the file         
  conversion workflow docs                                                                                      
  - Adds isNifti() helper to FileTypeMapper mixin for detecting NIfTI files  