### PR TITLE
Chat: Spotlight (Cmd-K), per-user quota meter, workflow-completion polish

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -49,6 +49,14 @@ let route = useRoute();
   <bf-download-file ref="downloadFile" />
 
   <office-365-dialog />
+
+  <!-- Spotlight compose modal — global capture surface for the org-level
+       chat. Cmd+K (or Ctrl+K) anywhere in the app opens it; user types a
+       prompt, optionally with the current page's entity auto-attached,
+       and the message is enqueued into the same conversation the
+       Insights page renders. See chat-frontend-handoff notes /
+       Spotlight.vue for the full rationale. -->
+  <chat-spotlight v-model:visible="spotlightOpen" />
 </template>
 
 <script>
@@ -65,6 +73,7 @@ import BfDownloadFile from "./components/bf-download-file/BfDownloadFile.vue";
 import request from "./mixins/request";
 import PennsieveUpload from "./components/PennsieveUpload/PennsieveUpload.vue";
 import Office365Dialog from "@/components/datasets/files/Office365Dialog/Office365Dialog.vue";
+import ChatSpotlight from "@/components/Chat/Spotlight.vue";
 import { useGetToken } from "@/composables/useGetToken";
 
 export default {
@@ -75,6 +84,7 @@ export default {
     PsAnalytics,
     BfDownloadFile,
     Office365Dialog,
+    ChatSpotlight,
   },
   mixins: [globalMessageHandler, request],
 
@@ -88,6 +98,14 @@ export default {
       showSessionTimerThreshold: 120,
       sessionLogoutThreshold: 5,
       loadingTimeout: 30000, // 30 seconds
+
+      // Spotlight (global chat compose modal) visibility. Toggled by
+      // Cmd+K / Ctrl+K anywhere in the app + by the header button.
+      // Component: ChatSpotlight (Spotlight.vue).
+      spotlightOpen: false,
+
+      // Bound handler reference so we can removeEventListener on unmount.
+      _spotlightKeyHandler: null,
     };
   },
   mounted() {
@@ -95,6 +113,41 @@ export default {
       this.getActiveOrganization,
       this.onActiveOrgChange.bind(this)
     );
+
+    // Global Cmd+K / Ctrl+K shortcut to open Spotlight. Captures on the
+    // document so it fires regardless of focused element. We don't try
+    // to filter when an input is focused — letting the user trigger
+    // Spotlight from inside a text field is desirable (e.g. quick
+    // "ask about this" from a comment box).
+    //
+    // Note: this overrides browser-level Cmd+K (address bar focus on
+    // Chrome). Intentional — matches the in-app shortcut pattern other
+    // workspace apps use (Linear, Notion, Slack).
+    this._spotlightKeyHandler = (e) => {
+      if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+        // Only intercept when the user has an active workspace. On the
+        // sign-in page we let the browser default fire.
+        if (!this.activeOrganization?.organization?.id) return;
+        e.preventDefault();
+        this.spotlightOpen = !this.spotlightOpen;
+      }
+    };
+    document.addEventListener("keydown", this._spotlightKeyHandler);
+
+    // Also expose an event-bus listener so other components (e.g. a
+    // header button) can open Spotlight without importing App.vue's
+    // state directly.
+    EventBus.$on("open-chat-spotlight", () => {
+      if (!this.activeOrganization?.organization?.id) return;
+      this.spotlightOpen = true;
+    });
+  },
+
+  beforeUnmount() {
+    if (this._spotlightKeyHandler) {
+      document.removeEventListener("keydown", this._spotlightKeyHandler);
+    }
+    EventBus.$off("open-chat-spotlight");
   },
 
   computed: {

--- a/src/components/Analysis/ComputeNodes/ComputeNodeLLMBudget.vue
+++ b/src/components/Analysis/ComputeNodes/ComputeNodeLLMBudget.vue
@@ -1,0 +1,248 @@
+<template>
+  <div class="llm-budget-content" v-loading="isLoading">
+    <p class="section-blurb">
+      Caps total LLM spend across <strong>all callers</strong> on this compute
+      node — chat <em>and</em> workflow applications. When the cap is reached,
+      every new LLM invocation is rejected at the governor until the period
+      rolls over.
+      <span class="propagation-note">
+        Changes take effect within ~60 seconds (governor caches the value).
+      </span>
+    </p>
+
+    <!-- Read-only view -->
+    <div v-if="!isEditing && config" class="budget-view">
+      <div class="info-row">
+        <span class="info-label">Budget cap:</span>
+        <span class="info-value strong">${{ Number(config.budgetUsd).toFixed(2) }}</span>
+      </div>
+      <div class="info-row">
+        <span class="info-label">Period:</span>
+        <span class="info-value">{{ periodLabel(config.budgetPeriod) }}</span>
+      </div>
+      <div v-if="isOwner" class="actions-row">
+        <bf-button class="small primary" @click="startEditing">Update Budget</bf-button>
+      </div>
+    </div>
+
+    <div v-else-if="!isEditing && !config && !isLoading" class="budget-empty">
+      No budget configured. The governor will reject all LLM calls until a cap
+      is set.
+      <div v-if="isOwner" class="actions-row">
+        <bf-button class="small primary" @click="startEditing">Set Budget</bf-button>
+      </div>
+    </div>
+
+    <!-- Edit view -->
+    <div v-if="isEditing" class="budget-edit">
+      <div class="info-row">
+        <span class="info-label">Budget cap (USD):</span>
+        <span class="info-value">
+          <el-input-number
+            v-model="form.budgetUsd"
+            :min="0"
+            :precision="2"
+            :step="10"
+            :controls="false"
+            style="width: 200px"
+          />
+        </span>
+      </div>
+      <div class="info-row">
+        <span class="info-label">Period:</span>
+        <span class="info-value">
+          <el-select v-model="form.budgetPeriod" size="default" style="width: 200px">
+            <el-option label="Daily" value="daily" />
+            <el-option label="Monthly" value="monthly" />
+          </el-select>
+        </span>
+      </div>
+      <div class="actions-row">
+        <button class="processor-edit-button" :disabled="isSaving" @click="onSave">
+          {{ isSaving ? 'Saving…' : 'Save' }}
+        </button>
+        <button class="processor-cancel-button" :disabled="isSaving" @click="cancelEditing">
+          Cancel
+        </button>
+      </div>
+    </div>
+
+    <p v-if="loadError" class="error-line">Couldn't load budget: {{ loadError.message }}</p>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { ElInputNumber, ElMessage, ElOption, ElSelect } from 'element-plus'
+import BfButton from '@/components/shared/bf-button/BfButton.vue'
+import { useNodeLlmBudgetStore } from '@/stores/nodeLlmBudgetStore'
+
+const props = defineProps({
+  nodeId: { type: String, required: true },
+  isOwner: { type: Boolean, default: false },
+})
+
+const store = useNodeLlmBudgetStore()
+
+const config = computed(() => store.getConfig(props.nodeId))
+const isLoading = computed(() => store.isLoading(props.nodeId))
+const loadError = computed(() => store.getError(props.nodeId))
+
+const isEditing = ref(false)
+const isSaving = ref(false)
+const form = ref({ budgetUsd: 0, budgetPeriod: 'daily' })
+
+function startEditing() {
+  form.value = {
+    budgetUsd: config.value?.budgetUsd ?? 0,
+    budgetPeriod: config.value?.budgetPeriod || 'daily',
+  }
+  isEditing.value = true
+}
+
+function cancelEditing() {
+  if (isSaving.value) return
+  isEditing.value = false
+}
+
+async function onSave() {
+  if (form.value.budgetUsd < 0) {
+    ElMessage.error('Budget must be non-negative')
+    return
+  }
+  isSaving.value = true
+  try {
+    await store.put(props.nodeId, {
+      budgetUsd: Number(form.value.budgetUsd),
+      budgetPeriod: form.value.budgetPeriod,
+    })
+    ElMessage.success('LLM budget updated')
+    isEditing.value = false
+  } catch (e) {
+    ElMessage.error(`Failed to update budget: ${e?.message || e}`)
+  } finally {
+    isSaving.value = false
+  }
+}
+
+function periodLabel(p) {
+  if (p === 'daily') return 'Daily (resets at 00:00 UTC)'
+  if (p === 'monthly') return 'Monthly (resets at the 1st of each month, UTC)'
+  return p
+}
+
+onMounted(() => {
+  store.fetch(props.nodeId)
+})
+</script>
+
+<style scoped lang="scss">
+@use '../../../styles/_theme.scss';
+
+.llm-budget-content {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.section-blurb {
+  margin: 0;
+  font-size: 13px;
+  color: theme.$gray_5;
+  line-height: 1.5;
+
+  strong { color: theme.$gray_6; }
+  em { font-style: italic; }
+}
+
+.propagation-note {
+  display: block;
+  margin-top: 6px;
+  font-size: 12px;
+  color: theme.$gray_4;
+}
+
+.budget-view,
+.budget-edit,
+.budget-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.budget-empty {
+  font-size: 13px;
+  color: theme.$gray_5;
+  padding: 12px;
+  background: theme.$gray_1;
+  border-radius: 6px;
+  border: 1px dashed theme.$gray_2;
+}
+
+.info-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.info-label {
+  min-width: 140px;
+  font-size: 13px;
+  color: theme.$gray_5;
+}
+
+.info-value {
+  font-size: 14px;
+  color: theme.$gray_6;
+}
+
+.info-value.strong {
+  font-weight: 600;
+  color: theme.$purple_3;
+}
+
+.actions-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.error-line {
+  margin: 8px 0 0 0;
+  font-size: 12px;
+  color: theme.$red_2;
+}
+
+.processor-edit-button {
+  background: theme.$purple_1;
+  color: theme.$white;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover { background: theme.$purple_2; }
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+}
+
+.processor-cancel-button {
+  background: theme.$white;
+  color: theme.$gray_5;
+  border: 1px solid theme.$gray_3;
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    border-color: theme.$gray_4;
+    color: theme.$gray_6;
+  }
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+}
+</style>

--- a/src/components/Analysis/ComputeNodes/ComputeNodeManagement.vue
+++ b/src/components/Analysis/ComputeNodes/ComputeNodeManagement.vue
@@ -13,6 +13,7 @@ import IconCopyDocument from '@/components/icons/IconCopyDocument.vue'
 import ComputeNodeSecrets from './ComputeNodeSecrets.vue'
 import ComputeNodeLayers from './ComputeNodeLayers.vue'
 import ComputeNodeQuotas from './ComputeNodeQuotas.vue'
+import ComputeNodeLLMBudget from './ComputeNodeLLMBudget.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -791,12 +792,29 @@ async function saveGpuConfig() {
         </div>
       </div>
 
-      <!-- LLM Cost Quotas Section. Anchor `#quotas` is what the chat
-           panel's "Manage quotas" link targets. -->
-      <div id="quotas" class="management-section" v-if="canManagePermissions">
+      <!-- Node-wide LLM budget. The SSM-backed cap the governor enforces
+           on every invocation — chat *and* workflow applications. This is
+           the only enforcement layer that catches non-chat callers, so
+           it's shown first. Per-user quotas (below) are an additional
+           cap on chat only. -->
+      <div id="llm-budget" class="management-section" v-if="canManagePermissions && computeNode?.enableLLMAccess">
         <div class="section-header">
-          <h2>LLM Cost Quotas</h2>
+          <h2>Node LLM Budget</h2>
         </div>
+        <ComputeNodeLLMBudget :node-id="nodeUuid" :is-owner="isNodeOwner" />
+      </div>
+
+      <!-- Per-user chat LLM quotas. Anchor `#quotas` is what the chat
+           panel's "Manage quotas" link targets. -->
+      <div id="quotas" class="management-section" v-if="canManagePermissions && computeNode?.enableLLMAccess">
+        <div class="section-header">
+          <h2>Per-user LLM Quotas</h2>
+        </div>
+        <p class="section-blurb">
+          Optional per-user caps applied <em>in addition to</em> the node
+          budget above. These only gate chat — workflow applications are
+          governed solely by the node budget.
+        </p>
         <ComputeNodeQuotas :node-id="nodeUuid" :is-owner="isNodeOwner" />
       </div>
 
@@ -1243,6 +1261,15 @@ async function saveGpuConfig() {
   border: 1px solid theme.$gray_2;
   margin-bottom: 24px;
   padding: 24px;
+
+  .section-blurb {
+    margin: -8px 0 16px 0;
+    font-size: 13px;
+    color: theme.$gray_5;
+    line-height: 1.5;
+
+    em { font-style: italic; }
+  }
 
   .section-header {
     display: flex;

--- a/src/components/Analysis/ComputeNodes/ComputeNodeManagement.vue
+++ b/src/components/Analysis/ComputeNodes/ComputeNodeManagement.vue
@@ -12,6 +12,7 @@ import IconRemove from '@/components/icons/IconRemove.vue'
 import IconCopyDocument from '@/components/icons/IconCopyDocument.vue'
 import ComputeNodeSecrets from './ComputeNodeSecrets.vue'
 import ComputeNodeLayers from './ComputeNodeLayers.vue'
+import ComputeNodeQuotas from './ComputeNodeQuotas.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -788,6 +789,15 @@ async function saveGpuConfig() {
             </div>
           </template>
         </div>
+      </div>
+
+      <!-- LLM Cost Quotas Section. Anchor `#quotas` is what the chat
+           panel's "Manage quotas" link targets. -->
+      <div id="quotas" class="management-section" v-if="canManagePermissions">
+        <div class="section-header">
+          <h2>LLM Cost Quotas</h2>
+        </div>
+        <ComputeNodeQuotas :node-id="nodeUuid" :is-owner="isNodeOwner" />
       </div>
 
       <!-- Access & Permissions Section -->

--- a/src/components/Analysis/ComputeNodes/ComputeNodeQuotas.vue
+++ b/src/components/Analysis/ComputeNodes/ComputeNodeQuotas.vue
@@ -1,0 +1,363 @@
+<template>
+  <div class="quotas-content" v-loading="isLoading">
+    <!-- Default-for-all-users card. Always rendered so the owner sees the
+         current platform-wide cap that applies when no per-user override
+         exists. -->
+    <div class="default-card">
+      <div class="default-card-head">
+        <div>
+          <h3 class="default-title">Default for all users</h3>
+          <p class="default-subtitle">
+            Applies to any user without their own override below. Unset
+            fields fall back to the platform safety cap.
+          </p>
+        </div>
+        <button v-if="isOwner" class="processor-edit-button" @click="openEditDefault">
+          {{ defaultRow ? 'Edit' : 'Set' }}
+        </button>
+      </div>
+      <div class="caps-grid">
+        <div class="cap-cell">
+          <span class="cap-label">Daily</span>
+          <span class="cap-value">{{ formatUsd(defaultRow?.dailyCostUsd) }}</span>
+        </div>
+        <div class="cap-cell">
+          <span class="cap-label">Monthly</span>
+          <span class="cap-value">{{ formatUsd(defaultRow?.monthlyCostUsd) }}</span>
+        </div>
+        <div class="cap-cell">
+          <span class="cap-label">Per workflow</span>
+          <span class="cap-value">{{ formatUsd(defaultRow?.perWorkflowUsd) }}</span>
+        </div>
+      </div>
+      <p v-if="defaultRow?.notes" class="notes-line">{{ defaultRow.notes }}</p>
+    </div>
+
+    <!-- Per-user overrides. Empty state when none, otherwise a compact
+         table. We deliberately skip per-row spend in v1 (one batch endpoint
+         would be needed to avoid N+1 fetches). -->
+    <div class="overrides-block">
+      <div class="overrides-head">
+        <h3 class="overrides-title">User overrides</h3>
+        <bf-button v-if="isOwner" class="small primary" @click="openAddUser">
+          Add User
+        </bf-button>
+      </div>
+
+      <div v-if="userRows.length === 0" class="overrides-empty">
+        No user-specific overrides — all users follow the default above.
+      </div>
+
+      <table v-else class="overrides-table">
+        <thead>
+          <tr>
+            <th>User</th>
+            <th>Daily</th>
+            <th>Monthly</th>
+            <th>Per workflow</th>
+            <th>Notes</th>
+            <th v-if="isOwner" class="actions-col">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="row in userRows" :key="row.userId">
+            <td>{{ getUserName(row.userId) }}</td>
+            <td>{{ formatUsd(row.dailyCostUsd) }}</td>
+            <td>{{ formatUsd(row.monthlyCostUsd) }}</td>
+            <td>{{ formatUsd(row.perWorkflowUsd) }}</td>
+            <td class="notes-cell">{{ row.notes || '' }}</td>
+            <td v-if="isOwner" class="actions-col">
+              <button class="row-action" @click="openEditUser(row)">Edit</button>
+              <button class="row-action danger" @click="confirmDelete(row)">Remove</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p v-if="loadError" class="error-line">Couldn't load quotas: {{ loadError.message }}</p>
+    </div>
+
+    <QuotaEditModal
+      v-model:visible="modalOpen"
+      :node-id="nodeId"
+      :mode="modalMode"
+      :row="modalRow"
+      :subject-label="modalSubjectLabel"
+      :available-users="availableUsersForPicker"
+      @saved="onSaved"
+    />
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { useStore } from 'vuex'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { useChatQuotaAdminStore, DEFAULT_USER_SENTINEL } from '@/stores/chatQuotaAdminStore'
+import BfButton from '@/components/shared/bf-button/BfButton.vue'
+import QuotaEditModal from './QuotaEditModal.vue'
+
+const props = defineProps({
+  nodeId: { type: String, required: true },
+  isOwner: { type: Boolean, default: false },
+})
+
+const vuexStore = useStore()
+const adminStore = useChatQuotaAdminStore()
+
+const orgMembers = computed(() => vuexStore.state?.orgMembers || [])
+const profile = computed(() => vuexStore.state?.profile)
+
+const defaultRow = computed(() => adminStore.getDefaultRow(props.nodeId))
+const userRows = computed(() => adminStore.getUserRows(props.nodeId))
+const isLoading = computed(() => adminStore.isLoading(props.nodeId))
+const loadError = computed(() => adminStore.getError(props.nodeId))
+
+// Eligible users for the picker — exclude anyone who already has an
+// override. We don't gate on "has access to the node" client-side; the
+// API enforces that the owner can set a quota on anyone (even users
+// without current access, in case access is later granted).
+const availableUsersForPicker = computed(() => {
+  const taken = new Set(userRows.value.map((r) => r.userId))
+  return orgMembers.value.filter((m) => !taken.has(m.id))
+})
+
+// Modal state.
+const modalOpen = ref(false)
+const modalMode = ref('add-user') // 'add-user' | 'edit-user' | 'edit-default'
+const modalRow = ref(null)
+const modalSubjectLabel = ref('')
+
+function openAddUser() {
+  modalMode.value = 'add-user'
+  modalRow.value = null
+  modalSubjectLabel.value = ''
+  modalOpen.value = true
+}
+
+function openEditUser(row) {
+  modalMode.value = 'edit-user'
+  modalRow.value = row
+  modalSubjectLabel.value = getUserName(row.userId)
+  modalOpen.value = true
+}
+
+function openEditDefault() {
+  modalMode.value = 'edit-default'
+  modalRow.value = defaultRow.value
+  modalSubjectLabel.value = 'All users (default)'
+  modalOpen.value = true
+}
+
+async function confirmDelete(row) {
+  try {
+    await ElMessageBox.confirm(
+      `Remove the quota override for ${getUserName(row.userId)}? They will fall back to the default.`,
+      'Remove override',
+      { type: 'warning', confirmButtonText: 'Remove', cancelButtonText: 'Cancel' },
+    )
+  } catch {
+    return
+  }
+  try {
+    await adminStore.deleteRow(props.nodeId, row.userId)
+    ElMessage.success('Override removed')
+  } catch (e) {
+    ElMessage.error(`Failed to remove: ${e?.message || e}`)
+  }
+}
+
+function onSaved() {
+  ElMessage.success('Quota saved')
+}
+
+function getUserName(userId) {
+  if (!userId) return 'Unknown'
+  if (userId === DEFAULT_USER_SENTINEL) return 'All users (default)'
+  if (profile.value && (profile.value.id === userId || profile.value.intId === userId)) {
+    return `${profile.value.firstName} ${profile.value.lastName}`.trim() || 'You'
+  }
+  const m = orgMembers.value.find((x) => x.id === userId || x.intId === userId)
+  if (m) return `${m.firstName || ''} ${m.lastName || ''}`.trim() || m.email || userId
+  return String(userId).includes(':') ? String(userId).split(':').pop() : String(userId)
+}
+
+function formatUsd(v) {
+  if (v === null || v === undefined) return '—'
+  return `$${Number(v).toFixed(2)}`
+}
+
+onMounted(() => {
+  adminStore.fetchAll(props.nodeId)
+})
+</script>
+
+<style scoped lang="scss">
+@use '../../../styles/_theme.scss';
+
+.quotas-content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.default-card {
+  border: 1px solid theme.$gray_2;
+  border-radius: 6px;
+  padding: 16px;
+  background: theme.$gray_1;
+}
+
+.default-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.default-title {
+  margin: 0 0 4px 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: theme.$purple_3;
+}
+
+.default-subtitle {
+  margin: 0;
+  font-size: 13px;
+  color: theme.$gray_5;
+}
+
+.caps-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+.cap-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.cap-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: theme.$gray_5;
+}
+
+.cap-value {
+  font-size: 16px;
+  font-weight: 600;
+  color: theme.$purple_3;
+}
+
+.notes-line {
+  margin: 12px 0 0 0;
+  font-size: 12px;
+  color: theme.$gray_5;
+  font-style: italic;
+}
+
+.overrides-block {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.overrides-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.overrides-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: theme.$gray_6;
+}
+
+.overrides-empty {
+  font-size: 13px;
+  color: theme.$gray_5;
+  padding: 12px;
+  background: theme.$gray_1;
+  border-radius: 6px;
+  border: 1px dashed theme.$gray_2;
+}
+
+.overrides-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.overrides-table th,
+.overrides-table td {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid theme.$gray_2;
+}
+
+.overrides-table th {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: theme.$gray_5;
+  font-weight: 500;
+}
+
+.actions-col {
+  width: 1%;
+  white-space: nowrap;
+}
+
+.notes-cell {
+  color: theme.$gray_5;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.row-action {
+  background: transparent;
+  border: none;
+  color: theme.$purple_2;
+  font-size: 13px;
+  padding: 2px 6px;
+  cursor: pointer;
+
+  &:hover { color: theme.$purple_3; }
+}
+
+.row-action.danger {
+  color: theme.$red_2;
+
+  &:hover { color: theme.$red_1; }
+}
+
+.error-line {
+  margin: 8px 0 0 0;
+  font-size: 12px;
+  color: theme.$red_2;
+}
+
+.processor-edit-button {
+  background: theme.$purple_1;
+  color: theme.$white;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover { background: theme.$purple_2; }
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+}
+</style>

--- a/src/components/Analysis/ComputeNodes/QuotaEditModal.vue
+++ b/src/components/Analysis/ComputeNodes/QuotaEditModal.vue
@@ -1,0 +1,251 @@
+<template>
+  <el-dialog
+    :model-value="visible"
+    @update:model-value="$emit('update:visible', $event)"
+    :title="title"
+    width="520px"
+    :close-on-click-modal="false"
+    @close="onClose"
+  >
+    <div class="quota-edit-body">
+      <p class="quota-edit-blurb">
+        Leave any field blank to fall back to the next tier
+        ({{ mode === 'edit-default' ? 'platform safety cap' : 'node default' }}).
+      </p>
+
+      <div v-if="mode === 'add-user'" class="form-row">
+        <label class="form-label">User</label>
+        <el-select
+          v-model="form.userId"
+          filterable
+          placeholder="Pick a user with access to this node"
+          style="width: 100%"
+        >
+          <el-option
+            v-for="u in availableUsers"
+            :key="u.id"
+            :label="userLabel(u)"
+            :value="u.id"
+          />
+        </el-select>
+      </div>
+
+      <div v-else class="form-row">
+        <label class="form-label">User</label>
+        <div class="form-static">{{ subjectLabel }}</div>
+      </div>
+
+      <div class="form-row">
+        <label class="form-label">Daily cap (USD)</label>
+        <el-input-number
+          v-model="form.dailyCostUsd"
+          :min="0"
+          :precision="2"
+          :step="1"
+          placeholder="No limit"
+          style="width: 100%"
+          :controls="false"
+        />
+      </div>
+
+      <div class="form-row">
+        <label class="form-label">Monthly cap (USD)</label>
+        <el-input-number
+          v-model="form.monthlyCostUsd"
+          :min="0"
+          :precision="2"
+          :step="10"
+          placeholder="No limit"
+          style="width: 100%"
+          :controls="false"
+        />
+      </div>
+
+      <div class="form-row">
+        <label class="form-label">Per-workflow cap (USD)</label>
+        <el-input-number
+          v-model="form.perWorkflowUsd"
+          :min="0"
+          :precision="2"
+          :step="0.5"
+          placeholder="No limit"
+          style="width: 100%"
+          :controls="false"
+        />
+      </div>
+
+      <div class="form-row">
+        <label class="form-label">Notes</label>
+        <el-input
+          v-model="form.notes"
+          type="textarea"
+          :rows="2"
+          placeholder="Optional — why this user has a custom cap"
+        />
+      </div>
+    </div>
+
+    <template #footer>
+      <div class="dialog-footer">
+        <el-button @click="onClose" :disabled="saving">Cancel</el-button>
+        <el-button
+          type="primary"
+          :disabled="!canSave"
+          :loading="saving"
+          @click="onSave"
+        >
+          Save
+        </el-button>
+      </div>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { ElButton, ElDialog, ElInput, ElInputNumber, ElOption, ElSelect, ElMessage } from 'element-plus'
+import { useChatQuotaAdminStore, DEFAULT_USER_SENTINEL } from '@/stores/chatQuotaAdminStore'
+
+const props = defineProps({
+  visible: { type: Boolean, default: false },
+  nodeId: { type: String, required: true },
+  // 'add-user' | 'edit-user' | 'edit-default'
+  mode: { type: String, required: true },
+  // Existing row to edit (null when mode === 'add-user').
+  row: { type: Object, default: null },
+  // Display name resolver for the subject row, used in 'edit-user' header.
+  subjectLabel: { type: String, default: '' },
+  // Org members eligible to receive an override (used by 'add-user' picker).
+  availableUsers: { type: Array, default: () => [] },
+})
+
+const emit = defineEmits(['update:visible', 'saved'])
+const adminStore = useChatQuotaAdminStore()
+
+const saving = ref(false)
+
+// el-input-number returns null when the field is cleared. We treat null as
+// "no cap on this axis" — i.e., omit / clear the field on the API call.
+const form = ref({
+  userId: '',
+  dailyCostUsd: null,
+  monthlyCostUsd: null,
+  perWorkflowUsd: null,
+  notes: '',
+})
+
+const title = computed(() => {
+  if (props.mode === 'add-user') return 'Add user override'
+  if (props.mode === 'edit-default') return 'Edit default for all users'
+  return 'Edit user override'
+})
+
+const canSave = computed(() => {
+  if (props.mode === 'add-user' && !form.value.userId) return false
+  return true
+})
+
+function userLabel(u) {
+  const name = `${u.firstName || ''} ${u.lastName || ''}`.trim()
+  return name || u.email || u.id
+}
+
+// Reset form whenever the modal becomes visible or the row prop changes.
+watch(
+  () => [props.visible, props.row, props.mode],
+  () => {
+    if (!props.visible) return
+    if (props.mode === 'edit-default') {
+      form.value = {
+        userId: DEFAULT_USER_SENTINEL,
+        dailyCostUsd: props.row?.dailyCostUsd ?? null,
+        monthlyCostUsd: props.row?.monthlyCostUsd ?? null,
+        perWorkflowUsd: props.row?.perWorkflowUsd ?? null,
+        notes: props.row?.notes ?? '',
+      }
+    } else if (props.mode === 'edit-user') {
+      form.value = {
+        userId: props.row?.userId || '',
+        dailyCostUsd: props.row?.dailyCostUsd ?? null,
+        monthlyCostUsd: props.row?.monthlyCostUsd ?? null,
+        perWorkflowUsd: props.row?.perWorkflowUsd ?? null,
+        notes: props.row?.notes ?? '',
+      }
+    } else {
+      form.value = {
+        userId: '',
+        dailyCostUsd: null,
+        monthlyCostUsd: null,
+        perWorkflowUsd: null,
+        notes: '',
+      }
+    }
+  },
+  { immediate: true },
+)
+
+function onClose() {
+  if (saving.value) return
+  emit('update:visible', false)
+}
+
+async function onSave() {
+  if (!canSave.value) return
+  saving.value = true
+  try {
+    const payload = {
+      dailyCostUsd: form.value.dailyCostUsd,
+      monthlyCostUsd: form.value.monthlyCostUsd,
+      perWorkflowUsd: form.value.perWorkflowUsd,
+      notes: form.value.notes || '',
+    }
+    await adminStore.putRow(props.nodeId, form.value.userId, payload)
+    emit('saved')
+    emit('update:visible', false)
+  } catch (e) {
+    ElMessage.error(`Failed to save quota: ${e?.message || e}`)
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style scoped lang="scss">
+@use '../../../styles/_theme.scss';
+
+.quota-edit-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.quota-edit-blurb {
+  margin: 0 0 4px 0;
+  font-size: 13px;
+  color: theme.$gray_5;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: theme.$gray_6;
+}
+
+.form-static {
+  font-size: 14px;
+  color: theme.$purple_3;
+  padding: 6px 0;
+}
+
+.dialog-footer {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+</style>

--- a/src/components/Chat/ChatImageBlock.vue
+++ b/src/components/Chat/ChatImageBlock.vue
@@ -1,0 +1,203 @@
+<template>
+  <div class="chat-image-block">
+    <div v-if="loading" class="image-skeleton" :aria-label="alt">
+      <span class="loading-text">Loading figure…</span>
+    </div>
+
+    <a
+      v-else-if="resolvedUrl"
+      :href="packageHref"
+      target="_blank"
+      rel="noopener"
+      class="image-link"
+      :aria-label="alt + ' — open package'"
+    >
+      <img
+        :src="resolvedUrl"
+        :alt="alt"
+        loading="lazy"
+        class="figure"
+        @error="onImgError"
+      />
+    </a>
+
+    <a
+      v-else
+      :href="packageHref"
+      target="_blank"
+      rel="noopener"
+      class="fallback-link"
+    >
+      View plot in package →
+    </a>
+  </div>
+</template>
+
+<script setup>
+// ChatImageBlock — renders one inline figure produced by an MCP-triggered
+// workflow (currently just plot_file). The frame carries no URL —
+// (packageNodeId, datasetNodeId, assetName, assetType) coordinates only.
+// This component resolves to a signed CloudFront URL by:
+//
+//   1. Calling the existing `fetchPackageViewerAssets` Vuex action against
+//      packages-service `/packages/assets?dataset_id=…&package_id=…`.
+//      Same call the package viewer uses for ome-zarr / neuroglancer
+//      rendering — see ViewerPane.vue.
+//   2. Picking the asset matching {name, asset_type}. When `assetName` is
+//      empty, pick the most recently created asset of the requested type.
+//   3. Building a query-string-signed URL:
+//      `${asset.asset_url}figure.png?Policy=…&Signature=…&Key-Pair-Id=…`.
+//      Query-string signing (vs. relying on the Set-Cookie machinery the
+//      assets endpoint emits) works regardless of cross-domain cookie
+//      attribute issues.
+//
+// On any error — API failure, no matching asset, image-load failure — the
+// component falls back to a plain text-link pointing at the package
+// viewer. Same UX older clients get from the plain-text `content` field.
+//
+// Filename convention: the `figure-asset` data-target writes `figure.png`
+// at the asset's S3 prefix root. If a future workflow ships a different
+// filename, the assets API would need to surface it; tracked as an open
+// question in compute-node-chat/docs/developer/inline-image-frames.md.
+
+import { computed, onMounted, ref } from 'vue'
+import { useStore } from 'vuex'
+
+const props = defineProps({
+  // The image block from AssistantMessage.blocks[]. Required fields on
+  // `source`: packageNodeId, datasetNodeId. Optional: assetName, assetType.
+  block: { type: Object, required: true },
+})
+
+const store = useStore()
+
+const loading = ref(true)
+const resolvedUrl = ref('')
+
+const alt = computed(() => props.block.alt || 'Inline figure')
+const source = computed(() => props.block.source || {})
+
+// Open-in-viewer fallback link. Matches the package-viewer route used
+// elsewhere in the app — keep this aligned if/when that route changes.
+const packageHref = computed(() => {
+  const { packageNodeId, datasetNodeId } = source.value
+  if (!packageNodeId || !datasetNodeId) return '#'
+  // Active workspace org slug lives in the route; route name matches the
+  // existing FileDetails entry point. router-link would be cleaner here
+  // but we want an external anchor so users can mouse-middle-click into a
+  // new tab without disrupting the chat session.
+  return `/datasets/${datasetNodeId}/files/${packageNodeId}`
+})
+
+const onImgError = () => {
+  // CloudFront returned an error for the signed URL — fall back to the
+  // plain link by clearing resolvedUrl. Most likely cause: figure file
+  // not at the expected filename (data-target convention drift).
+  resolvedUrl.value = ''
+}
+
+onMounted(async () => {
+  const { packageNodeId, datasetNodeId, assetName, assetType } = source.value
+
+  if (!packageNodeId || !datasetNodeId) {
+    loading.value = false
+    return
+  }
+
+  try {
+    const result = await store.dispatch('viewerModule/fetchPackageViewerAssets', {
+      datasetId: datasetNodeId,
+      packageId: packageNodeId,
+    })
+
+    if (!result?.assets?.length) {
+      loading.value = false
+      return
+    }
+
+    // Pick the right asset. Match on name + asset_type when both are
+    // specified; fall back to asset_type only if name is empty; fall back
+    // to "any ready asset" as a last resort. Sort by created_at desc so
+    // the most recent run wins when a user plotted the same package
+    // multiple times.
+    const typeFilter = assetType || 'PNG'
+    const candidates = result.assets
+      .filter((a) => a.status === 'ready')
+      .filter((a) => a.asset_type === typeFilter)
+      .filter((a) => !assetName || a.name === assetName)
+      .sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''))
+
+    const asset = candidates[0]
+    if (!asset || !asset.asset_url) {
+      loading.value = false
+      return
+    }
+
+    // Build the signed image URL. asset.asset_url ends with the asset's
+    // S3-prefix slash; the figure-asset data-target writes `figure.png`
+    // there. Sign with CloudFront query-string params from the API
+    // response.
+    const cf = result.cloudfront
+    if (!cf?.policy || !cf?.signature || !cf?.key_pair_id) {
+      // Asset exists but signing failed server-side — fall back.
+      loading.value = false
+      return
+    }
+    const qs = new URLSearchParams({
+      Policy: cf.policy,
+      Signature: cf.signature,
+      'Key-Pair-Id': cf.key_pair_id,
+    })
+    resolvedUrl.value = `${asset.asset_url}figure.png?${qs.toString()}`
+  } catch (err) {
+    // Permission denied / network / shape change — log and degrade.
+    // eslint-disable-next-line no-console
+    console.warn('[chat] ChatImageBlock: asset resolve failed', err)
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<style scoped lang="scss">
+.chat-image-block {
+  margin: 4px 0;
+}
+
+.image-skeleton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  max-width: 480px;
+  aspect-ratio: 4 / 3;
+  background: #e8eaed;
+  border-radius: 8px;
+
+  .loading-text {
+    color: #6b6b6b;
+    font-size: 13px;
+  }
+}
+
+.image-link {
+  display: inline-block;
+  line-height: 0; // collapse the anchor's text-baseline gap below the img
+}
+
+.figure {
+  display: block;
+  max-width: 480px;
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+  border: 1px solid #e0e2e6;
+}
+
+.fallback-link {
+  display: inline-block;
+  color: #5039f5;
+  font-size: 13px;
+  text-decoration: underline;
+}
+</style>

--- a/src/components/Chat/ChatMessage.vue
+++ b/src/components/Chat/ChatMessage.vue
@@ -28,6 +28,21 @@
         v-else
         :source="message.content"
       />
+
+      <!-- Persistent "background work in progress" indicators. Surfaced
+           when the assistant turn kicked off async-mode tools (e.g.
+           plot_file) whose results arrive in a later completion frame.
+           Cleared in the store when the next assistant message lands. -->
+      <div v-if="hasPendingTasks" class="pending-tasks">
+        <div
+          v-for="task in message.pendingTasks"
+          :key="task.runId || task.tool"
+          class="pending-task"
+        >
+          <span class="pending-spinner" aria-hidden="true"></span>
+          <span class="pending-label">{{ taskLabel(task) }}</span>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -49,6 +64,26 @@ const roleClass = computed(() => `role-${props.message.role}${props.message.bloc
 const hasBlocks = computed(
   () => Array.isArray(props.message.blocks) && props.message.blocks.length > 0,
 )
+
+// Background-task pills render when the assistant turn triggered one or
+// more async-mode workflow runs. Cleared by the store when the next
+// assistant message arrives in the same conversation.
+const hasPendingTasks = computed(
+  () => Array.isArray(props.message.pendingTasks) && props.message.pendingTasks.length > 0,
+)
+
+// Pick a friendly label per pending task. Backend may supply one via
+// `task.label` (typically the tool's own copy, e.g. "Plot generation
+// started in the background…"); otherwise derive from the tool name.
+function taskLabel(task) {
+  if (task?.label) return task.label
+  switch (task?.tool) {
+    case 'plot_file':
+      return 'Generating plot — you’ll be notified when it’s ready.'
+    default:
+      return 'Working on it in the background…'
+  }
+}
 </script>
 
 <style scoped lang="scss">
@@ -92,5 +127,43 @@ const hasBlocks = computed(
 
 .user-text {
   white-space: pre-wrap;
+}
+
+// Pending-task pills — one row per in-flight async workflow. Sized to
+// feel like the same-bubble continuation rather than a separate message.
+.pending-tasks {
+  margin-top: 8px;
+  padding-top: 6px;
+  border-top: 1px dashed #c9ced6;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pending-task {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #4a4a4a;
+}
+
+.pending-spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid #c9ced6;
+  border-top-color: #5039f5;
+  border-radius: 50%;
+  animation: pending-spin 0.9s linear infinite;
+  flex-shrink: 0;
+}
+
+.pending-label {
+  font-style: italic;
+}
+
+@keyframes pending-spin {
+  to { transform: rotate(360deg); }
 }
 </style>

--- a/src/components/Chat/ChatMessage.vue
+++ b/src/components/Chat/ChatMessage.vue
@@ -1,8 +1,29 @@
 <template>
   <div class="chat-message" :class="roleClass">
     <div class="bubble">
-      <!-- User turns: plain text only. No markdown, no blocks. -->
-      <span v-if="message.role !== 'assistant'" class="user-text">{{ message.content }}</span>
+      <!-- User turns: plain text + optional attachment chips above.
+           Chips come from Spotlight's current-page auto-attach (and
+           future @-mention / paste-URL flows). The chat-store keeps
+           the prose body separate from the structured attachment
+           metadata — the LLM-visible `[Attached file: …]` prefix is
+           re-derived only when the message goes onto the wire. -->
+      <template v-if="message.role !== 'assistant'">
+        <div v-if="message.attachments?.length" class="user-attachments">
+          <component
+            :is="attachmentRouteFor(att) ? 'router-link' : 'span'"
+            v-for="(att, idx) in message.attachments"
+            :key="idx"
+            :to="attachmentRouteFor(att) || undefined"
+            class="user-attachment-chip"
+            :class="`is-${att.type}`"
+            :title="attachmentTitle(att)"
+          >
+            <span class="att-icon" aria-hidden="true">{{ att.type === 'file' ? '📄' : '📁' }}</span>
+            <span class="att-name">{{ att.name || (att.type === 'file' ? 'File' : 'Dataset') }}</span>
+          </component>
+        </div>
+        <span class="user-text">{{ message.content }}</span>
+      </template>
 
       <!-- Assistant turns with structured blocks. Render in order;
            unknown block types are skipped (forward-compat). Used today
@@ -49,12 +70,56 @@
 
 <script setup>
 import { computed } from 'vue'
+import { useRoute } from 'vue-router'
 import MarkdownContent from './MarkdownContent.vue'
 import ChatImageBlock from './ChatImageBlock.vue'
 
 const props = defineProps({
   message: { type: Object, required: true },
 })
+
+const route = useRoute()
+
+// Build a vue-router target for an attachment chip so users can click
+// through to the file detail / dataset overview. Returns null when we
+// can't construct a route (missing orgId — chip degrades to a plain
+// non-clickable span via the <component :is> pattern in the template).
+function attachmentRouteFor(att) {
+  const orgId = route.params?.orgId
+  if (!orgId || !att?.datasetId) return null
+  if (att.type === 'file' && att.packageId) {
+    return {
+      name: 'file-record',
+      params: { orgId, datasetId: att.datasetId, fileId: att.packageId },
+    }
+  }
+  if (att.type === 'dataset') {
+    return {
+      name: 'dataset-overview',
+      params: { orgId, datasetId: att.datasetId },
+    }
+  }
+  return null
+}
+
+// Tooltip text for an attachment chip. Surfaces the node ID for
+// disambiguation when the chip name is ambiguous (e.g. multiple files
+// share a name across the workspace) and the underlying ID isn't
+// rendered anywhere else.
+function attachmentTitle(att) {
+  if (!att) return ''
+  if (att.type === 'file') {
+    return att.name
+      ? `${att.name} (${att.packageId}) — open file details`
+      : `Open ${att.packageId}`
+  }
+  if (att.type === 'dataset') {
+    return att.name
+      ? `${att.name} (${att.datasetId}) — open dataset`
+      : `Open ${att.datasetId}`
+  }
+  return ''
+}
 
 const roleClass = computed(() => `role-${props.message.role}${props.message.blocked ? ' blocked' : ''}`)
 
@@ -127,6 +192,56 @@ function taskLabel(task) {
 
 .user-text {
   white-space: pre-wrap;
+}
+
+// Attachment chips inside a user message bubble. Sit above the prose
+// body, sized small so they read as "this is metadata I attached" not
+// "this is the message". Both linked + non-linked variants — degrade
+// to a plain span when the chip can't resolve a clickable route.
+.user-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.user-attachment-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 4px;
+  // The bubble is theme.$purple_3 (navy); chip uses a translucent
+  // white tint that picks up the bubble color rather than fighting
+  // it. Theme-agnostic but tonally consistent.
+  background: rgba(theme.$white, 0.18);
+  border: none;
+  color: theme.$white;
+  text-decoration: none;
+  max-width: 100%;
+
+  .att-icon {
+    flex-shrink: 0;
+    font-size: 11px;
+  }
+  .att-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 200px;
+  }
+
+  // Hover treatment only on the link variant — the non-clickable
+  // <span> fallback gets no hover affordance.
+  &[href] {
+    cursor: pointer;
+
+    &:hover {
+      background: rgba(theme.$white, 0.28);
+    }
+  }
 }
 
 // Pending-task pills — one row per in-flight async workflow. Sized to

--- a/src/components/Chat/ChatMessage.vue
+++ b/src/components/Chat/ChatMessage.vue
@@ -1,8 +1,33 @@
 <template>
   <div class="chat-message" :class="roleClass">
     <div class="bubble">
-      <MarkdownContent v-if="message.role === 'assistant'" :source="message.content" />
-      <span v-else class="user-text">{{ message.content }}</span>
+      <!-- User turns: plain text only. No markdown, no blocks. -->
+      <span v-if="message.role !== 'assistant'" class="user-text">{{ message.content }}</span>
+
+      <!-- Assistant turns with structured blocks. Render in order;
+           unknown block types are skipped (forward-compat). Used today
+           for inline figure rendering on workflow-completion frames. -->
+      <template v-else-if="hasBlocks">
+        <template v-for="(block, idx) in message.blocks" :key="idx">
+          <MarkdownContent
+            v-if="block.type === 'text'"
+            :source="block.text || ''"
+          />
+          <ChatImageBlock
+            v-else-if="block.type === 'image'"
+            :block="block"
+          />
+          <!-- else: unknown block type — render nothing (forward-compat) -->
+        </template>
+      </template>
+
+      <!-- Default assistant render path: plain markdown content. This is
+           what every sync chat turn uses; only the workflow-completion
+           webhooks have started emitting `blocks` so far. -->
+      <MarkdownContent
+        v-else
+        :source="message.content"
+      />
     </div>
   </div>
 </template>
@@ -10,12 +35,20 @@
 <script setup>
 import { computed } from 'vue'
 import MarkdownContent from './MarkdownContent.vue'
+import ChatImageBlock from './ChatImageBlock.vue'
 
 const props = defineProps({
   message: { type: Object, required: true },
 })
 
 const roleClass = computed(() => `role-${props.message.role}${props.message.blocked ? ' blocked' : ''}`)
+
+// Structured-content rendering kicks in when the backend supplied a
+// non-empty `blocks` array. Older backends (and most sync chat turns)
+// don't set this field; we fall back to plain markdown of `content`.
+const hasBlocks = computed(
+  () => Array.isArray(props.message.blocks) && props.message.blocks.length > 0,
+)
 </script>
 
 <style scoped lang="scss">

--- a/src/components/Chat/ChatPanel.vue
+++ b/src/components/Chat/ChatPanel.vue
@@ -70,29 +70,6 @@
       </div>
     </div>
 
-    <!-- Recently-discussed datasets — datasets the assistant invoked
-         tools against this conversation. Source: backend's
-         `referencedDatasets` field on each `message` frame
-         (chat-integration.md §3.2.2). -->
-    <div v-if="referencedDatasets.length" class="discussed-row">
-      <span class="discussed-label">Discussed:</span>
-      <template v-for="ds in referencedDatasets" :key="ds.id">
-        <a
-          v-if="ds.resolved"
-          class="discussed-chip"
-          :href="datasetUrl(ds)"
-          target="_blank"
-          rel="noopener noreferrer"
-          :title="`Open ${ds.name}`"
-        >{{ ds.name }}</a>
-        <span
-          v-else
-          class="discussed-chip unresolved"
-          :title="ds.id"
-        >{{ ds.name }}</span>
-      </template>
-    </div>
-
     <div v-if="lastError" class="error-banner">
       <span>{{ errorLabel }}</span>
       <button type="button" class="dismiss" @click="dismissError" aria-label="Dismiss">×</button>

--- a/src/components/Chat/ChatPanel.vue
+++ b/src/components/Chat/ChatPanel.vue
@@ -58,6 +58,41 @@
       </div>
     </div>
 
+    <!-- Per-user LLM cost quota meter for the active compute node.
+         Collapsed by default — auto-expands once when the user hits the
+         "over" warning level. Hidden until the node id resolves or a
+         fetch starts. -->
+    <ChatQuotaHeader
+      v-if="selectedNodeId"
+      :quota="chatQuota"
+      :loading="chatQuotaLoading"
+      :error="chatQuotaError"
+      :manage-href="manageQuotasHref"
+    />
+
+    <!-- Recently-discussed datasets — datasets the assistant invoked
+         tools against this conversation. Source: backend's
+         `referencedDatasets` field on each `message` frame
+         (chat-integration.md §3.2.2). -->
+    <div v-if="referencedDatasets.length" class="discussed-row">
+      <span class="discussed-label">Discussed:</span>
+      <template v-for="ds in referencedDatasets" :key="ds.id">
+        <a
+          v-if="ds.resolved"
+          class="discussed-chip"
+          :href="datasetUrl(ds)"
+          target="_blank"
+          rel="noopener noreferrer"
+          :title="`Open ${ds.name}`"
+        >{{ ds.name }}</a>
+        <span
+          v-else
+          class="discussed-chip unresolved"
+          :title="ds.id"
+        >{{ ds.name }}</span>
+      </template>
+    </div>
+
     <div v-if="lastError" class="error-banner">
       <span>{{ errorLabel }}</span>
       <button type="button" class="dismiss" @click="dismissError" aria-label="Dismiss">×</button>
@@ -138,6 +173,8 @@ import ChatStarterPrompts from './ChatStarterPrompts.vue'
 import ComputeNodePicker from './ComputeNodePicker.vue'
 import EventBus from '@/utils/event-bus'
 import { cmdKLabel } from '@/utils/platform'
+import ChatQuotaHeader from './ChatQuotaHeader.vue'
+import { useChatQuota } from '@/composables/useChatQuota'
 
 const props = defineProps({
   mode: { type: String, required: true }, // 'workspace' | 'dataset'
@@ -261,6 +298,33 @@ const pending = computed(() => convo.value?.pending || false)
 const activeTools = computed(() => convo.value?.activeTools || [])
 const connectionState = computed(() => convo.value?.connectionState || 'idle')
 const lastError = computed(() => convo.value?.lastError || null)
+
+// Per-(user, compute-node) LLM cost quota meter. Fetches on mount, on node
+// change, and after each assistant turn (pending: true → false). See
+// useChatQuota for the orchestration; the data comes from account-service's
+// /effective endpoint.
+const {
+  quota: chatQuota,
+  loading: chatQuotaLoading,
+  error: chatQuotaError,
+} = useChatQuota(selectedNodeId, pending)
+
+// "Manage quotas" deep-link visibility. Only compute-node owners see it —
+// for non-owners the link would 403 on click. We treat node.ownerId being
+// the current user as the proxy; admins-with-manage-access can still get
+// in through the same page if they navigate there directly.
+const currentUserNodeId = computed(() => vuexStore.state?.profile?.id || '')
+const isSelectedNodeOwner = computed(() => {
+  if (!selectedNode.value || !currentUserNodeId.value) return false
+  return selectedNode.value.ownerId === currentUserNodeId.value
+})
+const manageQuotasHref = computed(() => {
+  if (!isSelectedNodeOwner.value || !selectedNode.value) return ''
+  // Settings page lives outside this PR — link target is the planned URL.
+  // Until the page ships the link is hidden anyway (isSelectedNodeOwner is
+  // gated AND the href is empty for non-owners).
+  return `/${props.orgId}/settings/compute/${selectedNode.value.uuid}#quotas`
+})
 
 const canSend = computed(() => !pending.value && !!selectedNodeId.value)
 

--- a/src/components/Chat/ChatPanel.vue
+++ b/src/components/Chat/ChatPanel.vue
@@ -33,37 +33,29 @@
           </svg>
         </button>
       </div>
-      <button
-        v-if="messageCount"
-        type="button"
-        class="header-btn"
-        @click="onResetConversation"
-        aria-label="Start a new conversation"
-        title="New conversation"
-      >New chat</button>
-    </div>
-
-    <!-- Recently-discussed datasets — datasets the assistant invoked
-         tools against this conversation. Source: backend's
-         `referencedDatasets` field on each `message` frame
-         (chat-integration.md §3.2.2). -->
-    <div v-if="referencedDatasets.length" class="discussed-row">
-      <span class="discussed-label">Discussed:</span>
-      <template v-for="ds in referencedDatasets" :key="ds.id">
-        <a
-          v-if="ds.resolved"
-          class="discussed-chip"
-          :href="datasetUrl(ds)"
-          target="_blank"
-          rel="noopener noreferrer"
-          :title="`Open ${ds.name}`"
-        >{{ ds.name }}</a>
-        <span
-          v-else
-          class="discussed-chip unresolved"
-          :title="ds.id"
-        >{{ ds.name }}</span>
-      </template>
+      <div class="header-actions">
+        <!-- Quick-compose trigger. The Spotlight modal is also bound to
+             Cmd+K (Ctrl+K on non-Mac); this button is the discoverable
+             affordance for users who don't reach for keyboard shortcuts.
+             EventBus hook is registered in App.vue. -->
+        <button
+          type="button"
+          class="header-btn quick-compose"
+          @click="openSpotlight"
+          :aria-label="`Quick compose (${cmdKLabel})`"
+          :title="`Quick compose from any page (${cmdKLabel})`"
+        >
+          <span class="kbd-inline" aria-hidden="true">{{ cmdKLabel }}</span>
+        </button>
+        <button
+          v-if="messageCount"
+          type="button"
+          class="header-btn"
+          @click="onResetConversation"
+          aria-label="Start a new conversation"
+          title="New conversation"
+        >New chat</button>
+      </div>
     </div>
 
     <div v-if="lastError" class="error-banner">
@@ -105,7 +97,9 @@
           <p class="empty-title">{{ emptyTitle }}</p>
           <ChatStarterPrompts :prompts="starterPrompts" :disabled="!canSend" @pick="onPickPrompt" />
           <p v-if="mode === 'workspace'" class="empty-hint">
-            Tip: type <kbd>@</kbd> in your message to mention a specific dataset.
+            Tip: type <kbd>@</kbd> to mention a specific dataset, or press
+            <kbd>{{ cmdKLabel }}</kbd> from any page to compose with the
+            current file or dataset attached.
           </p>
         </div>
       </template>
@@ -142,6 +136,8 @@ import ChatMessageList from './ChatMessageList.vue'
 import ChatInput from './ChatInput.vue'
 import ChatStarterPrompts from './ChatStarterPrompts.vue'
 import ComputeNodePicker from './ComputeNodePicker.vue'
+import EventBus from '@/utils/event-bus'
+import { cmdKLabel } from '@/utils/platform'
 
 const props = defineProps({
   mode: { type: String, required: true }, // 'workspace' | 'dataset'
@@ -239,56 +235,14 @@ const convo = computed(() => chatStore.getConversation(key.value))
 const messages = computed(() => convo.value?.messages || [])
 const messageCount = computed(() => messages.value.length)
 
-// Backend supplies `referencedDatasets` on each `message` frame
-// (chat-integration.md §3.2.2) — dataset node IDs the assistant
-// actually invoked tools against. Union across all assistant turns
-// to get the conversation-wide set, then resolve names from the
-// workspace dataset list.
+// Workspace dataset list — sourced from Vuex (loaded once per org
+// when the user lands in the workspace). Used by the @-mention
+// autocomplete in ChatInput; the per-conversation `referencedDatasets`
+// field on each `message` frame is still recorded on the message in
+// the chat store for forward-compat, but we no longer render a
+// separate "Discussed:" pill row — attachments and references read
+// inline in the thread now, mirroring how other chat UIs work.
 const workspaceDatasets = computed(() => vuexStore.state?.datasets || [])
-
-const datasetById = computed(() => {
-  const map = new Map()
-  for (const ds of workspaceDatasets.value) {
-    const id = ds?.content?.id
-    if (id) map.set(id, ds.content)
-  }
-  return map
-})
-
-const referencedDatasets = computed(() => {
-  // Show chips only in workspace mode — in dataset mode the page
-  // already names the focused dataset in its heading.
-  if (props.mode !== 'workspace') return []
-  if (!messages.value.length) return []
-
-  // Walk newest → oldest so most-recently-referenced sits first.
-  const seen = new Set()
-  const out = []
-  for (let i = messages.value.length - 1; i >= 0 && out.length < 5; i--) {
-    const refs = messages.value[i]?.referencedDatasets || []
-    for (const nodeId of refs) {
-      if (seen.has(nodeId)) continue
-      seen.add(nodeId)
-      const meta = datasetById.value.get(nodeId)
-      out.push({
-        id: nodeId,
-        intId: meta?.intId,
-        // Fall back to the node ID's UUID suffix when the dataset
-        // isn't in the loaded page (e.g. beyond paginated limit) —
-        // still recognizable, link won't work, chip is greyed out.
-        name: meta?.name || nodeId.split(':').pop().slice(0, 8) + '…',
-        resolved: !!meta,
-      })
-      if (out.length >= 5) break
-    }
-  }
-  return out
-})
-
-const datasetUrl = (ds) => {
-  if (!ds?.intId) return '#'
-  return `/${props.orgId}/datasets/${ds.intId}/overview`
-}
 
 // Datasets surfaced in the @-mention autocomplete in ChatInput.
 // Only meaningful in workspace mode — in dataset mode the chat is
@@ -361,6 +315,12 @@ const onPickPrompt = (prompt) => onSubmit(prompt)
 
 const onResetConversation = () => chatStore.resetConversation(key.value)
 
+// Open the global Spotlight compose modal (the same one bound to
+// Cmd+K). Available from inside the chat panel too as a discoverable
+// trigger for users who don't reach for keyboard shortcuts. App.vue
+// owns the modal's visibility state; we just emit the open signal.
+const openSpotlight = () => EventBus.$emit('open-chat-spotlight')
+
 onMounted(() => {
   // Just load the node list; don't auto-open the picker. Users hit the
   // picker when they pick a node from the empty state, click the
@@ -398,59 +358,6 @@ watch(nodes, (list) => {
   padding: 8px 16px;
   font-size: 12px;
   color: #666;
-}
-
-.discussed-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 6px;
-  padding: 0 16px 8px;
-  font-size: 12px;
-}
-
-.discussed-label {
-  color: #888;
-  font-weight: 500;
-  margin-right: 2px;
-}
-
-.discussed-chip {
-  display: inline-flex;
-  align-items: center;
-  background: #f1f3f5;
-  color: theme.$purple_3;
-  border: 1px solid transparent;
-  border-radius: 12px;
-  padding: 2px 10px;
-  font-size: 12px;
-  font-weight: 500;
-  text-decoration: none;
-  max-width: 200px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  transition: background 0.15s ease, border-color 0.15s ease;
-
-  &:hover {
-    background: #e8edf5;
-    border-color: theme.$purple_3;
-    text-decoration: none;
-  }
-
-  // Datasets whose names we couldn't resolve from the loaded
-  // dataset list (e.g., beyond the paginated page) get a muted,
-  // non-link treatment.
-  &.unresolved {
-    color: #888;
-    font-style: italic;
-    cursor: default;
-
-    &:hover {
-      background: #f1f3f5;
-      border-color: transparent;
-    }
-  }
 }
 
 .context-info {
@@ -502,6 +409,31 @@ watch(nodes, (list) => {
   cursor: pointer;
 
   &:hover { background: #f0f2f5; }
+}
+
+// Quick-compose button is a tighter, icon-style trigger. The label
+// ("⌘K" / "Ctrl+K") doubles as both the affordance and the keyboard-
+// shortcut hint, so there's no need for a separate label.
+.quick-compose {
+  padding: 4px 6px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+
+  .kbd-inline {
+    font-size: 11px;
+    color: #6b7280;
+    background: #f3f4f6;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    line-height: 1.4;
+  }
+
+  &:hover .kbd-inline {
+    background: #e5e7eb;
+    color: #1f2937;
+  }
 }
 
 .error-banner {

--- a/src/components/Chat/ChatPanel.vue
+++ b/src/components/Chat/ChatPanel.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="chat-panel">
-    <!-- Sub-bar: chat context + compute node + new-chat affordance. The
-         "Ask Pennsieve" title lives in the dashboard widget header (via
-         the layout item's componentName) — not duplicated here. The
-         context label is optional (e.g., the dataset overview already
-         shows the dataset name in the page heading). -->
+    <!-- Sub-bar: chat context + compute node + per-user quota meter +
+         new-chat affordance. The "Ask Pennsieve" title lives in the
+         dashboard widget header (via the layout item's componentName) —
+         not duplicated here. The context label is optional (e.g., the
+         dataset overview already shows the dataset name in the page
+         heading). -->
     <div class="chat-context">
       <div class="context-info">
         <span v-if="contextLabel" class="context-label">{{ contextLabel }}</span>
@@ -32,6 +33,17 @@
             <path d="M2 4l3 3 3-3" stroke="currentColor" stroke-width="1.5" fill="none" />
           </svg>
         </button>
+        <!-- Per-user LLM cost quota meter — inline-compact next to the
+             compute-pill. Expanded panel pops out below the chat-context
+             row via absolute positioning (see ChatQuotaHeader.vue). -->
+        <ChatQuotaHeader
+          v-if="selectedNodeId"
+          inline
+          :quota="chatQuota"
+          :loading="chatQuotaLoading"
+          :error="chatQuotaError"
+          :manage-href="manageQuotasHref"
+        />
       </div>
       <div class="header-actions">
         <!-- Quick-compose trigger. The Spotlight modal is also bound to
@@ -57,18 +69,6 @@
         >New chat</button>
       </div>
     </div>
-
-    <!-- Per-user LLM cost quota meter for the active compute node.
-         Collapsed by default — auto-expands once when the user hits the
-         "over" warning level. Hidden until the node id resolves or a
-         fetch starts. -->
-    <ChatQuotaHeader
-      v-if="selectedNodeId"
-      :quota="chatQuota"
-      :loading="chatQuotaLoading"
-      :error="chatQuotaError"
-      :manage-href="manageQuotasHref"
-    />
 
     <!-- Recently-discussed datasets — datasets the assistant invoked
          tools against this conversation. Source: backend's
@@ -422,6 +422,11 @@ watch(nodes, (list) => {
   padding: 8px 16px;
   font-size: 12px;
   color: #666;
+  // Anchor for the quota meter's absolutely-positioned expanded panel.
+  // The collapsed trigger sits inline next to the compute pill; opening
+  // it drops the breakdown popover down below this row without pushing
+  // the message list.
+  position: relative;
 }
 
 .context-info {
@@ -438,7 +443,7 @@ watch(nodes, (list) => {
   gap: 4px;
   background: #fff;
   border: 1px solid #d1d5db;
-  border-radius: 16px;
+  border-radius: 4px;
   padding: 1px 8px;
   font-size: 12px;
   color: #1c1c1c;

--- a/src/components/Chat/ChatPanel.vue
+++ b/src/components/Chat/ChatPanel.vue
@@ -438,17 +438,27 @@ watch(nodes, (list) => {
 .dot-sep { color: #c5cbd6; }
 
 .compute-pill {
+  // Reset native button defaults first; the explicit font-size +
+  // line-height + height below are what actually decides the pill's
+  // geometry. `font: inherit` is a shorthand that resets font-size and
+  // line-height, so it must come BEFORE those overrides.
+  font: inherit;
   display: inline-flex;
   align-items: center;
   gap: 4px;
   background: #fff;
   border: 1px solid #d1d5db;
   border-radius: 4px;
-  padding: 1px 8px;
+  // Padding intentionally 0 vertical — height is set explicitly so the
+  // compute-pill and the inline quota-meter pill match pixel-for-pixel.
+  // Height must agree with .inline .collapsed-row in ChatQuotaHeader.vue.
+  padding: 0 8px;
+  height: 24px;
+  box-sizing: border-box;
   font-size: 12px;
+  line-height: 1;
   color: #1c1c1c;
   cursor: pointer;
-  font: inherit;
 
   &:hover { border-color: theme.$purple_3; color: theme.$purple_3; }
 

--- a/src/components/Chat/ChatPanel.vue
+++ b/src/components/Chat/ChatPanel.vue
@@ -71,7 +71,16 @@
     </div>
 
     <div v-if="lastError" class="error-banner">
-      <span>{{ errorLabel }}</span>
+      <span>
+        {{ errorLabel }}
+        <a
+          v-if="isQuotaError"
+          href="https://docs.pennsieve.io/docs/registering-a-compute-resource"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="error-cta"
+        >Set up your own compute node →</a>
+      </span>
       <button type="button" class="dismiss" @click="dismissError" aria-label="Dismiss">×</button>
     </div>
 
@@ -297,10 +306,7 @@ const isSelectedNodeOwner = computed(() => {
 })
 const manageQuotasHref = computed(() => {
   if (!isSelectedNodeOwner.value || !selectedNode.value) return ''
-  // Settings page lives outside this PR — link target is the planned URL.
-  // Until the page ships the link is hidden anyway (isSelectedNodeOwner is
-  // gated AND the href is empty for non-owners).
-  return `/${props.orgId}/settings/compute/${selectedNode.value.uuid}#quotas`
+  return `/${props.orgId}/analysis/compute-nodes/${selectedNode.value.uuid}#quotas`
 })
 
 const canSend = computed(() => !pending.value && !!selectedNodeId.value)
@@ -312,9 +318,14 @@ const inputPlaceholder = computed(() => {
   return props.mode === 'dataset' ? 'Ask about this dataset…' : 'Ask about your workspace…'
 })
 
+const isQuotaError = computed(() => lastError.value?.code === 'QUOTA_EXCEEDED')
+
 const errorLabel = computed(() => {
   if (!lastError.value) return ''
   const code = lastError.value.code || ''
+  if (code === 'QUOTA_EXCEEDED') {
+    return lastError.value.message || "You've reached your LLM cost limit on this compute node."
+  }
   if (code === 'WS_CLOSE_1006') {
     return "Couldn't reach the chat service. Please try again in a moment, or contact your workspace admin if this persists."
   }
@@ -511,6 +522,15 @@ watch(nodes, (list) => {
   line-height: 1;
   cursor: pointer;
   padding: 0 4px;
+}
+
+.error-cta {
+  display: inline-block;
+  margin-left: 6px;
+  color: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+  &:hover { opacity: 0.85; }
 }
 
 .empty-state {

--- a/src/components/Chat/ChatQuotaHeader.vue
+++ b/src/components/Chat/ChatQuotaHeader.vue
@@ -82,6 +82,17 @@
         <span class="axis-source">{{ sourceLabel(quota.perWorkflowSource) }}</span>
       </div>
 
+      <div v-if="level === 'over'" class="own-node-cta">
+        Reached your limit on this compute node? You can register your own
+        compute resource to keep working.
+        <a
+          href="https://docs.pennsieve.io/docs/registering-a-compute-resource"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="own-node-link"
+        >Set up your own compute node →</a>
+      </div>
+
       <div class="footnote">
         Daily resets at 00:00 UTC.
         <a v-if="manageHref" :href="manageHref" class="manage-link">Manage quotas →</a>
@@ -480,5 +491,25 @@ const ariaLabel = computed(() => {
 .error-note {
   color: #8a2222;
   font-size: 11px;
+}
+
+.own-node-cta {
+  margin-top: 8px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: rgba(theme.$red_2, 0.06);
+  border: 1px solid rgba(theme.$red_2, 0.2);
+  color: theme.$gray_6;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.own-node-link {
+  display: inline-block;
+  margin-top: 4px;
+  color: theme.$purple_3;
+  text-decoration: none;
+  font-weight: 500;
+  &:hover { text-decoration: underline; }
 }
 </style>

--- a/src/components/Chat/ChatQuotaHeader.vue
+++ b/src/components/Chat/ChatQuotaHeader.vue
@@ -19,9 +19,15 @@
         <template v-if="loading && !quota">Checking your LLM quota…</template>
         <template v-else-if="!quota">Quota unavailable</template>
         <template v-else>
-          <strong>${{ fmt(quota.dailySpentUsd) }}</strong>
-          <span class="sep">/</span>
-          ${{ fmt(quota.dailyCostUsd) }}<span class="suffix"> today</span>
+          <!--
+            Tokens, not dollars, in the collapsed pill — less in-your-face
+            than money on every chat. The progress bar still reflects
+            dollar-utilization (the actual enforcement axis), so the bar
+            growth matches reality; the caption is a softer "usage stat"
+            instead of a bill running in front of the user. Full dollar
+            breakdown is one click away in the expanded panel.
+          -->
+          <strong>{{ fmtTokens(quota.dailyTokens) }}</strong><span class="suffix"> tokens today</span>
         </template>
       </span>
       <span v-if="level === 'over'" class="pill pill-over">Limit reached</span>
@@ -45,6 +51,7 @@
           <span class="axis-label">Daily</span>
           <span class="axis-numbers">
             <strong>${{ fmt(quota.dailySpentUsd) }}</strong> / ${{ fmt(quota.dailyCostUsd) }}
+            <span class="axis-tokens">({{ fmtTokens(quota.dailyTokens) }} tokens)</span>
           </span>
         </div>
         <span class="meter" aria-hidden="true">
@@ -58,6 +65,7 @@
           <span class="axis-label">Monthly</span>
           <span class="axis-numbers">
             <strong>${{ fmt(quota.monthlySpentUsd) }}</strong> / ${{ fmt(quota.monthlyCostUsd) }}
+            <span class="axis-tokens">({{ fmtTokens(quota.monthlyTokens) }} tokens)</span>
           </span>
         </div>
         <span class="meter" aria-hidden="true">
@@ -127,6 +135,22 @@ const fmt = (n) => {
   // wide on micro-amounts.
   if (n >= 1) return n.toFixed(2)
   return n.toFixed(Math.min(4, Math.max(2, Math.ceil(-Math.log10(Math.max(n, 1e-6))) + 2)))
+}
+
+// fmtTokens compacts a raw token count for the collapsed caption.
+// We want a short, glanceable number that doesn't dominate the pill
+// — "1,234" feels precise but cluttered next to a small bar; "1.2k"
+// or "1.23M" reads better. Thresholds:
+//   <1000      → "823"
+//   <10000     → "1.2k"
+//   <1000000   → "47k"   (no decimals once we're past 5 digits)
+//   ≥1000000   → "1.4M"
+const fmtTokens = (n) => {
+  if (typeof n !== 'number' || n < 0) return '0'
+  if (n < 1000) return String(Math.floor(n))
+  if (n < 10000) return (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k'
+  if (n < 1_000_000) return Math.round(n / 1000) + 'k'
+  return (n / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'M'
 }
 
 const NEAR = 0.8
@@ -421,6 +445,15 @@ const ariaLabel = computed(() => {
     color: #222;
     font-weight: 600;
   }
+}
+
+// Secondary metric: raw token count next to the dollar figure. Quieter
+// than the cost (which is the actual enforcement axis) — small,
+// neutral gray, sits in parens.
+.axis-tokens {
+  color: #999;
+  font-size: 11px;
+  margin-left: 4px;
 }
 
 .axis-source {

--- a/src/components/Chat/ChatQuotaHeader.vue
+++ b/src/components/Chat/ChatQuotaHeader.vue
@@ -1,0 +1,375 @@
+<template>
+  <div
+    v-if="show"
+    class="quota-header"
+    :class="[`level-${level}`, { expanded }]"
+  >
+    <!-- Collapsed row — always visible. -->
+    <button
+      type="button"
+      class="collapsed-row"
+      :aria-expanded="expanded"
+      :aria-label="ariaLabel"
+      @click="toggle"
+    >
+      <span class="meter" :class="`level-${level}`" aria-hidden="true">
+        <span class="meter-fill" :style="{ width: dailyPct + '%' }" />
+      </span>
+      <span class="caption">
+        <template v-if="loading && !quota">Checking your LLM quota…</template>
+        <template v-else-if="!quota">Quota unavailable</template>
+        <template v-else>
+          <strong>${{ fmt(quota.dailySpentUsd) }}</strong>
+          <span class="sep">/</span>
+          ${{ fmt(quota.dailyCostUsd) }} today
+        </template>
+      </span>
+      <span v-if="level === 'over'" class="pill pill-over">Limit reached</span>
+      <span v-else-if="level === 'near'" class="pill pill-near">Near limit</span>
+      <svg
+        class="chevron"
+        :class="{ flipped: expanded }"
+        width="10"
+        height="10"
+        viewBox="0 0 10 10"
+        aria-hidden="true"
+      >
+        <path d="M2 4l3 3 3-3" stroke="currentColor" stroke-width="1.5" fill="none" />
+      </svg>
+    </button>
+
+    <!-- Expanded panel — three axes + source attribution + manage link. -->
+    <div v-if="expanded && quota" class="expanded">
+      <div class="axis">
+        <div class="axis-head">
+          <span class="axis-label">Daily</span>
+          <span class="axis-numbers">
+            <strong>${{ fmt(quota.dailySpentUsd) }}</strong> / ${{ fmt(quota.dailyCostUsd) }}
+          </span>
+        </div>
+        <span class="meter" aria-hidden="true">
+          <span class="meter-fill" :class="`level-${dailyLevel}`" :style="{ width: dailyPct + '%' }" />
+        </span>
+        <span class="axis-source">{{ sourceLabel(quota.dailySource) }}</span>
+      </div>
+
+      <div class="axis">
+        <div class="axis-head">
+          <span class="axis-label">Monthly</span>
+          <span class="axis-numbers">
+            <strong>${{ fmt(quota.monthlySpentUsd) }}</strong> / ${{ fmt(quota.monthlyCostUsd) }}
+          </span>
+        </div>
+        <span class="meter" aria-hidden="true">
+          <span class="meter-fill" :class="`level-${monthlyLevel}`" :style="{ width: monthlyPct + '%' }" />
+        </span>
+        <span class="axis-source">{{ sourceLabel(quota.monthlySource) }}</span>
+      </div>
+
+      <div class="axis flat">
+        <div class="axis-head">
+          <span class="axis-label">Per workflow</span>
+          <span class="axis-numbers">max ${{ fmt(quota.perWorkflowUsd) }}</span>
+        </div>
+        <span class="axis-source">{{ sourceLabel(quota.perWorkflowSource) }}</span>
+      </div>
+
+      <div class="footnote">
+        Daily resets at 00:00 UTC.
+        <a v-if="manageHref" :href="manageHref" class="manage-link">Manage quotas →</a>
+      </div>
+      <div v-if="error" class="error-note">Couldn't refresh: {{ error.message }}</div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+
+// ChatQuotaHeader surfaces the user's per-(user, compute-node) LLM cost
+// quota at the top of the chat panel. Collapsed by default — auto-expands
+// once when the user hits the "over" warning level so they understand why
+// the next turn was blocked. Pure presentation; the parent panel wires up
+// the data via useChatQuota.
+const props = defineProps({
+  // The quota state returned by /effective. null while loading or after a
+  // fetch error; the component renders a "Checking your LLM quota…" caption
+  // in that case.
+  quota: { type: Object, default: null },
+  // True while a fetch is in flight. Only used to distinguish "still
+  // loading" from "no quota state available" in the collapsed caption.
+  loading: { type: Boolean, default: false },
+  // { message: string } when the most recent fetch failed. Surfaced in the
+  // expanded panel as a subtle note; doesn't block the meter rendering with
+  // the previous quota state.
+  error: { type: Object, default: null },
+  // Optional deep-link target shown only to compute-node owners (parent
+  // gates visibility based on the user's ownership of the active node).
+  manageHref: { type: String, default: '' },
+})
+
+const expanded = ref(false)
+const autoExpandedOnce = ref(false)
+
+const toggle = () => {
+  expanded.value = !expanded.value
+}
+
+const fmt = (n) => {
+  if (typeof n !== 'number') return '0.00'
+  // 2 decimal places for the common case (whole dollars look weirder than
+  // $1.00 when sitting next to $0.42). Cap at 4 to keep the bar from going
+  // wide on micro-amounts.
+  if (n >= 1) return n.toFixed(2)
+  return n.toFixed(Math.min(4, Math.max(2, Math.ceil(-Math.log10(Math.max(n, 1e-6))) + 2)))
+}
+
+const NEAR = 0.8
+const OVER = 1.0
+const axisLevel = (spent, cap) => {
+  if (!cap || cap <= 0) return 'ok'
+  const u = spent / cap
+  if (u >= OVER) return 'over'
+  if (u >= NEAR) return 'near'
+  return 'ok'
+}
+const dailyLevel = computed(() =>
+  props.quota ? axisLevel(props.quota.dailySpentUsd, props.quota.dailyCostUsd) : 'ok',
+)
+const monthlyLevel = computed(() =>
+  props.quota ? axisLevel(props.quota.monthlySpentUsd, props.quota.monthlyCostUsd) : 'ok',
+)
+// Overall level is the worse of the two — drives the header tint + auto-open.
+const level = computed(() => {
+  const lv = [dailyLevel.value, monthlyLevel.value]
+  if (lv.includes('over')) return 'over'
+  if (lv.includes('near')) return 'near'
+  return 'ok'
+})
+
+// Auto-expand once on hitting the "over" state so users see exactly which
+// axis tripped without having to click the chevron. Only auto-opens once
+// per session — if the user closes the panel after being warned, we don't
+// nag them by reopening on the next render.
+watch(level, (lv) => {
+  if (lv === 'over' && !autoExpandedOnce.value) {
+    expanded.value = true
+    autoExpandedOnce.value = true
+  }
+})
+
+const dailyPct = computed(() => {
+  if (!props.quota) return 0
+  const u = props.quota.dailyCostUsd
+    ? props.quota.dailySpentUsd / props.quota.dailyCostUsd
+    : 0
+  return Math.min(100, Math.max(0, Math.round(u * 100)))
+})
+const monthlyPct = computed(() => {
+  if (!props.quota) return 0
+  const u = props.quota.monthlyCostUsd
+    ? props.quota.monthlySpentUsd / props.quota.monthlyCostUsd
+    : 0
+  return Math.min(100, Math.max(0, Math.round(u * 100)))
+})
+
+const sourceLabel = (src) => {
+  switch (src) {
+    case 'user':
+      return 'Custom limit set for you'
+    case 'node-default':
+      return 'Set by the compute node owner'
+    case 'platform-safety':
+      return 'Pennsieve default (no custom limit set)'
+    default:
+      return ''
+  }
+}
+
+const show = computed(() => props.loading || !!props.quota || !!props.error)
+const ariaLabel = computed(() => {
+  if (!props.quota) return 'LLM quota'
+  return `LLM quota — $${fmt(props.quota.dailySpentUsd)} of $${fmt(props.quota.dailyCostUsd)} used today`
+})
+</script>
+
+<style scoped lang="scss">
+@use 'sass:color';
+@use '../../styles/theme';
+
+.quota-header {
+  border-bottom: 1px solid #ececec;
+  font-size: 12px;
+  background: #fafbfc;
+
+  &.level-near {
+    background: color.mix(#fff3d6, #fafbfc, 60%);
+  }
+  &.level-over {
+    background: color.mix(#fde0e0, #fafbfc, 55%);
+  }
+}
+
+.collapsed-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 6px 16px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+  color: #444;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.02);
+  }
+  &:focus-visible {
+    outline: 2px solid theme.$purple_3;
+    outline-offset: -2px;
+  }
+}
+
+.caption {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  strong {
+    color: #222;
+    font-weight: 600;
+  }
+  .sep {
+    color: #aaa;
+    margin: 0 3px;
+  }
+}
+
+.meter {
+  display: inline-block;
+  position: relative;
+  width: 120px;
+  height: 6px;
+  border-radius: 3px;
+  background: #e6e8eb;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.meter-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: theme.$purple_3;
+  border-radius: 3px;
+  transition: width 0.25s ease;
+
+  &.level-near {
+    background: #d99416;
+  }
+  &.level-over {
+    background: #c64545;
+  }
+}
+.collapsed-row .meter.level-near .meter-fill {
+  background: #d99416;
+}
+.collapsed-row .meter.level-over .meter-fill {
+  background: #c64545;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 10px;
+  padding: 1px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.pill-near {
+  background: #fff3d6;
+  color: #8a5a0c;
+}
+.pill-over {
+  background: #fde0e0;
+  color: #8a2222;
+}
+
+.chevron {
+  flex-shrink: 0;
+  color: #888;
+  transition: transform 0.15s ease;
+  &.flipped {
+    transform: rotate(180deg);
+  }
+}
+
+.expanded {
+  padding: 8px 16px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-top: 1px solid #eee;
+}
+
+.axis {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  .meter {
+    width: 100%;
+  }
+
+  &.flat .meter {
+    display: none;
+  }
+}
+
+.axis-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.axis-label {
+  font-weight: 600;
+  color: #444;
+}
+
+.axis-numbers {
+  color: #666;
+  font-variant-numeric: tabular-nums;
+  strong {
+    color: #222;
+    font-weight: 600;
+  }
+}
+
+.axis-source {
+  color: #888;
+  font-size: 11px;
+}
+
+.footnote {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 2px;
+  color: #888;
+}
+
+.manage-link {
+  color: theme.$purple_3;
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.error-note {
+  color: #8a2222;
+  font-size: 11px;
+}
+</style>

--- a/src/components/Chat/ChatQuotaHeader.vue
+++ b/src/components/Chat/ChatQuotaHeader.vue
@@ -2,7 +2,7 @@
   <div
     v-if="show"
     class="quota-header"
-    :class="[`level-${level}`, { expanded }]"
+    :class="[`level-${level}`, { expanded, inline }]"
   >
     <!-- Collapsed row — always visible. -->
     <button
@@ -21,7 +21,7 @@
         <template v-else>
           <strong>${{ fmt(quota.dailySpentUsd) }}</strong>
           <span class="sep">/</span>
-          ${{ fmt(quota.dailyCostUsd) }} today
+          ${{ fmt(quota.dailyCostUsd) }}<span class="suffix"> today</span>
         </template>
       </span>
       <span v-if="level === 'over'" class="pill pill-over">Limit reached</span>
@@ -106,6 +106,11 @@ const props = defineProps({
   // Optional deep-link target shown only to compute-node owners (parent
   // gates visibility based on the user's ownership of the active node).
   manageHref: { type: String, default: '' },
+  // When true, render the collapsed trigger as a compact inline pill
+  // (sized to match the compute-node selector next to it) and pop the
+  // expanded panel out as an absolutely-positioned dropdown below. When
+  // false (default), the header is a full-width banner block.
+  inline: { type: Boolean, default: false },
 })
 
 const expanded = ref(false)
@@ -208,6 +213,25 @@ const ariaLabel = computed(() => {
   &.level-over {
     background: color.mix(#fde0e0, #fafbfc, 55%);
   }
+
+  // Inline mode: the trigger sits next to the compute-pill (compact pill
+  // styling, no banner background or bottom border). The expanded panel
+  // pops out as an absolutely-positioned dropdown anchored to the parent
+  // .chat-context row (which sets `position: relative` — we deliberately
+  // do NOT add it here, so the absolute child escapes up to that row).
+  &.inline {
+    border-bottom: 0;
+    background: transparent;
+
+    &.level-near .collapsed-row {
+      border-color: #d99416;
+      color: #8a5a0c;
+    }
+    &.level-over .collapsed-row {
+      border-color: #c64545;
+      color: #8a2222;
+    }
+  }
 }
 
 .collapsed-row {
@@ -229,6 +253,38 @@ const ariaLabel = computed(() => {
     outline: 2px solid theme.$purple_3;
     outline-offset: -2px;
   }
+
+  // Compact inline form — matches compute-pill geometry (1px 8px,
+  // border-radius 4px, 1px border). Meter shrinks and the caption
+  // becomes "X / Y" without the trailing "today" word so the whole
+  // thing stays one short pill.
+  .inline & {
+    width: auto;
+    gap: 6px;
+    padding: 1px 8px;
+    background: #fff;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    color: #1c1c1c;
+
+    &:hover {
+      background: #fff;
+      border-color: theme.$purple_3;
+      color: theme.$purple_3;
+    }
+  }
+}
+
+// Compact meter inside the inline trigger.
+.inline .collapsed-row .meter {
+  width: 60px;
+  height: 5px;
+}
+
+// "today" suffix is dropped in inline mode — the caption shows just
+// "$X / $Y" so the pill stays small. See the v-if in the template.
+.inline .caption .suffix {
+  display: none;
 }
 
 .caption {
@@ -311,6 +367,23 @@ const ariaLabel = computed(() => {
   flex-direction: column;
   gap: 10px;
   border-top: 1px solid #eee;
+}
+
+// Inline mode: float the expanded panel as a dropdown below the
+// chat-context row. Anchored to .chat-context (which sets
+// position: relative). Width matches the parent row so the meters
+// have room to breathe.
+.inline .expanded {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 16px;
+  right: 16px;
+  background: #fff;
+  border: 1px solid #e6e8eb;
+  border-top: 1px solid #e6e8eb;
+  border-radius: 6px;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+  z-index: 10;
 }
 
 .axis {

--- a/src/components/Chat/ChatQuotaHeader.vue
+++ b/src/components/Chat/ChatQuotaHeader.vue
@@ -254,14 +254,17 @@ const ariaLabel = computed(() => {
     outline-offset: -2px;
   }
 
-  // Compact inline form — matches compute-pill geometry (1px 8px,
-  // border-radius 4px, 1px border). Meter shrinks and the caption
-  // becomes "X / Y" without the trailing "today" word so the whole
-  // thing stays one short pill.
+  // Compact inline form — must match the compute-pill geometry in
+  // ChatPanel.vue pixel-for-pixel so the two sit on the same baseline.
+  // Padding is 0 vertical with an explicit height; line-height: 1 to
+  // keep the text from inflating the row.
   .inline & {
     width: auto;
     gap: 6px;
-    padding: 1px 8px;
+    padding: 0 8px;
+    height: 24px;
+    box-sizing: border-box;
+    line-height: 1;
     background: #fff;
     border: 1px solid #d1d5db;
     border-radius: 4px;

--- a/src/components/Chat/Spotlight.vue
+++ b/src/components/Chat/Spotlight.vue
@@ -1,0 +1,580 @@
+<template>
+  <!-- Teleport to body so the modal isn't constrained by parent
+       overflow / z-index / transform contexts that vary page to page.
+       Owning the DOM ourselves (vs. <el-dialog>) avoids the global
+       dialog stylesheet leaking into our chrome. -->
+  <Teleport to="body">
+    <transition name="spotlight-fade">
+      <div
+        v-if="visible"
+        class="spotlight-backdrop"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Ask Insights"
+        @mousedown.self="close"
+      >
+        <div class="spotlight-modal" @mousedown.stop>
+          <!-- Optional chip row, only when current page has a known
+               entity AND the user hasn't dismissed it for this compose.
+               Removing the chip lets the user ask a workspace-level
+               question from a dataset / file page without dragging in
+               that context. Reset on next modal open. -->
+          <div v-if="contextChip" class="chip-row">
+            <div class="context-chip">
+              <span class="context-icon" aria-hidden="true">
+                {{ contextChip.icon }}
+              </span>
+              <span class="context-name">{{ contextChip.label }}</span>
+              <button
+                type="button"
+                class="chip-remove"
+                :aria-label="`Remove ${contextChip.label} attachment`"
+                @click="dismissChip"
+              >×</button>
+            </div>
+            <span class="kbd-badge" aria-hidden="true">{{ cmdKLabel }}</span>
+          </div>
+
+          <!-- Compute-node guardrail. -->
+          <div v-if="!hasComputeNode" class="setup-required">
+            <span>Set up your chat compute node first.</span>
+            <router-link
+              :to="{ name: 'workspace-insights', params: { orgId } }"
+              class="setup-link"
+              @click="close"
+            >
+              Open Insights →
+            </router-link>
+          </div>
+
+          <!-- Input row — the prominent thing. Textarea looks like a
+               single growing input until the user types past one line.
+               Send button sits inline on the right. -->
+          <div v-else class="input-row">
+            <textarea
+              ref="textareaRef"
+              v-model="prompt"
+              class="spotlight-input"
+              rows="1"
+              :placeholder="placeholder"
+              @keydown="onKeydown"
+              @input="autoResize"
+            />
+            <button
+              type="button"
+              class="send-btn"
+              :disabled="!canSend"
+              aria-label="Send and open chat"
+              @click="onSendAndNavigate"
+            >
+              <span aria-hidden="true">→</span>
+            </button>
+            <!-- ⌘K badge only shows here when no chip row above
+                 absorbed it (i.e. no current-page entity). -->
+            <span v-if="!contextChip" class="kbd-badge" aria-hidden="true">⌘K</span>
+          </div>
+
+          <div class="hint-row">
+            <kbd>Enter</kbd> send + open chat ·
+            <kbd>{{ cmdKLabel === '⌘K' ? '⌘↩' : 'Ctrl+↩' }}</kbd>
+            send + stay here ·
+            <kbd>⇧↩</kbd> newline ·
+            <kbd>Esc</kbd> close
+          </div>
+        </div>
+      </div>
+    </transition>
+  </Teleport>
+</template>
+
+<script setup>
+// Spotlight — global compose modal for the org-level chat.
+//
+// Design (see chat-integration follow-up):
+//
+//   - Single org-wide chat session lives on the Insights page. Spotlight
+//     is a CAPTURE surface, not a second chat surface — its only job is
+//     to enqueue a user turn into that same conversation.
+//   - The current-page entity (file detail page → file; dataset page →
+//     dataset; nothing elsewhere) gets auto-attached as a context chip
+//     and inlined into the prompt body as a structured `[Attached file:
+//     <name> (<packageId>) in dataset <datasetId>]` prefix.
+//   - Fire-and-forget: send → toast → close. User navigates to Insights
+//     via the left-nav link to see the assistant's reply.
+//
+// Implementation note: we own the modal DOM directly via <Teleport> +
+// raw markup rather than going through <el-dialog>. Reason: the global
+// styles/element/_dialog.scss partial that several pages import applies
+// a heavy header/footer styling that bled into Spotlight and made the
+// modal look broken on those pages. Owning the DOM gives us a clean,
+// page-independent visual.
+
+import { computed, nextTick, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { useStore as useVuexStore } from 'vuex'
+import { ElMessage } from 'element-plus'
+import { pathOr } from 'ramda'
+
+import { useChatStore, getRememberedComputeNode } from '@/stores/chatStore'
+import { useChatSocket } from '@/composables/useChatSocket'
+import { useRouteContext } from '@/composables/useRouteContext'
+import { cmdKLabel } from '@/utils/platform'
+
+const props = defineProps({
+  visible: { type: Boolean, required: true },
+})
+
+const emit = defineEmits(['update:visible'])
+
+const vuex = useVuexStore()
+const router = useRouter()
+const chatStore = useChatStore()
+const { sendUserMessage } = useChatSocket()
+const { context } = useRouteContext()
+
+const prompt = ref('')
+const textareaRef = ref(null)
+
+// When true, suppress the auto-attached context chip for this compose.
+// Set by the chip's ✕ button. Reset every time the modal opens so the
+// default "attach what the user is currently looking at" is the starting
+// state on every invocation.
+const chipDismissed = ref(false)
+const dismissChip = () => {
+  chipDismissed.value = true
+}
+
+// ---------------------------------------------------------------------------
+// Active workspace + remembered compute node
+// ---------------------------------------------------------------------------
+
+const orgId = computed(() =>
+  pathOr('', ['organization', 'id'], vuex.getters.activeOrganization),
+)
+
+const computeNodeId = computed(() => {
+  if (!orgId.value) return null
+  return getRememberedComputeNode(orgId.value)
+})
+
+const hasComputeNode = computed(() => Boolean(computeNodeId.value))
+
+// ---------------------------------------------------------------------------
+// Context chip
+// ---------------------------------------------------------------------------
+
+// Effective context attached to this compose — null when the user
+// dismissed the chip OR when there's no current-page entity in the
+// first place. Used for both render (chip visible / hidden) and send
+// (formatPromptWithContext skips when null).
+const effectiveContext = computed(() =>
+  chipDismissed.value ? null : context.value,
+)
+
+const contextChip = computed(() => {
+  const c = effectiveContext.value
+  if (!c) return null
+  if (c.type === 'file') {
+    return { icon: '📄', label: c.name || 'This file' }
+  }
+  if (c.type === 'dataset') {
+    return { icon: '📁', label: c.name || 'This dataset' }
+  }
+  return null
+})
+
+const placeholder = computed(() => {
+  const c = effectiveContext.value
+  if (c?.type === 'file') return 'Ask about this file…'
+  if (c?.type === 'dataset') return 'Ask about this dataset…'
+  return 'Ask anything about your workspace…'
+})
+
+// ---------------------------------------------------------------------------
+// Send path
+// ---------------------------------------------------------------------------
+
+const canSend = computed(
+  () => hasComputeNode.value && Boolean(prompt.value.trim()),
+)
+
+// dispatchPrompt — shared core of both send-modes (fire-and-forget +
+// send-and-navigate). Captures the compose state synchronously, closes
+// the modal immediately, then fires the WebSocket send in the
+// background.
+//
+// Ordering note: `close()` runs BEFORE the WS send so that:
+//   1. The user can't double-fire by hitting Enter again while the
+//      send is in-flight (the textarea is gone after close).
+//   2. Resetting `prompt.value` to '' also flips `canSend` to false —
+//      belt-and-suspenders guard if a stray Enter event still fires
+//      against the textarea during Vue's render-flush window.
+//   3. The visible latency between Enter and modal close stays at
+//      zero regardless of WS send speed.
+//
+// The send itself is fire-and-forget. The chat store's
+// markFailedTurn path surfaces any error in the chat panel's error
+// banner when the user reaches Insights; no modal-side error UI is
+// needed for the optimistic fire-and-forget UX.
+//
+// Attachments are passed as structured metadata (NOT inlined into the
+// prompt text) so the chat thread can render them as chips above the
+// user's prose. useChatSocket re-derives the `[Attached file: …]`
+// prefix for the wire when serializing — see serializeUserContent.
+const dispatchPrompt = () => {
+  const payload = {
+    mode: 'workspace',
+    orgId: orgId.value,
+    datasetId: null,
+    computeNodeId: computeNodeId.value,
+    content: prompt.value.trim(),
+    attachments: contextToAttachments(effectiveContext.value),
+  }
+  prompt.value = ''
+  close()
+  // Fire-and-forget; .catch keeps an unhandled-rejection warning out
+  // of the console. Real failures land in the store.
+  sendUserMessage(payload).catch(() => {})
+}
+
+// Default send — fire-and-forget. User stays on whatever page they
+// were composing from; toast confirms the message landed.
+const onSend = () => {
+  if (!canSend.value) return
+  dispatchPrompt()
+  ElMessage({
+    type: 'success',
+    message: 'Sent to your Insights chat',
+    duration: 3000,
+  })
+}
+
+// Cmd/Ctrl+Enter alternative — send AND immediately navigate to
+// Insights so the user can watch the reply unfold. Same dispatch path;
+// the only difference is the post-send router push.
+const onSendAndNavigate = () => {
+  if (!canSend.value) return
+  dispatchPrompt()
+  router.push({ name: 'workspace-insights', params: { orgId: orgId.value } })
+}
+
+// Translate the route-context shape (file or dataset) into the
+// chat-store attachments shape (an array). Kept tiny — same fields,
+// just normalized into the form the store + socket expect.
+function contextToAttachments(ctx) {
+  if (!ctx) return []
+  if (ctx.type === 'file') {
+    return [{
+      type: 'file',
+      packageId: ctx.packageId,
+      datasetId: ctx.datasetId,
+      name: ctx.name || null,
+    }]
+  }
+  if (ctx.type === 'dataset') {
+    return [{
+      type: 'dataset',
+      datasetId: ctx.datasetId,
+      name: ctx.name || null,
+    }]
+  }
+  return []
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle / keyboard
+// ---------------------------------------------------------------------------
+
+const close = () => emit('update:visible', false)
+
+const onKeydown = (e) => {
+  if (e.key !== 'Enter' || e.isComposing) return
+  // Shift+Enter inserts a newline (default textarea behavior).
+  if (e.shiftKey) return
+  e.preventDefault()
+  // Enter = send + navigate to Insights so the user can see the
+  // reply. Cmd+Enter / Ctrl+Enter = fire-and-forget (stay on
+  // current page). Enter as the primary "do the thing" action
+  // matches what users expect when they think of the modal as
+  // "compose a message to the assistant".
+  if (e.metaKey || e.ctrlKey) {
+    onSend()
+  } else {
+    onSendAndNavigate()
+  }
+}
+
+// Auto-grow the textarea as the user types so the modal stays compact
+// at rest (one line) but expands gracefully for longer prompts. Caps at
+// ~6 rows worth so a runaway paste doesn't push the modal off-screen.
+const autoResize = () => {
+  const el = textareaRef.value
+  if (!el) return
+  el.style.height = 'auto'
+  const max = 160 // px ~= 6 lines at 14px / 1.4 line-height + padding
+  el.style.height = Math.min(el.scrollHeight, max) + 'px'
+}
+
+// Esc handler at the backdrop level (Teleported to body, so document
+// keydown listener mounted with the modal). Bound while visible, removed
+// when closed so we don't intercept Esc when the modal is hidden.
+let escHandler = null
+watch(
+  () => props.visible,
+  async (open) => {
+    if (open) {
+      await nextTick()
+      textareaRef.value?.focus()
+      escHandler = (e) => {
+        if (e.key === 'Escape') {
+          e.preventDefault()
+          close()
+        }
+      }
+      document.addEventListener('keydown', escHandler)
+    } else {
+      prompt.value = ''
+      // Reset auto-grown height so the next open starts at 1 row.
+      if (textareaRef.value) textareaRef.value.style.height = ''
+      // Restore default-attach behavior on the next invocation —
+      // dismiss is intentionally per-compose, not persistent.
+      chipDismissed.value = false
+      if (escHandler) {
+        document.removeEventListener('keydown', escHandler)
+        escHandler = null
+      }
+    }
+  },
+)
+
+// Pre-warm the conversation entry so chat-store side state exists by
+// the time the user hits send. ensureConversation is idempotent.
+watch(
+  () => [orgId.value, computeNodeId.value, props.visible],
+  ([newOrg, newNode, isOpen]) => {
+    if (!isOpen || !newOrg || !newNode) return
+    chatStore.ensureConversation({
+      mode: 'workspace',
+      orgId: newOrg,
+      datasetId: null,
+      computeNodeId: newNode,
+    })
+  },
+)
+</script>
+
+<style scoped lang="scss">
+@use '../../styles/theme';
+
+// Backdrop: subtle dimmer, modal hovers near the top third of the
+// viewport like Raycast / Linear's command palette — not center, so the
+// user's eye lands on it immediately without it covering page content
+// they were looking at. Z-index outranks Element Plus overlays
+// (defaults ~2000).
+.spotlight-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 5000;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 14vh;
+  background: rgba(15, 23, 42, 0.28);
+  backdrop-filter: blur(2px);
+}
+
+.spotlight-modal {
+  width: 560px;
+  max-width: calc(100vw - 32px);
+  background: theme.$white;
+  border-radius: 12px;
+  // Shadow uses navy tint (theme.$purple_3 = #011F5B) so the depth
+  // cue matches the brand color rather than a generic black drop.
+  box-shadow:
+    0 24px 48px rgba(theme.$purple_3, 0.22),
+    0 6px 14px rgba(theme.$purple_3, 0.08);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+// Top chip row — only rendered when a current-page entity attached.
+// Sits flush against the input row below; the whole modal reads as one
+// connected surface.
+.chip-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px 0;
+  gap: 8px;
+}
+
+.context-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px 4px 10px;
+  background: theme.$purple_tint;
+  border: none;
+  border-radius: 4px;
+  font-size: 12px;
+  min-width: 0;
+
+  .context-icon {
+    flex-shrink: 0;
+    font-size: 11px;
+  }
+  .context-name {
+    font-weight: 600;
+    color: theme.$gray_6;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 280px;
+  }
+  .chip-remove {
+    background: transparent;
+    border: none;
+    color: theme.$gray_4;
+    font-size: 16px;
+    line-height: 1;
+    padding: 0 4px;
+    cursor: pointer;
+    border-radius: 4px;
+    flex-shrink: 0;
+
+    // Subtle darken on hover via a navy overlay — stays in palette
+    // without jumping to a contrast-heavy $purple_0_7 fill.
+    &:hover {
+      background: rgba(theme.$purple_3, 0.08);
+      color: theme.$gray_6;
+    }
+  }
+}
+
+// Compact ⌘K badge. Doubles as the close affordance — clicking it
+// dismisses the modal. Saves a separate ✕ button.
+.kbd-badge {
+  font-size: 11px;
+  color: theme.$gray_5;
+  background: theme.$gray_0;
+  padding: 2px 7px;
+  border-radius: 4px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  flex-shrink: 0;
+}
+
+// Main input row — the single tall element of the modal. Input grows
+// to fill horizontal space; send button is a small icon-sized button on
+// the right.
+.input-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+}
+
+.spotlight-input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 15px;
+  line-height: 1.4;
+  resize: none;
+  padding: 4px 0;
+  color: theme.$gray_6;
+  // 1-row height by default; autoResize() bumps it up to 160px max.
+  // Don't expose vertical resize handles.
+  min-height: 22px;
+
+  &::placeholder {
+    color: theme.$gray_4;
+  }
+}
+
+.send-btn {
+  background: theme.$purple_3;
+  color: theme.$white;
+  border: none;
+  width: 30px;
+  height: 30px;
+  border-radius: 4px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0;
+  line-height: 1;
+
+  &:disabled {
+    background: theme.$gray_2;
+    color: theme.$gray_4;
+    cursor: not-allowed;
+  }
+
+  &:not(:disabled):hover {
+    filter: brightness(1.15);
+  }
+}
+
+// Compute-node setup-required state. Replaces the input-row entirely.
+// Uses the yellow_tint / yellow_2 pair so the warning reads against
+// rest of platform's yellow-status convention.
+.setup-required {
+  margin: 10px 14px 0;
+  padding: 10px 14px;
+  background: theme.$yellow_tint;
+  border: 1px solid theme.$yellow_2;
+  color: theme.$gray_6;
+  border-radius: 4px;
+  font-size: 13px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: baseline;
+
+  .setup-link {
+    color: theme.$purple_3;
+    font-weight: 600;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+// Subtle hint footer — separator above, very small text.
+.hint-row {
+  padding: 6px 14px 10px;
+  border-top: 1px solid theme.$gray_1;
+  font-size: 11px;
+  color: theme.$gray_4;
+
+  kbd {
+    background: theme.$gray_1;
+    border: 1px solid theme.$gray_2;
+    border-radius: 3px;
+    padding: 0 4px;
+    font-size: 10px;
+    font-family: inherit;
+    color: theme.$gray_5;
+    margin: 0 1px;
+  }
+}
+
+// Enter/exit transition for the backdrop+modal combo.
+.spotlight-fade-enter-active,
+.spotlight-fade-leave-active {
+  transition: opacity 120ms ease;
+}
+.spotlight-fade-enter-from,
+.spotlight-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/composables/useChatQuota.js
+++ b/src/composables/useChatQuota.js
@@ -1,0 +1,70 @@
+// @/composables/useChatQuota.js
+//
+// Glue between the ChatPanel and chatQuotaStore. The panel passes in two
+// reactive refs — the active compute node id and the per-turn `pending` flag
+// — and this composable handles the orchestration:
+//
+//   1. Initial fetch when the node id resolves.
+//   2. Re-fetch every time `pending` transitions true → false (i.e. an
+//      assistant turn just completed, so the daily / monthly aggregates
+//      almost certainly changed in account-service's chat_user_usage table).
+//   3. Re-fetch when the node id changes (user switched compute node mid-
+//      session — likely a different cap applies).
+//   4. Periodic safety-net refresh (60s) so the meter doesn't drift if the
+//      user has the panel open without sending turns, e.g. while an owner
+//      adjusts the cap in another tab.
+//
+// The store dedupes in-flight requests, so overlapping triggers are safe.
+
+import { watch, onMounted, onBeforeUnmount } from 'vue'
+import { useChatQuotaStore } from '@/stores/chatQuotaStore'
+
+// 60 seconds. Quota tables update on every chat turn (sub-second after the
+// AssistantMessage lands) and on owner CRUD (rare). 60s is well within any
+// "stale enough to matter" threshold and keeps the request rate trivial.
+const POLL_INTERVAL_MS = 60 * 1000
+
+export function useChatQuota(nodeIdRef, pendingRef) {
+  const quotaStore = useChatQuotaStore()
+
+  // Mirror the active node into the store so component slots that don't
+  // have direct access to nodeIdRef can still read activeQuota.
+  watch(
+    nodeIdRef,
+    (id) => {
+      quotaStore.setActiveNode(id)
+      if (id) quotaStore.fetch(id)
+    },
+    { immediate: true },
+  )
+
+  // Re-fetch when an assistant turn finishes. We don't bother refreshing on
+  // turn START — the values haven't changed yet, and the store update would
+  // race with the assistant frame arriving. The end-of-turn trigger gives us
+  // the just-incremented totals on the next paint.
+  watch(pendingRef, (now, prev) => {
+    if (prev === true && now === false && nodeIdRef.value) {
+      quotaStore.fetch(nodeIdRef.value)
+    }
+  })
+
+  // Safety-net periodic refresh. setInterval is cleared on unmount; the
+  // store's in-flight dedupe means overlapping with a turn-end refresh is
+  // benign (the periodic call short-circuits onto the in-flight promise).
+  let intervalId = null
+  onMounted(() => {
+    intervalId = window.setInterval(() => {
+      if (nodeIdRef.value) quotaStore.fetch(nodeIdRef.value)
+    }, POLL_INTERVAL_MS)
+  })
+  onBeforeUnmount(() => {
+    if (intervalId !== null) window.clearInterval(intervalId)
+  })
+
+  return {
+    quota: quotaStore.activeQuota,
+    loading: quotaStore.activeLoading,
+    error: quotaStore.activeError,
+    refresh: () => nodeIdRef.value && quotaStore.fetch(nodeIdRef.value),
+  }
+}

--- a/src/composables/useChatQuota.js
+++ b/src/composables/useChatQuota.js
@@ -16,7 +16,7 @@
 //
 // The store dedupes in-flight requests, so overlapping triggers are safe.
 
-import { watch, onMounted, onBeforeUnmount } from 'vue'
+import { computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useChatQuotaStore } from '@/stores/chatQuotaStore'
 
 // 60 seconds. Quota tables update on every chat turn (sub-second after the
@@ -61,10 +61,15 @@ export function useChatQuota(nodeIdRef, pendingRef) {
     if (intervalId !== null) window.clearInterval(intervalId)
   })
 
+  // Wrap each accessor in computed so consumers receive reactive refs.
+  // Destructuring `quotaStore.activeQuota` directly would capture the value
+  // at call time and silently break reactivity — Pinia setup-style stores
+  // auto-unwrap computeds on member access, so the consumer would never see
+  // store updates and the UI would stay blank after the fetch completes.
   return {
-    quota: quotaStore.activeQuota,
-    loading: quotaStore.activeLoading,
-    error: quotaStore.activeError,
+    quota: computed(() => quotaStore.activeQuota),
+    loading: computed(() => quotaStore.activeLoading),
+    error: computed(() => quotaStore.activeError),
     refresh: () => nodeIdRef.value && quotaStore.fetch(nodeIdRef.value),
   }
 }

--- a/src/composables/useChatSocket.js
+++ b/src/composables/useChatSocket.js
@@ -90,7 +90,7 @@ export function useChatSocket() {
     return ws
   }
 
-  const sendUserMessage = async ({ mode, orgId, datasetId, computeNodeId, content }) => {
+  const sendUserMessage = async ({ mode, orgId, datasetId, computeNodeId, content, attachments }) => {
     const key = contextKey({ mode, orgId, datasetId })
     const trimmed = (content || '').trim()
     if (!trimmed) return
@@ -99,8 +99,14 @@ export function useChatSocket() {
     // appendUserMessage no-ops on the first send (the convo doesn't
     // exist until connect() runs below), and we end up sending an
     // empty messages array (server rejects with EMPTY_REQUEST).
+    //
+    // `attachments` (optional, from Spotlight's current-page auto-attach)
+    // is stored on the message as structured metadata so the UI can
+    // render chips. The LLM-visible prefix is re-derived when we build
+    // the wire payload below — keeping the rendered + serialized forms
+    // separate.
     store.ensureConversation({ mode, orgId, datasetId, computeNodeId })
-    store.appendUserMessage(key, trimmed)
+    store.appendUserMessage(key, trimmed, attachments)
 
     let ws = sockets.get(key)
     if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -134,7 +140,17 @@ export function useChatSocket() {
     }
 
     const convo = store.getConversation(key)
-    const messages = (convo?.messages || []).map((m) => ({ role: m.role, content: m.content }))
+    // Walk the conversation and serialize each turn for the wire.
+    // For user messages that carry structured attachments (Spotlight
+    // auto-attach today; @-mentions etc. later), prepend the
+    // `[Attached file: …]` / `[Attached dataset: …]` prefix so the
+    // model has the structured node IDs to work with. The store keeps
+    // the chip + body separate; this is the only place the two forms
+    // merge.
+    const messages = (convo?.messages || []).map((m) => ({
+      role: m.role,
+      content: m.role === 'user' ? serializeUserContent(m) : m.content,
+    }))
     // Defensive: never send an empty messages array. The server rejects
     // it with EMPTY_REQUEST and that error has historically leaked into
     // the next turn in confusing ways.
@@ -143,6 +159,34 @@ export function useChatSocket() {
       return
     }
     ws.send(JSON.stringify({ action: 'chat', messages }))
+  }
+
+  // serializeUserContent — fold structured attachments into the LLM-
+  // visible content string. Kept here (vs. inside the store) so the
+  // store's user messages stay clean and rendering doesn't have to
+  // worry about parsing back out.
+  const serializeUserContent = (m) => {
+    const attachments = m.attachments || []
+    if (!attachments.length) return m.content
+    const prefix = attachments
+      .map((a) => formatAttachment(a))
+      .filter(Boolean)
+      .join(' ')
+    if (!prefix) return m.content
+    return `${prefix}\n\n${m.content}`
+  }
+
+  const formatAttachment = (a) => {
+    if (a.type === 'file') {
+      const name = a.name ? `${a.name} ` : ''
+      const ds = a.datasetId ? ` in dataset ${a.datasetId}` : ''
+      return `[Attached file: ${name}(${a.packageId})${ds}]`
+    }
+    if (a.type === 'dataset') {
+      const name = a.name ? `${a.name} ` : ''
+      return `[Attached dataset: ${name}(${a.datasetId})]`
+    }
+    return ''
   }
 
   const disconnect = ({ mode, orgId, datasetId }) => {

--- a/src/composables/useRouteContext.js
+++ b/src/composables/useRouteContext.js
@@ -1,0 +1,108 @@
+// @/composables/useRouteContext.js
+//
+// Resolves the current vue-router route to a "chat context" descriptor —
+// what file or dataset (if any) the user is currently looking at. Used by
+// the Spotlight compose modal to auto-attach the on-screen entity to the
+// chat message the user is about to send, so they don't have to navigate
+// to Insights and re-explain context.
+//
+// Returns null when the current route doesn't correspond to a known
+// entity (e.g. settings, workspace home) — the Spotlight modal still
+// opens, it just shows no auto-attached chip.
+//
+// Naming notes:
+//
+//   - `file-record` is the Vue route for the single-file Detail page —
+//     the canonical "I'm looking at this file" surface.
+//   - `dataset-overview` (and its children like dataset-files, dataset-
+//     publishing, etc.) puts us in a dataset context but not on a
+//     specific file. For v1 we ONLY auto-attach when we have a specific
+//     file — dataset-level attachment is easy to add later but the user
+//     intent ("ask about THIS thing") matches file precision better.
+
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { useStore as useVuexStore } from 'vuex'
+import { pathOr } from 'ramda'
+
+// Route names that resolve to a single-file context. Add new ones here
+// when more file-detail surfaces ship (e.g. a dedicated viewer route).
+const FILE_ROUTE_NAMES = new Set(['file-record'])
+
+// Routes anywhere under a dataset get the dataset attached as context
+// when the user isn't on a more-specific file page. Detection is
+// keyed on the presence of `:datasetId` in route params — this covers
+// every dataset child route (overview, files, publishing, settings,
+// etc.) without us having to enumerate them and stay in sync as the
+// router evolves.
+//
+// File detail (FILE_ROUTE_NAMES above) takes priority: when the user
+// is looking at a specific file, "this file" is the more useful
+// attachment than "this dataset".
+
+/**
+ * useRouteContext — returns a reactive `context` ref that updates as the
+ * route changes. Shape:
+ *
+ *   null
+ *     | { type: 'file',    packageId, datasetId, name }
+ *     | { type: 'dataset', datasetId, name }
+ *
+ * The `name` field is best-effort: pulled from Vuex when the
+ * corresponding page populated it; otherwise null and the consumer
+ * (Spotlight chip) shows a neutral fallback like "this file".
+ */
+export function useRouteContext() {
+  const route = useRoute()
+  const vuex = useVuexStore()
+
+  const context = computed(() => {
+    const routeName = route.name
+    const { datasetId, fileId } = route.params || {}
+
+    if (FILE_ROUTE_NAMES.has(routeName) && fileId && datasetId) {
+      // Pull a human-readable filename from Vuex when the FileDetails
+      // page has populated activeViewer. Shape (from viewerModule):
+      //   activeViewer = { content: { id, name, packageType, ... }, ... }
+      // We don't *require* the name — passing the packageId structurally
+      // is enough for the LLM to do its job. The name just makes the
+      // chip readable.
+      const activeViewer = pathOr({}, ['viewerModule', 'activeViewer'], vuex.state)
+      const name = pathOr(null, ['content', 'name'], activeViewer)
+      return {
+        type: 'file',
+        packageId: fileId,
+        datasetId,
+        name: name && activeViewer.content?.id === fileId ? name : null,
+      }
+    }
+
+    // Anywhere else under a dataset → attach the dataset itself.
+    // datasetId on params comes from the parent route, so this matches
+    // overview / files / publishing / settings / etc. uniformly.
+    //
+    // Skip the dedicated Insights page — when the user is already on
+    // the chat surface, the modal would be pointless and the chip
+    // would be misleading (the chat itself is workspace-scoped, not
+    // dataset-scoped).
+    if (datasetId && routeName !== 'workspace-insights') {
+      const stateDataset = pathOr(null, ['dataset', 'content'], vuex.state)
+      // Only use the cached name when it matches the current route's
+      // datasetId — otherwise we'd attach a stale name from a
+      // previously-viewed dataset while the new one loads.
+      const name =
+        stateDataset && stateDataset.nodeId === datasetId
+          ? stateDataset.name
+          : null
+      return {
+        type: 'dataset',
+        datasetId,
+        name,
+      }
+    }
+
+    return null
+  })
+
+  return { context }
+}

--- a/src/stores/chatQuotaAdminStore.js
+++ b/src/stores/chatQuotaAdminStore.js
@@ -1,0 +1,168 @@
+// @/stores/chatQuotaAdminStore.js
+//
+// Owner-side state for the compute-node quota management UI.
+//
+// Distinct from chatQuotaStore (per-user effective view shown in the chat
+// header) — this one owns the *list* of explicit quota rows on a node, plus
+// the create / update / delete actions an owner uses to set caps. The chat
+// header reads /effective and never mutates; this store reads /user-quotas
+// (list) and PUT/DELETE per row.
+//
+// Account-service endpoints (owner-only on list/PUT/DELETE):
+//   GET    /compute/resources/compute-nodes/{id}/user-quotas
+//   PUT    /compute/resources/compute-nodes/{id}/user-quotas/{userId}
+//   DELETE /compute/resources/compute-nodes/{id}/user-quotas/{userId}
+//
+// Rows are keyed by userId. The "__default__" sentinel is a normal row to the
+// API; consumers split it out for display (pinned default card vs. per-user
+// table).
+
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { useGetToken } from '@/composables/useGetToken'
+import * as siteConfig from '@/site-config/site.json'
+
+export const DEFAULT_USER_SENTINEL = '__default__'
+
+const baseUrl = (nodeId) =>
+  `${siteConfig.api2Url}/compute/resources/compute-nodes/${encodeURIComponent(nodeId)}/user-quotas`
+
+async function authedFetch(url, init = {}) {
+  const token = await useGetToken()
+  if (!token) throw new Error('no session token')
+  return window.fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...(init.headers || {}),
+    },
+  })
+}
+
+export const useChatQuotaAdminStore = defineStore('chatQuotaAdmin', () => {
+  // Map<nodeId, Map<userId, QuotaRow>>. QuotaRow shape matches what
+  // account-service returns from list/get — see effectiveQuotaResponse in the
+  // handler, minus the resolved-limits envelope (those are computed lazily by
+  // the GET .../effective endpoint, not stored as rows).
+  const rowsByNodeId = ref(new Map())
+  const loadingByNodeId = ref(new Map())
+  const errorByNodeId = ref(new Map())
+
+  const getRows = (nodeId) => {
+    const m = nodeId && rowsByNodeId.value.get(nodeId)
+    return m ? Array.from(m.values()) : []
+  }
+
+  const getRow = (nodeId, userId) => {
+    const m = nodeId && rowsByNodeId.value.get(nodeId)
+    return (m && m.get(userId)) || null
+  }
+
+  const getDefaultRow = (nodeId) => getRow(nodeId, DEFAULT_USER_SENTINEL)
+
+  // Per-user rows (excludes the default sentinel) — what the table renders.
+  const getUserRows = (nodeId) =>
+    getRows(nodeId).filter((r) => r.userId !== DEFAULT_USER_SENTINEL)
+
+  const isLoading = (nodeId) =>
+    (nodeId && loadingByNodeId.value.get(nodeId)) || false
+
+  const getError = (nodeId) =>
+    (nodeId && errorByNodeId.value.get(nodeId)) || null
+
+  // In-flight dedupe per node — the section may mount multiple times in dev
+  // hot-reload, and we don't want stacked list requests.
+  const inflightList = new Map()
+
+  const fetchAll = async (nodeId) => {
+    if (!nodeId) return []
+    const existing = inflightList.get(nodeId)
+    if (existing) return existing
+
+    loadingByNodeId.value.set(nodeId, true)
+    errorByNodeId.value.delete(nodeId)
+
+    const p = (async () => {
+      try {
+        const resp = await authedFetch(baseUrl(nodeId), { method: 'GET' })
+        if (!resp.ok) {
+          const body = await resp.text().catch(() => '')
+          throw new Error(`HTTP ${resp.status}${body ? `: ${body.slice(0, 200)}` : ''}`)
+        }
+        const data = await resp.json()
+        const rows = Array.isArray(data?.quotas) ? data.quotas : []
+        const m = new Map()
+        for (const r of rows) {
+          if (r?.userId) m.set(r.userId, r)
+        }
+        rowsByNodeId.value.set(nodeId, m)
+        return rows
+      } catch (e) {
+        errorByNodeId.value.set(nodeId, { message: e?.message || 'fetch failed' })
+        return []
+      } finally {
+        loadingByNodeId.value.set(nodeId, false)
+        inflightList.delete(nodeId)
+      }
+    })()
+    inflightList.set(nodeId, p)
+    return p
+  }
+
+  // putRow creates-or-replaces a quota row. `payload` should contain the
+  // editable fields only; the API fills in updatedBy / updatedAt server-side.
+  // Pass `null` (not undefined) for an axis to explicitly clear the cap.
+  const putRow = async (nodeId, userId, payload) => {
+    if (!nodeId || !userId) throw new Error('nodeId and userId are required')
+    const resp = await authedFetch(
+      `${baseUrl(nodeId)}/${encodeURIComponent(userId)}`,
+      { method: 'PUT', body: JSON.stringify(payload || {}) },
+    )
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '')
+      throw new Error(`HTTP ${resp.status}${body ? `: ${body.slice(0, 200)}` : ''}`)
+    }
+    const row = await resp.json()
+    const m = rowsByNodeId.value.get(nodeId) || new Map()
+    m.set(row.userId, row)
+    rowsByNodeId.value.set(nodeId, new Map(m))
+    return row
+  }
+
+  const deleteRow = async (nodeId, userId) => {
+    if (!nodeId || !userId) throw new Error('nodeId and userId are required')
+    const resp = await authedFetch(
+      `${baseUrl(nodeId)}/${encodeURIComponent(userId)}`,
+      { method: 'DELETE' },
+    )
+    if (!resp.ok && resp.status !== 404) {
+      const body = await resp.text().catch(() => '')
+      throw new Error(`HTTP ${resp.status}${body ? `: ${body.slice(0, 200)}` : ''}`)
+    }
+    const m = rowsByNodeId.value.get(nodeId)
+    if (m) {
+      m.delete(userId)
+      rowsByNodeId.value.set(nodeId, new Map(m))
+    }
+  }
+
+  return {
+    DEFAULT_USER_SENTINEL,
+    // state
+    rowsByNodeId,
+    loadingByNodeId,
+    errorByNodeId,
+    // actions
+    fetchAll,
+    putRow,
+    deleteRow,
+    // getters
+    getRows,
+    getRow,
+    getDefaultRow,
+    getUserRows,
+    isLoading,
+    getError,
+  }
+})

--- a/src/stores/chatQuotaStore.js
+++ b/src/stores/chatQuotaStore.js
@@ -1,0 +1,163 @@
+// @/stores/chatQuotaStore.js
+//
+// Per-(node) LLM cost quota state shown in the chat panel header.
+//
+// State is keyed by computeNodeId because users can have different limits on
+// different nodes (per-node quotas are how the platform models LLM cost
+// governance — see account-service docs). The store fetches via HTTP rather
+// than over the chat WebSocket so the meter:
+//
+//   1. paints before the user sends their first turn (no chat traffic yet),
+//   2. stays in sync after an owner CRUD action (a single `refresh()` is
+//      enough — no need to wait for the next assistant turn),
+//   3. doesn't couple chat-service to the meter UX (chat-service ships
+//      AssistantMessages, account-service owns quota — clean separation).
+//
+// The endpoint is GET /compute-nodes/{id}/user-quotas/me/effective on
+// account-service, which already returns the axis-by-axis resolved limits
+// plus current daily / monthly spend plus per-axis source attribution.
+
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { useGetToken } from '@/composables/useGetToken'
+import * as siteConfig from '@/site-config/site.json'
+
+// Utilization thresholds for the "warning level" getter. Values are
+// fractions of cap consumed (0.8 = 80%). Color-coding lives in the
+// component; the store just classifies.
+const NEAR_THRESHOLD = 0.8
+const OVER_THRESHOLD = 1.0
+
+export const useChatQuotaStore = defineStore('chatQuota', () => {
+  // Map<computeNodeId, EffectiveQuota>. EffectiveQuota is the shape returned
+  // by the account-service /effective endpoint — see the chatUserEffectiveQuota
+  // schema in account-service's OpenAPI spec.
+  const quotaByNodeId = ref(new Map())
+  // Map<computeNodeId, Date> — last successful fetch. Used for staleness UI
+  // and to avoid hammering the endpoint on rapid prop changes.
+  const fetchedAtByNodeId = ref(new Map())
+  // Map<computeNodeId, boolean> — true while a fetch is in flight. Lets the
+  // header render a skeleton bar instead of $0/$0 (which would look like a
+  // real cap of zero).
+  const loadingByNodeId = ref(new Map())
+  // Map<computeNodeId, { code, message }> — last fetch error. Surfaced as a
+  // subtle "couldn't load quota" pill rather than blocking the chat — users
+  // can still send turns; the backend still enforces.
+  const errorByNodeId = ref(new Map())
+
+  const getQuota = (nodeId) =>
+    (nodeId && quotaByNodeId.value.get(nodeId)) || null
+
+  const isLoading = (nodeId) =>
+    (nodeId && loadingByNodeId.value.get(nodeId)) || false
+
+  const getError = (nodeId) =>
+    (nodeId && errorByNodeId.value.get(nodeId)) || null
+
+  // utilization returns a fraction of the daily (or monthly) cap consumed.
+  // Returns 0 when the quota hasn't loaded yet. Can exceed 1 if the user
+  // somehow blew past the cap (race between turn dispatch + cap lookup).
+  const utilization = (nodeId, axis /* 'daily' | 'monthly' */) => {
+    const q = getQuota(nodeId)
+    if (!q) return 0
+    const spent = axis === 'daily' ? q.dailySpentUsd : q.monthlySpentUsd
+    const cap = axis === 'daily' ? q.dailyCostUsd : q.monthlyCostUsd
+    if (!cap || cap <= 0) return 0
+    return spent / cap
+  }
+
+  // warningLevel returns "ok" / "near" / "over" based on the worse of daily
+  // and monthly. Drives header tint + auto-expand decisions.
+  const warningLevel = (nodeId) => {
+    const u = Math.max(utilization(nodeId, 'daily'), utilization(nodeId, 'monthly'))
+    if (u >= OVER_THRESHOLD) return 'over'
+    if (u >= NEAR_THRESHOLD) return 'near'
+    return 'ok'
+  }
+
+  // fetch hits account-service for one node. Idempotent — safe to call on
+  // mount + after each assistant turn + on manual refresh.
+  //
+  // Implementation choices:
+  //   - One in-flight request per node at a time. If a fetch is already
+  //     running for `nodeId`, return the existing promise instead of stacking
+  //     duplicate requests (e.g. mount + first assistant message firing close
+  //     together).
+  //   - On HTTP error, keep any previous quota state — better to show
+  //     slightly-stale numbers than blank the meter mid-conversation.
+  const inflight = new Map() // nodeId -> Promise
+
+  const fetch_ = async (nodeId) => {
+    if (!nodeId) return null
+    const existing = inflight.get(nodeId)
+    if (existing) return existing
+
+    loadingByNodeId.value.set(nodeId, true)
+    errorByNodeId.value.delete(nodeId)
+
+    const p = (async () => {
+      try {
+        const token = await useGetToken()
+        if (!token) throw new Error('no session token')
+        const url = `${siteConfig.api2Url}/compute/resources/compute-nodes/${encodeURIComponent(nodeId)}/user-quotas/me/effective`
+        const resp = await window.fetch(url, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+        })
+        if (!resp.ok) {
+          const body = await resp.text().catch(() => '')
+          throw new Error(`HTTP ${resp.status}${body ? `: ${body.slice(0, 200)}` : ''}`)
+        }
+        const data = await resp.json()
+        quotaByNodeId.value.set(nodeId, data)
+        fetchedAtByNodeId.value.set(nodeId, new Date())
+        return data
+      } catch (e) {
+        errorByNodeId.value.set(nodeId, { message: e?.message || 'fetch failed' })
+        // Don't rethrow — callers don't want to deal with this; the error
+        // surfaces through getError().
+        return null
+      } finally {
+        loadingByNodeId.value.set(nodeId, false)
+        inflight.delete(nodeId)
+      }
+    })()
+    inflight.set(nodeId, p)
+    return p
+  }
+
+  // Convenience refs for components that bind to a single "active node".
+  // Use the action-style API (getQuota / utilization / etc.) when looping
+  // over multiple nodes.
+  const activeNodeId = ref(null)
+  const setActiveNode = (nodeId) => {
+    activeNodeId.value = nodeId || null
+  }
+  const activeQuota = computed(() => getQuota(activeNodeId.value))
+  const activeLoading = computed(() => isLoading(activeNodeId.value))
+  const activeError = computed(() => getError(activeNodeId.value))
+
+  return {
+    // state
+    quotaByNodeId,
+    fetchedAtByNodeId,
+    loadingByNodeId,
+    errorByNodeId,
+    // actions
+    fetch: fetch_,
+    setActiveNode,
+    // getters
+    getQuota,
+    isLoading,
+    getError,
+    utilization,
+    warningLevel,
+    activeNodeId,
+    activeQuota,
+    activeLoading,
+    activeError,
+  }
+})

--- a/src/stores/chatStore.js
+++ b/src/stores/chatStore.js
@@ -71,10 +71,26 @@ export const useChatStore = defineStore('chat', () => {
     }))
   }
 
-  const appendUserMessage = (key, content) => {
+  // Append a user turn to the named conversation.
+  //
+  // `attachments` (optional) is the structured form of context the user
+  // attached when composing — currently only via the Spotlight modal's
+  // current-page auto-attach. Stored on the message so the chat UI can
+  // render them as chips ABOVE the prompt body (vs. inlining them as
+  // raw `[Attached file: …(N:package:…)…]` text the way v1 did). The
+  // wire-level prefix that the LLM needs gets re-derived when the
+  // socket serializes the message — see useChatSocket.sendUserMessage.
+  //
+  // Shape: [{ type: 'file' | 'dataset', packageId?, datasetId, name? }]
+  // Absent / empty array on plain typed turns.
+  const appendUserMessage = (key, content, attachments) => {
     const convo = conversations.value.get(key)
     if (!convo) return
-    convo.messages.push({ role: 'user', content })
+    convo.messages.push({
+      role: 'user',
+      content,
+      attachments: Array.isArray(attachments) && attachments.length ? attachments : undefined,
+    })
     convo.pending = true
     convo.activeTools = []
     convo.lastError = null

--- a/src/stores/chatStore.js
+++ b/src/stores/chatStore.js
@@ -103,6 +103,15 @@ export const useChatStore = defineStore('chat', () => {
         return
       }
       case 'message': {
+        // A new assistant message arriving "resolves" any pending
+        // background-task indicators on prior messages in this
+        // conversation — the next frame is, by definition, the
+        // completion the user was waiting for. Clear them now so the
+        // "in flight" pill disappears as the figure (or follow-up text)
+        // renders.
+        for (const m of convo.messages) {
+          if (m.pendingTasks?.length) m.pendingTasks = []
+        }
         convo.messages.push({
           role: 'assistant',
           content: frame.content || '',
@@ -120,6 +129,12 @@ export const useChatStore = defineStore('chat', () => {
           // → figure.png inline). See compute-node-chat docs:
           //   docs/developer/inline-image-frames.md
           blocks: Array.isArray(frame.blocks) ? frame.blocks : null,
+          // Background-workflow indicators. Non-empty when this assistant
+          // turn fired off one or more async-mode MCP tools (plot_file
+          // etc.) whose results arrive in a later completion frame.
+          // Rendered as persistent "running…" pills below the message
+          // until the next assistant frame arrives (see clear loop above).
+          pendingTasks: Array.isArray(frame.pendingTasks) ? frame.pendingTasks : [],
         })
         convo.pending = false
         convo.activeTools = []

--- a/src/stores/chatStore.js
+++ b/src/stores/chatStore.js
@@ -113,6 +113,13 @@ export const useChatStore = defineStore('chat', () => {
           referencedDatasets: Array.isArray(frame.referencedDatasets)
             ? frame.referencedDatasets
             : [],
+          // Optional structured-content render path. When the backend
+          // supplies `blocks`, newer clients render those in order;
+          // otherwise fall back to `content`. Used today for inline
+          // figure rendering on workflow-completion frames (plot_file
+          // → figure.png inline). See compute-node-chat docs:
+          //   docs/developer/inline-image-frames.md
+          blocks: Array.isArray(frame.blocks) ? frame.blocks : null,
         })
         convo.pending = false
         convo.activeTools = []

--- a/src/stores/nodeLlmBudgetStore.js
+++ b/src/stores/nodeLlmBudgetStore.js
@@ -1,0 +1,115 @@
+// @/stores/nodeLlmBudgetStore.js
+//
+// Owner-side state for the node-wide LLM cost budget — the SSM-backed cap
+// the governor enforces on every Bedrock invocation. This is independent
+// of the per-user chat quotas (chatQuotaAdminStore.js): the node budget
+// caps total spend across all users *and* applies to workflow
+// applications, while per-user quotas only gate chat-service turns.
+//
+// Account-service endpoints (owner-only):
+//   GET  /compute/resources/compute-nodes/{id}/llm-config
+//   PUT  /compute/resources/compute-nodes/{id}/llm-config
+//
+// Wire shape mirrors the SSM JSON the governor reads:
+//   { budgetUsd: number, budgetPeriod: "daily" | "monthly" }
+
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { useGetToken } from '@/composables/useGetToken'
+import * as siteConfig from '@/site-config/site.json'
+
+const url = (nodeId) =>
+  `${siteConfig.api2Url}/compute/resources/compute-nodes/${encodeURIComponent(nodeId)}/llm-config`
+
+async function authedFetch(u, init = {}) {
+  const token = await useGetToken()
+  if (!token) throw new Error('no session token')
+  return window.fetch(u, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...(init.headers || {}),
+    },
+  })
+}
+
+export const useNodeLlmBudgetStore = defineStore('nodeLlmBudget', () => {
+  // Map<nodeId, { budgetUsd, budgetPeriod }>
+  const configByNodeId = ref(new Map())
+  const loadingByNodeId = ref(new Map())
+  const errorByNodeId = ref(new Map())
+
+  const getConfig = (nodeId) =>
+    (nodeId && configByNodeId.value.get(nodeId)) || null
+
+  const isLoading = (nodeId) =>
+    (nodeId && loadingByNodeId.value.get(nodeId)) || false
+
+  const getError = (nodeId) =>
+    (nodeId && errorByNodeId.value.get(nodeId)) || null
+
+  const inflight = new Map()
+
+  const fetch_ = async (nodeId) => {
+    if (!nodeId) return null
+    const existing = inflight.get(nodeId)
+    if (existing) return existing
+
+    loadingByNodeId.value.set(nodeId, true)
+    errorByNodeId.value.delete(nodeId)
+
+    const p = (async () => {
+      try {
+        const resp = await authedFetch(url(nodeId), { method: 'GET' })
+        // 503 = "LLM not enabled on this node" — surface as null config
+        // rather than an error; UI hides the section in that case.
+        if (resp.status === 503) {
+          configByNodeId.value.set(nodeId, null)
+          return null
+        }
+        if (!resp.ok) {
+          const body = await resp.text().catch(() => '')
+          throw new Error(`HTTP ${resp.status}${body ? `: ${body.slice(0, 200)}` : ''}`)
+        }
+        const data = await resp.json()
+        configByNodeId.value.set(nodeId, data)
+        return data
+      } catch (e) {
+        errorByNodeId.value.set(nodeId, { message: e?.message || 'fetch failed' })
+        return null
+      } finally {
+        loadingByNodeId.value.set(nodeId, false)
+        inflight.delete(nodeId)
+      }
+    })()
+    inflight.set(nodeId, p)
+    return p
+  }
+
+  const put = async (nodeId, payload) => {
+    if (!nodeId) throw new Error('nodeId is required')
+    const resp = await authedFetch(url(nodeId), {
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    })
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '')
+      throw new Error(`HTTP ${resp.status}${body ? `: ${body.slice(0, 200)}` : ''}`)
+    }
+    const data = await resp.json()
+    configByNodeId.value.set(nodeId, data)
+    return data
+  }
+
+  return {
+    configByNodeId,
+    loadingByNodeId,
+    errorByNodeId,
+    fetch: fetch_,
+    put,
+    getConfig,
+    isLoading,
+    getError,
+  }
+})

--- a/src/utils/platform.js
+++ b/src/utils/platform.js
@@ -1,0 +1,22 @@
+// Platform-detection helpers for keyboard-shortcut display.
+//
+// macOS uses ⌘ for the Command key; Windows / Linux use Ctrl. The
+// shortcut LOGIC (in App.vue) already handles both via `metaKey || ctrlKey`;
+// these helpers are just for the user-facing label so the right symbol
+// renders on each platform.
+//
+// Use the value in a `computed()` or template — `navigator.platform` is
+// stable for the session, so a one-time read is fine.
+
+const PLATFORM = typeof navigator !== 'undefined' ? navigator.platform || '' : ''
+
+export const isMac = /Mac|iPod|iPhone|iPad/.test(PLATFORM)
+
+// Display label for the Cmd-or-Ctrl + K shortcut. Used by Spotlight's
+// ⌘K badge and by ChatPanel's tip text. Macs see "⌘K", everyone else
+// sees "Ctrl+K".
+export const cmdKLabel = isMac ? '⌘K' : 'Ctrl+K'
+
+// Parts variant — useful when the consumer wants to wrap the modifier
+// + key in separate <kbd> tags.
+export const cmdKParts = isMac ? ['⌘', 'K'] : ['Ctrl', 'K']


### PR DESCRIPTION
## Summary
- **Spotlight** — global Cmd-K / Ctrl-K compose modal so users can fire a chat from any page (with current dataset/file attached).
- **Per-user LLM quota meter** — inline pill in the chat panel header that shows daily/monthly cost vs. limit, expanding to a fuller panel once over the warn threshold.
- **Workflow-completion polish** — render inline figures from `blocks` frames, and surface a persistent "background task in progress" pill while async tools run.
- One follow-up fix in the same series: drop a stale "Discussed:" pill row that no longer has supporting state.

## Commits (9)
\`\`\`
07839951 chat: drop stale "Discussed:" pill row from header
7423f21c chat: show tokens in the collapsed quota pill, dollars in expanded panel
78175a5c chat: align compute-pill and quota-meter pill to identical 24px height
7268fff9 chat: inline the quota meter next to the compute-node pill
e8834112 chat quota: fix reactivity — wrap store accessors in computed
a880cd72 chat: per-user LLM quota meter in chat panel
62af0fe4 chat: Spotlight (Cmd-K) compose modal + supporting plumbing
e387ad81 chat: render persistent "background task in progress" pill
1123ba21 chat: render inline figures from workflow-completion \`blocks\` frames
\`\`\`

## Test plan
- [ ] Press Cmd-K (Ctrl-K on non-Mac) from any page → Spotlight modal opens; submitting a prompt routes to chat.
- [ ] Open chat panel → quota meter pill renders next to the compute-node pill; collapsed shows tokens, expanded shows USD.
- [ ] Trigger an async workflow tool → "background task in progress" pill stays visible until completion.
- [ ] Workflow completion frame with \`blocks\` containing figures → figures render inline in the thread.
- [ ] Chat panel header no longer throws on render when there are no referenced datasets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)