### PR TITLE
chat: use chat.pennsieve.net custom WS domain (dev + local)

### DIFF
--- a/src/site-config/dev.json
+++ b/src/site-config/dev.json
@@ -42,5 +42,5 @@
   "GitHubAppUrl": "https://github.com/apps/pennsieve-test/installations/new",
   "reCAPTCHASiteKey": "6Le2Wr0aAAAAAHouFUEmy7UwN6b9wa_PPRGrWxAG",
   "neuroglancerUrl": "https://orthogonal-viewer.pennsieve.net",
-  "chatWsUrl": "wss://szgl9urld5.execute-api.us-east-1.amazonaws.com/dev"
+  "chatWsUrl": "wss://chat.pennsieve.net"
 }

--- a/src/site-config/local.json
+++ b/src/site-config/local.json
@@ -43,5 +43,5 @@
   },
   "reCAPTCHASiteKey": "6Le2Wr0aAAAAAHouFUEmy7UwN6b9wa_PPRGrWxAG",
   "neuroglancerUrl": "https://orthogonal-viewer.pennsieve.net",
-  "chatWsUrl": "wss://szgl9urld5.execute-api.us-east-1.amazonaws.com/dev"
+  "chatWsUrl": "wss://chat.pennsieve.net"
 }


### PR DESCRIPTION
## Summary
- Flips `chatWsUrl` in `dev.json` and `local.json` from the raw execute-api hostname (`wss://szgl9urld5.execute-api.us-east-1.amazonaws.com/dev`) to the API Gateway custom domain (`wss://chat.pennsieve.net`).
- Prod was already on the custom-domain pattern (`wss://chat.pennsieve.io/prod`); this brings dev in line.

## Why
- CSP `connect-src` should allowlist stable Pennsieve-owned hostnames, not API IDs that churn on redeploy.
- Symptom of the gap: chat WS was CSP-blocked before the browser even attempted a TCP connect — no entry appeared in DevTools → Network → WS, and chat looked silently dead.

## Companion
- Infrastructure CSP `connect-src` add: Pennsieve/infrastructure#465 — must merge + apply before this is live, or the new hostname is also CSP-blocked.

## Test plan
- [ ] After infra apply, hard-refresh app.pennsieve.net, send a chat message, verify WS entry to `wss://chat.pennsieve.net/?...` appears and transitions to OPEN.
- [ ] Confirm normal chat round-trip works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)