### PR TITLE
chat: fix file-details 404 + stale WebSocket auto-reconnect

### DIFF
--- a/src/components/Chat/ChatImageBlock.vue
+++ b/src/components/Chat/ChatImageBlock.vue
@@ -77,16 +77,21 @@ const resolvedUrl = ref('')
 const alt = computed(() => props.block.alt || 'Inline figure')
 const source = computed(() => props.block.source || {})
 
-// Open-in-viewer fallback link. Matches the package-viewer route used
-// elsewhere in the app — keep this aligned if/when that route changes.
+// Open-in-viewer fallback link. Matches the `file-record` route registered
+// in router/index.js (`:orgId/datasets/:datasetId/files/:fileId/details`).
+// Two pieces routinely missed when this was first built:
+//   - the org slug at the start (a /datasets/... URL with no org 404s)
+//   - the /details suffix (the route is FileDetails, not the dataset-files
+//     index)
+// Read the org from Vuex's activeOrganization rather than a route param —
+// the chat panel can be hosted in widgets (e.g. Spotlight) where the
+// current route isn't org-scoped, but activeOrganization is set globally.
 const packageHref = computed(() => {
   const { packageNodeId, datasetNodeId } = source.value
   if (!packageNodeId || !datasetNodeId) return '#'
-  // Active workspace org slug lives in the route; route name matches the
-  // existing FileDetails entry point. router-link would be cleaner here
-  // but we want an external anchor so users can mouse-middle-click into a
-  // new tab without disrupting the chat session.
-  return `/datasets/${datasetNodeId}/files/${packageNodeId}`
+  const orgId = store.state?.activeOrganization?.organization?.id
+  if (!orgId) return '#'
+  return `/${orgId}/datasets/${datasetNodeId}/files/${packageNodeId}/details`
 })
 
 const onImgError = () => {

--- a/src/composables/useChatSocket.js
+++ b/src/composables/useChatSocket.js
@@ -10,6 +10,14 @@ import { useChatStore, contextKey } from '@/stores/chatStore'
 
 const sockets = new Map() // contextKey -> WebSocket
 
+// Treat the cached socket as stale (despite readyState===OPEN) when no
+// frame has been received from AWS for this long. AWS API Gateway closes
+// idle WebSockets after 10 minutes; the browser-side readyState often
+// stays OPEN well past that, silently swallowing sends. Five minutes is
+// well under that bound while still being long enough to span normal
+// "user is thinking" gaps without forcing unnecessary reconnects.
+const STALE_SOCKET_MS = 5 * 60 * 1000
+
 const buildUrl = ({ token, orgId, computeNodeId, datasetId, sessionId }) => {
   const params = new URLSearchParams()
   params.set('token', token)
@@ -27,10 +35,21 @@ export function useChatSocket() {
     const key = contextKey({ mode, orgId, datasetId })
     const convo = store.ensureConversation({ mode, orgId, datasetId, computeNodeId })
 
-    // Already open or connecting — reuse.
+    // Already open or connecting — reuse, but only if the connection
+    // looks genuinely live. A browser-side OPEN socket whose server side
+    // has been closed for >STALE_SOCKET_MS produces silent send drops
+    // (no error, no AWS log line, no chat response). Force-close stale
+    // ones so the next branch builds a fresh socket.
     const existing = sockets.get(key)
     if (existing && (existing.readyState === WebSocket.OPEN || existing.readyState === WebSocket.CONNECTING)) {
-      return existing
+      const lastFrameAt = convo?.lastFrameAt || 0
+      const idleMs = lastFrameAt ? Date.now() - lastFrameAt : 0
+      if (existing.readyState === WebSocket.CONNECTING || lastFrameAt === 0 || idleMs < STALE_SOCKET_MS) {
+        return existing
+      }
+      // Stale — bin it and fall through to reconnect.
+      try { existing.close(4000, 'stale-reconnect') } catch (_) {}
+      sockets.delete(key)
     }
 
     store.setConnectionState(key, 'connecting')
@@ -61,6 +80,12 @@ export function useChatSocket() {
 
     ws.onopen = () => {
       store.setConnectionState(key, 'open')
+      // A successful handshake counts as evidence the socket is alive,
+      // even before the first inbound frame. Without this, a socket that
+      // opens and then sits idle past the staleness window would be
+      // treated as stale on the next send purely because no frame had
+      // ever arrived.
+      store.markSocketAlive(key)
     }
     ws.onmessage = (event) => {
       try {
@@ -74,7 +99,13 @@ export function useChatSocket() {
       // Don't surface raw error events — onclose runs next with diagnostic info.
     }
     ws.onclose = (event) => {
-      sockets.delete(key)
+      // If a new socket has already taken our place in the map (e.g. the
+      // stale-socket force-reconnect flow closed us *after* binding a
+      // replacement), don't touch global state — the old close arriving
+      // late would otherwise stomp the new socket's 'open' state with an
+      // 'error'.
+      if (sockets.get(key) === ws) sockets.delete(key)
+      else return
       // 1000 / 1001 are clean closes; anything else suggests a problem.
       const wasClean = event.code === 1000 || event.code === 1001
       if (!wasClean) {
@@ -108,30 +139,32 @@ export function useChatSocket() {
     store.ensureConversation({ mode, orgId, datasetId, computeNodeId })
     store.appendUserMessage(key, trimmed, attachments)
 
-    let ws = sockets.get(key)
-    if (!ws || ws.readyState !== WebSocket.OPEN) {
-      try {
-        ws = await connect({ mode, orgId, datasetId, computeNodeId })
-      } catch (e) {
-        store.markFailedTurn(key, 'Could not connect to chat service')
-        return
-      }
-      if (ws.readyState !== WebSocket.OPEN) {
-        await new Promise((resolve, reject) => {
-          const onOpen = () => {
-            ws.removeEventListener('open', onOpen)
-            ws.removeEventListener('close', onClose)
-            resolve()
-          }
-          const onClose = () => {
-            ws.removeEventListener('open', onOpen)
-            ws.removeEventListener('close', onClose)
-            reject(new Error('socket closed before open'))
-          }
-          ws.addEventListener('open', onOpen)
-          ws.addEventListener('close', onClose)
-        }).catch(() => {})
-      }
+    // Always route through connect() so its stale-socket check fires —
+    // doing the readyState check inline here would skip that and reuse a
+    // half-dead socket. connect() is a no-op fast-path when the cached
+    // socket is genuinely live (CONNECTING, or OPEN with a recent frame).
+    let ws
+    try {
+      ws = await connect({ mode, orgId, datasetId, computeNodeId })
+    } catch (e) {
+      store.markFailedTurn(key, 'Could not connect to chat service')
+      return
+    }
+    if (ws.readyState !== WebSocket.OPEN) {
+      await new Promise((resolve, reject) => {
+        const onOpen = () => {
+          ws.removeEventListener('open', onOpen)
+          ws.removeEventListener('close', onClose)
+          resolve()
+        }
+        const onClose = () => {
+          ws.removeEventListener('open', onOpen)
+          ws.removeEventListener('close', onClose)
+          reject(new Error('socket closed before open'))
+        }
+        ws.addEventListener('open', onOpen)
+        ws.addEventListener('close', onClose)
+      }).catch(() => {})
     }
 
     if (!ws || ws.readyState !== WebSocket.OPEN) {

--- a/src/stores/chatStore.js
+++ b/src/stores/chatStore.js
@@ -32,6 +32,12 @@ const newConversation = ({ mode, orgId, datasetId, computeNodeId }) => ({
   activeTools: [],
   connectionState: 'idle', // 'idle' | 'connecting' | 'open' | 'reconnecting' | 'error'
   lastError: null,
+  // Wall-clock ms of the last frame received on this conversation's
+  // WebSocket. Used by useChatSocket to detect "browser thinks the socket
+  // is OPEN but AWS hung up minutes ago" — when the gap exceeds the
+  // staleness threshold, the socket is force-closed and reconnected
+  // before the next send. Set on every frame in handleIncomingFrame.
+  lastFrameAt: 0,
 })
 
 export const contextKey = ({ mode, orgId, datasetId }) => {
@@ -100,6 +106,11 @@ export const useChatStore = defineStore('chat', () => {
   const handleIncomingFrame = (key, frame) => {
     const convo = conversations.value.get(key)
     if (!convo) return
+
+    // Mark liveness: any frame we receive proves the socket is genuinely
+    // connected to AWS, not just OPEN in the browser's local view.
+    // useChatSocket reads this before reusing a cached socket to send.
+    convo.lastFrameAt = Date.now()
 
     switch (frame.type) {
       case 'tool_progress': {
@@ -185,6 +196,15 @@ export const useChatStore = defineStore('chat', () => {
     if (error) convo.lastError = error
   }
 
+  // markSocketAlive — bumps lastFrameAt without applying a frame. Called
+  // by useChatSocket's onopen so a freshly handshaken socket isn't
+  // immediately treated as stale just because no frame has yet arrived.
+  const markSocketAlive = (key) => {
+    const convo = conversations.value.get(key)
+    if (!convo) return
+    convo.lastFrameAt = Date.now()
+  }
+
   const clearError = (key) => {
     const convo = conversations.value.get(key)
     if (!convo) return
@@ -211,6 +231,7 @@ export const useChatStore = defineStore('chat', () => {
     appendUserMessage,
     handleIncomingFrame,
     setConnectionState,
+    markSocketAlive,
     clearError,
     markFailedTurn,
   }


### PR DESCRIPTION
Follow-up to [#708](https://github.com/Pennsieve/pennsieve-app/pull/708) — two narrow chat-panel fixes that landed on the same branch after the merge.

## 1. \"View plot in package\" link 404

\`ChatImageBlock.vue\` built the fallback href as \`/datasets/{datasetId}/files/{packageId}\`, which 404s because the route registered as \`file-record\` requires an org slug prefix and a \`/details\` suffix. Now builds the correct URL (\`/{orgId}/datasets/{datasetId}/files/{packageId}/details\`) with \`orgId\` read from Vuex's \`activeOrganization\` so it works inside Spotlight + widget hosts that aren't org-scoped routes.

## 2. Stale-WebSocket detection + auto-reconnect

When AWS API Gateway closes an idle chat WebSocket (10-min default), the browser-side \`readyState\` often stays \`OPEN\` for many minutes longer. The previous code reused any cached \`OPEN\` socket unconditionally, so \`ws.send()\` ended up writing bytes into a half-dead TCP connection: no error fired, the message never reached AWS, no Lambda invocation, no chat response.

Three changes:

- \`chatStore\` tracks \`lastFrameAt\` on each conversation; bumped on every inbound frame and on \`onopen\`.
- \`useChatSocket.connect\` treats a cached \`OPEN\` socket as stale when no frame has been received in >5 minutes (under AWS's 10-min idle bound). Stale sockets are force-closed and the next iteration builds a fresh one.
- \`sendUserMessage\` now always routes through \`connect()\` so the staleness check can never be bypassed.

Also fixes a latent race: when the stale-reconnect closes the old socket, the old socket's \`onclose\` fires asynchronously and used to overwrite the new socket's \`'open'\` state with an \`'error'\`. The handler now no-ops if a newer socket already occupies the map slot.

## Commits

\`\`\`
cc4351fe chat: detect stale WebSockets and auto-reconnect before sending
09d658e7 chat: fix 404 on "View plot in package" fallback link
\`\`\`

## Test plan

- [ ] Click "View plot in package →" on a workflow-completion frame — opens the file-details page, no 404.
- [ ] Open chat, send a message, leave the tab idle past the 10-minute AWS WebSocket timeout, send another message — the new message dispatches (vs. silently disappearing). CloudWatch shows a fresh \`$connect\` event right before the dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)