### PR TITLE
Archive Applications, Update location of Application configuration screens and features, restore runtime configuration options

### DIFF
--- a/src/components/Analysis/Applications/ApplicationDetail.vue
+++ b/src/components/Analysis/Applications/ApplicationDetail.vue
@@ -5,6 +5,8 @@ import { marked } from "marked";
 import DOMPurify from "dompurify";
 
 import MetricsDashboard from "../Metrics/MetricsDashboard.vue";
+import AppPermissions from "../../user/code/AppPermissions.vue";
+import AppArchiveToggle from "../../user/code/AppArchiveToggle.vue";
 
 
 const props = defineProps({
@@ -69,6 +71,17 @@ const isAppOwner = computed(() => {
   const intId = profile.value?.intId;
   return !!ownerId && (ownerId === id || ownerId === intId);
 });
+
+// Permissions only apply to private applications.
+const isPublic = computed(() => detail.value?.isPrivate === false);
+
+// Keep the local detail in sync when the archive toggle changes status.
+const onArchiveChange = (status) => {
+  if (detail.value) detail.value = { ...detail.value, status };
+};
+
+// Visibility may change via the permissions editor — reload to reflect it.
+const reloadAfterPermissions = () => loadDetail(props.uuid);
 
 const sortedVersions = computed(() => {
   const versions = detail.value?.versions || [];
@@ -342,16 +355,15 @@ watch(
               </div>
             </div>
 
-            <div class="info-actions">
-              <router-link
-                :to="{
-                  name: 'published-app-details',
-                  params: { uuid: detail.uuid },
-                }"
-                class="text-link-btn"
-              >
-                Manage in My Workspace &rarr;
-              </router-link>
+            <div class="info-actions archive-actions">
+              <span class="info-label">Status</span>
+              <app-archive-toggle
+                :uuid="detail.uuid"
+                :owner-id="detail.ownerId"
+                :source-url="detail.sourceUrl"
+                :status="detail.status"
+                @change="onArchiveChange"
+              />
             </div>
 
           </el-collapse-item>
@@ -418,6 +430,16 @@ watch(
             />
           </el-collapse-item>
         </el-collapse>
+
+        <div class="sidebar-permissions">
+          <app-permissions
+            :uuid="detail.uuid"
+            :owner-id="detail.ownerId"
+            :is-public="isPublic"
+            :organization-id="detail.organizationId"
+            @updated="reloadAfterPermissions"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -754,6 +776,20 @@ watch(
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.archive-actions {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 12px;
+}
+
+.sidebar-permissions {
+  background: theme.$white;
+  border: 1px solid theme.$gray_3;
+  padding: 16px;
+  margin-top: 12px;
 }
 
 .text-link-btn {

--- a/src/components/Analysis/Applications/ApplicationDetail.vue
+++ b/src/components/Analysis/Applications/ApplicationDetail.vue
@@ -7,6 +7,8 @@ import DOMPurify from "dompurify";
 import MetricsDashboard from "../Metrics/MetricsDashboard.vue";
 import AppPermissions from "../../user/code/AppPermissions.vue";
 import AppArchiveToggle from "../../user/code/AppArchiveToggle.vue";
+import { useGetToken } from "@/composables/useGetToken";
+import { useSendXhr } from "@/mixins/request/request_composable";
 
 
 const props = defineProps({
@@ -203,6 +205,38 @@ const renderReadme = (markdown) => {
   readmeHtml.value = DOMPurify.sanitize(doc.body.innerHTML);
 };
 
+// Members and teams power friendly-name resolution for the owner badge.
+// They are not always preloaded when navigating directly to this page;
+// fall back to fetching them here.
+const ensureOrgData = async () => {
+  const orgId =
+    store.state.activeOrganization?.organization?.id ||
+    store.state.profile?.preferredOrganization ||
+    store.state.organizations?.[0]?.organization?.id;
+  if (!orgId) return;
+  const needsMembers = !store.state.orgMembers?.length;
+  const needsTeams = !store.state.teams?.length;
+  if (!needsMembers && !needsTeams) return;
+  try {
+    const token = await useGetToken();
+    const base = `${store.state.config.apiUrl}/organizations/${orgId}`;
+    await Promise.all([
+      needsMembers
+        ? useSendXhr(`${base}/members?api_key=${token}`).then((r) =>
+            store.dispatch("updateOrgMembers", r)
+          )
+        : Promise.resolve(),
+      needsTeams
+        ? useSendXhr(`${base}/teams?api_key=${token}`).then((r) =>
+            store.dispatch("updateTeams", r)
+          )
+        : Promise.resolve(),
+    ]);
+  } catch (err) {
+    console.warn("Failed to load org data for application detail:", err);
+  }
+};
+
 /*
   Fetch application detail
 */
@@ -217,6 +251,7 @@ const loadDetail = async (uuid) => {
     const [detailResult] = await Promise.allSettled([
       store.dispatch("analysisModule/fetchApplication", uuid),
       store.dispatch("analysisModule/fetchApplicationPermissions", uuid),
+      ensureOrgData(),
     ]);
 
     if (detailResult.status === "fulfilled") {

--- a/src/components/Analysis/Applications/ApplicationDetail.vue
+++ b/src/components/Analysis/Applications/ApplicationDetail.vue
@@ -360,7 +360,6 @@ watch(
               <app-archive-toggle
                 :uuid="detail.uuid"
                 :owner-id="detail.ownerId"
-                :source-url="detail.sourceUrl"
                 :status="detail.status"
                 @change="onArchiveChange"
               />

--- a/src/components/Analysis/Applications/ApplicationsGrid.vue
+++ b/src/components/Analysis/Applications/ApplicationsGrid.vue
@@ -11,7 +11,7 @@ import IconAnalysis from "../../icons/IconAnalysis.vue";
 */
 const searchQuery = ref("");
 const visibilityFilter = ref("all");
-const showArchived = ref(false);
+const statusFilter = ref("active");
 
 const pageSize = 10;
 const currentPage = ref(1);
@@ -20,6 +20,12 @@ const visibilityOptions = [
   { label: "All", value: "all" },
   { label: "Public", value: "public" },
   { label: "Private", value: "private" },
+];
+
+const statusOptions = [
+  { label: "All", value: "all" },
+  { label: "Active", value: "active" },
+  { label: "Archived", value: "archived" },
 ];
 
 /*
@@ -126,9 +132,11 @@ const visibilityLabel = (app) => {
 const filteredApplications = computed(() => {
   let list = applications.value;
 
-  // Archived applications are hidden unless the user opts to show them.
-  if (!showArchived.value) {
+  // Filter by lifecycle status. "Active" (the default) hides archived apps.
+  if (statusFilter.value === "active") {
     list = list.filter((app) => app.status !== "archived");
+  } else if (statusFilter.value === "archived") {
+    list = list.filter((app) => app.status === "archived");
   }
 
   const q = searchQuery.value.trim().toLowerCase();
@@ -167,13 +175,13 @@ watch(filteredApplications, () => {
   currentPage.value = 1;
 });
 
-// Archived applications are excluded from the default list response, so
-// toggling visibility requires refetching with the includeArchived flag.
-watch(showArchived, (show) => {
+// Archived applications are excluded from the default list response, so any
+// view that includes them must refetch with the includeArchived flag.
+watch(statusFilter, (val) => {
   store
     .dispatch("analysisModule/fetchApplications", {
       force: true,
-      includeArchived: show,
+      includeArchived: val !== "active",
     })
     .catch(() => {});
 });
@@ -243,23 +251,38 @@ const goToDetail = (app) => {
         />
       </div>
 
-      <div class="status-buttons">
-        <button
-          v-for="option in visibilityOptions"
-          :key="option.value"
-          class="filter-btn"
-          :class="{ active: visibilityFilter === option.value }"
-          @click="visibilityFilter = option.value"
-        >
-          {{ option.label }}
-        </button>
-        <el-checkbox
-          v-model="showArchived"
-          size="small"
-          class="show-archived-toggle"
-        >
-          Show archived
-        </el-checkbox>
+      <div class="filter-bar">
+        <label class="filter-field">
+          <span class="filter-field-label">Visibility</span>
+          <el-select
+            v-model="visibilityFilter"
+            size="default"
+            class="filter-select"
+          >
+            <el-option
+              v-for="option in visibilityOptions"
+              :key="option.value"
+              :label="option.label"
+              :value="option.value"
+            />
+          </el-select>
+        </label>
+
+        <label class="filter-field">
+          <span class="filter-field-label">Status</span>
+          <el-select
+            v-model="statusFilter"
+            size="default"
+            class="filter-select"
+          >
+            <el-option
+              v-for="option in statusOptions"
+              :key="option.value"
+              :label="option.label"
+              :value="option.value"
+            />
+          </el-select>
+        </label>
       </div>
 
       <div v-if="filteredApplications.length > 0" class="applications-grid">
@@ -446,39 +469,28 @@ const goToDetail = (app) => {
   max-width: 320px;
 }
 
-.status-buttons {
+.filter-bar {
   display: flex;
   align-items: center;
-  gap: 8px;
+  flex-wrap: wrap;
+  gap: 20px;
   margin-bottom: 16px;
 }
 
-.show-archived-toggle {
-  margin-left: auto;
+.filter-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
-.filter-btn {
-  padding: 4px 16px;
-  border: 1px solid theme.$gray_2;
-  border-radius: 4px;
-  background: white;
-  color: theme.$gray_5;
+.filter-field-label {
   font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s;
-  line-height: 1.4;
+  font-weight: 600;
+  color: theme.$gray_5;
+}
 
-  &:hover {
-    border-color: theme.$purple_1;
-    color: theme.$purple_1;
-  }
-
-  &.active {
-    background: theme.$purple_1;
-    border-color: theme.$purple_1;
-    color: white;
-  }
+.filter-select {
+  width: 150px;
 }
 
 .applications-grid {

--- a/src/components/Analysis/Applications/ApplicationsGrid.vue
+++ b/src/components/Analysis/Applications/ApplicationsGrid.vue
@@ -11,6 +11,7 @@ import IconAnalysis from "../../icons/IconAnalysis.vue";
 */
 const searchQuery = ref("");
 const visibilityFilter = ref("all");
+const showArchived = ref(false);
 
 const pageSize = 10;
 const currentPage = ref(1);
@@ -125,6 +126,11 @@ const visibilityLabel = (app) => {
 const filteredApplications = computed(() => {
   let list = applications.value;
 
+  // Archived applications are hidden unless the user opts to show them.
+  if (!showArchived.value) {
+    list = list.filter((app) => app.status !== "archived");
+  }
+
   const q = searchQuery.value.trim().toLowerCase();
   if (q) {
     list = list.filter((app) => {
@@ -159,6 +165,17 @@ const paginatedApplications = computed(() => {
 
 watch(filteredApplications, () => {
   currentPage.value = 1;
+});
+
+// Archived applications are excluded from the default list response, so
+// toggling visibility requires refetching with the includeArchived flag.
+watch(showArchived, (show) => {
+  store
+    .dispatch("analysisModule/fetchApplications", {
+      force: true,
+      includeArchived: show,
+    })
+    .catch(() => {});
 });
 
 /*
@@ -236,6 +253,13 @@ const goToDetail = (app) => {
         >
           {{ option.label }}
         </button>
+        <el-checkbox
+          v-model="showArchived"
+          size="small"
+          class="show-archived-toggle"
+        >
+          Show archived
+        </el-checkbox>
       </div>
 
       <div v-if="filteredApplications.length > 0" class="applications-grid">
@@ -276,6 +300,9 @@ const goToDetail = (app) => {
                 </span>
                 <span class="tag created">
                   {{ new Date(app.createdAt).toLocaleDateString() }}
+                </span>
+                <span v-if="app.status === 'archived'" class="tag archived">
+                  Archived
                 </span>
               </div>
             </div>
@@ -426,6 +453,10 @@ const goToDetail = (app) => {
   margin-bottom: 16px;
 }
 
+.show-archived-toggle {
+  margin-left: auto;
+}
+
 .filter-btn {
   padding: 4px 16px;
   border: 1px solid theme.$gray_2;
@@ -554,6 +585,11 @@ const goToDetail = (app) => {
 
     &.created {
       background: theme.$gray_1;
+      color: theme.$gray_5;
+    }
+
+    &.archived {
+      background: theme.$gray_2;
       color: theme.$gray_5;
     }
   }

--- a/src/components/Analysis/RunMonitor/RunDetail.vue
+++ b/src/components/Analysis/RunMonitor/RunDetail.vue
@@ -43,6 +43,9 @@ import {
   getMemoryOptionsForCpu,
   NODE_WIDTH,
   NODE_HEIGHT,
+  validateRunName,
+  runDisplayName,
+  RUN_NAME_MAX_LENGTH,
 } from "./runHelpers";
 
 const props = defineProps({
@@ -69,7 +72,8 @@ let analyticsChannel = null;
 let analyticsChannelName = null;
 
 // Configure mode state
-const initiateForm = ref({ workflowId: "", computeNodeId: "", datasetId: "" });
+const initiateForm = ref({ workflowId: "", computeNodeId: "", datasetId: "", name: "" });
+const runNameError = ref("");
 const configDefinition = ref(null);
 const dataSourceFiles = reactive({});
 const nodeConfigs = reactive({});
@@ -209,6 +213,12 @@ const runTimeLabel = computed(() => {
 const runWorkflowName = computed(() => {
   const activity = selectedWorkflowActivity.value;
   return activity?.workflowName || "";
+});
+
+const runName = computed(() => {
+  const activity = selectedWorkflowActivity.value;
+  const raw = activity?.name || "";
+  return typeof raw === "string" ? raw.trim() : "";
 });
 
 /*
@@ -514,7 +524,8 @@ onPaneClick(() => {
 */
 const initiateWorkflowFromConfig = async (pendingConfig) => {
   const { workflowId, computeNodeId, datasetId, rerunSource: source } = pendingConfig;
-  initiateForm.value = { workflowId, computeNodeId, datasetId };
+  initiateForm.value = { workflowId, computeNodeId, datasetId, name: "" };
+  runNameError.value = "";
 
   try {
     const definition = await store.dispatch("analysisModule/fetchWorkflowDefinition", workflowId);
@@ -615,6 +626,15 @@ const cancelConfigure = () => {
 const executeWorkflow = async () => {
   const dag = configDefinition.value?.dag || [];
 
+  const nameResult = validateRunName(initiateForm.value.name);
+  runNameError.value = nameResult.error || "";
+  if (!nameResult.valid) {
+    EventBus.$emit("toast", {
+      detail: { type: "error", msg: nameResult.error },
+    });
+    return;
+  }
+
   // Validate data sources have files selected
   const missingSources = dataSourceNodes.value.filter(
     (d) => !dataSourceFiles[d.id] || dataSourceFiles[d.id].length === 0
@@ -705,6 +725,7 @@ const executeWorkflow = async () => {
       }
     });
 
+    const trimmedName = nameResult.value;
     const payload = {
       workflowInstanceConfiguration: {
         workflowId: initiateForm.value.workflowId,
@@ -713,6 +734,7 @@ const executeWorkflow = async () => {
       },
       datasetId: initiateForm.value.datasetId,
       dataSources,
+      ...(trimmedName && { name: trimmedName }),
       ...(Object.keys(dataTargets).length > 0 && { dataTargets }),
       ...(Object.keys(processorParams).length > 0 && { processorParams }),
     };
@@ -1179,7 +1201,8 @@ onUnmounted(() => {
         <span class="header-title">
           <a class="header-back-link" @click="goBack">Runs</a>
           <span class="header-breadcrumb-sep">/</span>
-          {{ runTimeLabel }}
+          {{ runName || runTimeLabel }}
+          <span v-if="runName && runTimeLabel" class="header-workflow-name">{{ runTimeLabel }}</span>
           <span v-if="runWorkflowName" class="header-workflow-name">{{ runWorkflowName }}</span>
         </span>
       </template>
@@ -1625,6 +1648,24 @@ onUnmounted(() => {
             <template v-else-if="mode === 'configure'">
               <h4 class="sidebar-section-title">Configuration Summary</h4>
               <div class="info-card">
+                <div class="info-row info-row-stacked">
+                  <label class="info-label" for="run-name-input">Run Name <span class="info-label-hint">(optional)</span></label>
+                  <input
+                    id="run-name-input"
+                    v-model="initiateForm.name"
+                    class="run-name-input"
+                    :class="{ 'has-error': !!runNameError }"
+                    type="text"
+                    :maxlength="RUN_NAME_MAX_LENGTH"
+                    placeholder="e.g. Sleep-stage-batch-01"
+                    @input="runNameError = ''"
+                    @blur="runNameError = validateRunName(initiateForm.name).error || ''"
+                  />
+                  <span v-if="runNameError" class="run-name-error">{{ runNameError }}</span>
+                  <span v-else class="run-name-hint">
+                    Up to {{ RUN_NAME_MAX_LENGTH }} characters — letters, numbers, spaces, hyphens, underscores, periods.
+                  </span>
+                </div>
                 <div class="info-row">
                   <span class="info-label">Workflow</span>
                   <span class="info-value">{{ configDefinition?.name || 'N/A' }}</span>
@@ -1740,6 +1781,12 @@ onUnmounted(() => {
             <template v-else-if="mode === 'browse' && selectedWorkflowActivity?.uuid">
               <h4 class="sidebar-section-title">Run Details</h4>
               <div class="info-card">
+                <div v-if="runName" class="info-row">
+                  <span class="info-label">Name</span>
+                  <span class="info-value truncate-value">
+                    <span class="truncate-text" :title="runName">{{ runName }}</span>
+                  </span>
+                </div>
                 <div v-if="runWorkflowName" class="info-row">
                   <span class="info-label">Workflow</span>
                   <span class="info-value truncate-value">
@@ -1930,7 +1977,7 @@ onUnmounted(() => {
     >
       <div v-if="runMetrics" class="metrics-receipt">
         <div class="receipt-header">
-          <div class="receipt-title">{{ runWorkflowName || 'Workflow Run' }}</div>
+          <div class="receipt-title">{{ runName || runWorkflowName || 'Workflow Run' }}</div>
           <div class="receipt-date">{{ formatTime(selectedWorkflowActivity?.startedAt) }}</div>
         </div>
 
@@ -2128,7 +2175,7 @@ onUnmounted(() => {
     >
       <div v-if="runMetrics" class="metrics-receipt">
         <div class="receipt-header">
-          <div class="receipt-title">{{ selectedWorkflowActivity?.workflowName || 'Workflow' }}</div>
+          <div class="receipt-title">{{ runName || selectedWorkflowActivity?.workflowName || 'Workflow' }}</div>
           <div class="receipt-date">Total: {{ formatDurationSec(runMetrics.executionTimeSec) }}</div>
         </div>
 
@@ -2851,6 +2898,53 @@ onUnmounted(() => {
   color: theme.$gray_4;
   line-height: 1.5;
   margin-top: 8px;
+}
+
+.info-row-stacked {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+}
+
+.info-label-hint {
+  font-weight: 400;
+  color: theme.$gray_4;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.run-name-input {
+  width: 100%;
+  font-size: 13px;
+  padding: 6px 8px;
+  border: 1px solid theme.$gray_3;
+  border-radius: 4px;
+  background: theme.$white;
+  color: theme.$black;
+  box-sizing: border-box;
+
+  &:focus {
+    outline: none;
+    border-color: theme.$purple_3;
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.15);
+  }
+
+  &.has-error {
+    border-color: #e02d2d;
+    box-shadow: 0 0 0 2px rgba(224, 45, 45, 0.12);
+  }
+}
+
+.run-name-hint {
+  font-size: 11px;
+  color: theme.$gray_4;
+  line-height: 1.4;
+}
+
+.run-name-error {
+  font-size: 11px;
+  color: #e02d2d;
+  line-height: 1.4;
 }
 
 .runtime-tag {

--- a/src/components/Analysis/RunMonitor/RunMonitor.vue
+++ b/src/components/Analysis/RunMonitor/RunMonitor.vue
@@ -18,6 +18,7 @@ import { useSendXhr } from "@/mixins/request/request_composable";
 import { useMetricsCounters } from "@/composables/useMetricsCounters";
 import toQueryParams from "@/utils/toQueryParams";
 import LayerNameSelector from "./LayerNameSelector.vue";
+import { validateRunName, runDisplayName, RUN_NAME_MAX_LENGTH } from "./runHelpers";
 
 const { onNodeClick, onPaneClick, fitView, updateNodeData } = useVueFlow();
 
@@ -57,7 +58,9 @@ const initiateForm = ref({
   workflowId: "",
   computeNodeId: "",
   datasetId: "",
+  name: "",
 });
+const runNameError = ref("");
 const wizardVisible = ref(false);
 const wizardStep = ref(0); // 0=workflow, 1=compute, 2=dataset, 3=confirm
 const wizardForm = ref({ workflowId: "", computeNodeId: "", datasetId: "" });
@@ -220,6 +223,14 @@ const runWorkflowName = computed(() => {
   if (!run) return '';
   const activity = selectedWorkflowActivity.value;
   return activity?.workflowName || run.workflowName || '';
+});
+
+const runName = computed(() => {
+  const run = selectedRun.value;
+  if (!run) return '';
+  const activity = selectedWorkflowActivity.value;
+  const raw = activity?.name || run.name || '';
+  return typeof raw === 'string' ? raw.trim() : '';
 });
 
 /*
@@ -910,8 +921,10 @@ const wizardBack = () => {
 };
 
 const wizardConfirm = () => {
-  // Copy wizard selections into initiateForm and trigger the existing flow
-  initiateForm.value = { ...wizardForm.value };
+  // Copy wizard selections into initiateForm and trigger the existing flow.
+  // Name is collected later in the Configuration Summary panel — start blank.
+  initiateForm.value = { ...wizardForm.value, name: "" };
+  runNameError.value = "";
   wizardVisible.value = false;
   initiateWorkflow();
 };
@@ -1037,6 +1050,8 @@ const cancelConfigure = () => {
   nodes.value = [];
   edges.value = [];
   selectedNode.value = null;
+  initiateForm.value.name = "";
+  runNameError.value = "";
   accordionActiveNames.value = ["runs"];
 };
 
@@ -1046,6 +1061,16 @@ const cancelConfigure = () => {
 const executeWorkflow = async () => {
   // Validate required inputs before executing
   const dag = configDefinition.value?.dag || [];
+
+  // Validate the optional run name first so the user can fix it before any other check.
+  const nameResult = validateRunName(initiateForm.value.name);
+  runNameError.value = nameResult.error || "";
+  if (!nameResult.valid) {
+    EventBus.$emit("toast", {
+      detail: { type: "error", msg: nameResult.error },
+    });
+    return;
+  }
 
   // Validate data sources have files selected
   const missingSources = dataSourceNodes.value.filter(
@@ -1152,6 +1177,7 @@ const executeWorkflow = async () => {
       }
     });
 
+    const trimmedName = nameResult.value;
     const payload = {
       workflowInstanceConfiguration: {
         workflowId: initiateForm.value.workflowId,
@@ -1160,6 +1186,7 @@ const executeWorkflow = async () => {
       },
       datasetId: initiateForm.value.datasetId,
       dataSources,
+      ...(trimmedName && { name: trimmedName }),
       ...(Object.keys(dataTargets).length > 0 && { dataTargets }),
       ...(Object.keys(processorParams).length > 0 && { processorParams }),
     };
@@ -1177,6 +1204,8 @@ const executeWorkflow = async () => {
     Object.keys(dataSourceFiles).forEach((k) => delete dataSourceFiles[k]);
     Object.keys(nodeConfigs).forEach((k) => delete nodeConfigs[k]);
     selectedNode.value = null;
+    initiateForm.value.name = "";
+    runNameError.value = "";
 
     // Set a temporary placeholder so the canvas doesn't show the dashboard
     const runId = newRun?.uuid || newRun?.id || newRun?.runId;
@@ -1652,7 +1681,8 @@ onUnmounted(() => {
           <template v-if="selectedRun">
             <a class="header-back-link" @click="clearRunSelection">Runs</a>
             <span class="header-breadcrumb-sep">/</span>
-            {{ runTimeLabel }}
+            {{ runName || runTimeLabel }}
+            <span v-if="runName && runTimeLabel" class="header-workflow-name">{{ runTimeLabel }}</span>
             <span v-if="runWorkflowName" class="header-workflow-name">{{ runWorkflowName }}</span>
           </template>
           <template v-else>
@@ -1679,7 +1709,8 @@ onUnmounted(() => {
                 class="active-run-card"
                 @click="selectRun(run)"
               >
-                <div class="active-run-name">{{ run.workflowName || 'Unnamed workflow' }}</div>
+                <div class="active-run-name">{{ runDisplayName(run) || 'Unnamed run' }}</div>
+                <div v-if="run.name && run.workflowName" class="active-run-subtitle">{{ run.workflowName }}</div>
                 <div class="active-run-meta">
                   <span class="run-status-dot" :class="statusDotClass(run.status)" />
                   <span>{{ statusLabel(run.status) }}</span>
@@ -1747,7 +1778,7 @@ onUnmounted(() => {
                 @click="selectRun(run)"
               >
                 <span class="run-status-dot" :class="statusDotClass(run.status)" />
-                <span class="recent-run-name">{{ run.workflowName || 'Unnamed' }}</span>
+                <span class="recent-run-name">{{ runDisplayName(run) || 'Unnamed' }}</span>
                 <span class="recent-run-status">{{ statusLabel(run.status) }}</span>
                 <span class="recent-run-time">{{ formatTime(run.completedAt || run.startedAt) }}</span>
               </div>
@@ -2198,6 +2229,24 @@ onUnmounted(() => {
             <template v-else-if="mode === 'configure'">
               <h4 class="sidebar-section-title">Configuration Summary</h4>
               <div class="info-card">
+                <div class="info-row info-row-stacked">
+                  <label class="info-label" for="run-name-input">Run Name <span class="info-label-hint">(optional)</span></label>
+                  <input
+                    id="run-name-input"
+                    v-model="initiateForm.name"
+                    class="run-name-input"
+                    :class="{ 'has-error': !!runNameError }"
+                    type="text"
+                    :maxlength="RUN_NAME_MAX_LENGTH"
+                    placeholder="e.g. Sleep-stage-batch-01"
+                    @input="runNameError = ''"
+                    @blur="runNameError = validateRunName(initiateForm.name).error || ''"
+                  />
+                  <span v-if="runNameError" class="run-name-error">{{ runNameError }}</span>
+                  <span v-else class="run-name-hint">
+                    Up to {{ RUN_NAME_MAX_LENGTH }} characters — letters, numbers, spaces, hyphens, underscores, periods.
+                  </span>
+                </div>
                 <div class="info-row">
                   <span class="info-label">Workflow</span>
                   <span class="info-value">{{ configDefinition?.name || 'N/A' }}</span>
@@ -2311,6 +2360,10 @@ onUnmounted(() => {
             <template v-else-if="mode === 'browse' && selectedRun && selectedWorkflowActivity?.uuid">
               <h4 class="sidebar-section-title">Run Details</h4>
               <div class="info-card">
+                <div v-if="runName" class="info-row">
+                  <span class="info-label">Name</span>
+                  <span class="info-value">{{ runName }}</span>
+                </div>
                 <div v-if="runWorkflowName" class="info-row">
                   <span class="info-label">Workflow</span>
                   <span class="info-value">{{ runWorkflowName }}</span>
@@ -2446,10 +2499,10 @@ onUnmounted(() => {
               >
                 <span class="run-status-dot" :class="statusDotClass(run.status)"></span>
                 <div class="wf-item-info">
-                  <div class="wf-item-name">{{ formatTime(run.startedAt) }} </div>
-                  <div class="wf-item-meta">{{ run.workflowName || 'Unnamed workflow' }}</div>
+                  <div class="wf-item-name">{{ runDisplayName(run) || formatTime(run.startedAt) }}</div>
+                  <div v-if="run.name" class="wf-item-meta">{{ run.workflowName || 'Unnamed workflow' }}</div>
+                  <div class="wf-item-meta">{{ formatTime(run.startedAt) }}</div>
                   <div class="wf-item-meta">
-
                     {{ computeNodeName(run.computeNodeUuid) }}
                   </div>
                   <div class="wf-item-meta">{{ getUserName(run.createdBy) }}</div>
@@ -2724,7 +2777,7 @@ onUnmounted(() => {
       <div v-if="runMetrics" class="metrics-receipt">
         <!-- Header -->
         <div class="receipt-header">
-          <div class="receipt-title">{{ runWorkflowName || 'Workflow Run' }}</div>
+          <div class="receipt-title">{{ runName || runWorkflowName || 'Workflow Run' }}</div>
           <div class="receipt-date">{{ formatTime(selectedWorkflowActivity?.startedAt) }}</div>
         </div>
 
@@ -2926,7 +2979,7 @@ onUnmounted(() => {
     >
       <div v-if="runMetrics" class="metrics-receipt">
         <div class="receipt-header">
-          <div class="receipt-title">{{ selectedWorkflowActivity?.workflowName || 'Workflow' }}</div>
+          <div class="receipt-title">{{ runName || selectedWorkflowActivity?.workflowName || 'Workflow' }}</div>
           <div class="receipt-date">Total: {{ formatDurationSec(runMetrics.executionTimeSec) }}</div>
         </div>
 
@@ -3283,6 +3336,13 @@ onUnmounted(() => {
   font-size: 14px;
   font-weight: 600;
   color: theme.$black;
+  margin-bottom: 6px;
+}
+
+.active-run-subtitle {
+  font-size: 11px;
+  color: theme.$gray_4;
+  margin-top: -4px;
   margin-bottom: 6px;
 }
 
@@ -3899,6 +3959,53 @@ onUnmounted(() => {
   color: theme.$gray_4;
   line-height: 1.5;
   margin-top: 8px;
+}
+
+.info-row-stacked {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+}
+
+.info-label-hint {
+  font-weight: 400;
+  color: theme.$gray_4;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.run-name-input {
+  width: 100%;
+  font-size: 13px;
+  padding: 6px 8px;
+  border: 1px solid theme.$gray_3;
+  border-radius: 4px;
+  background: theme.$white;
+  color: theme.$black;
+  box-sizing: border-box;
+
+  &:focus {
+    outline: none;
+    border-color: theme.$purple_3;
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.15);
+  }
+
+  &.has-error {
+    border-color: #e02d2d;
+    box-shadow: 0 0 0 2px rgba(224, 45, 45, 0.12);
+  }
+}
+
+.run-name-hint {
+  font-size: 11px;
+  color: theme.$gray_4;
+  line-height: 1.4;
+}
+
+.run-name-error {
+  font-size: 11px;
+  color: #e02d2d;
+  line-height: 1.4;
 }
 
 .runtime-tag {

--- a/src/components/Analysis/RunMonitor/RunsOverview.vue
+++ b/src/components/Analysis/RunMonitor/RunsOverview.vue
@@ -17,6 +17,7 @@ import {
   computeNodeName as computeNodeNameFn,
   getUserName as getUserNameFn,
   runStatusOptions,
+  runDisplayName,
 } from "./runHelpers";
 
 const store = useStore();
@@ -395,7 +396,8 @@ onBeforeUnmount(() => {
               class="active-run-card"
               @click="selectRun(run)"
             >
-              <div class="active-run-name">{{ run.workflowName || 'Unnamed workflow' }}</div>
+              <div class="active-run-name">{{ runDisplayName(run) || 'Unnamed run' }}</div>
+              <div v-if="run.name && run.workflowName" class="active-run-subtitle">{{ run.workflowName }}</div>
               <div class="active-run-meta">
                 <span class="run-status-dot" :class="statusDotClass(run.status)" />
                 <span>{{ statusLabel(run.status) }}</span>
@@ -463,7 +465,7 @@ onBeforeUnmount(() => {
               @click="selectRun(run)"
             >
               <span class="run-status-dot" :class="statusDotClass(run.status)" />
-              <span class="recent-run-name">{{ run.workflowName || 'Unnamed' }}</span>
+              <span class="recent-run-name">{{ runDisplayName(run) || 'Unnamed' }}</span>
               <span class="recent-run-status">{{ statusLabel(run.status) }}</span>
               <span class="recent-run-time">{{ formatTime(run.completedAt || run.startedAt) }}</span>
             </div>
@@ -535,8 +537,9 @@ onBeforeUnmount(() => {
               >
                 <span class="run-status-dot" :class="statusDotClass(run.status)"></span>
                 <div class="wf-item-info">
-                  <div class="wf-item-name">{{ formatTime(run.startedAt) }}</div>
-                  <div class="wf-item-meta">{{ run.workflowName || 'Unnamed workflow' }}</div>
+                  <div class="wf-item-name">{{ runDisplayName(run) || formatTime(run.startedAt) }}</div>
+                  <div v-if="run.name" class="wf-item-meta">{{ run.workflowName || 'Unnamed workflow' }}</div>
+                  <div class="wf-item-meta">{{ formatTime(run.startedAt) }}</div>
                   <div class="wf-item-meta">{{ computeNodeName(run.computeNodeUuid) }}</div>
                   <div class="wf-item-meta">{{ getUserName(run.createdBy) }}</div>
                 </div>
@@ -894,6 +897,13 @@ onBeforeUnmount(() => {
   font-size: 14px;
   font-weight: 600;
   color: theme.$black;
+  margin-bottom: 6px;
+}
+
+.active-run-subtitle {
+  font-size: 11px;
+  color: theme.$gray_4;
+  margin-top: -4px;
   margin-bottom: 6px;
 }
 

--- a/src/components/Analysis/RunMonitor/runHelpers.js
+++ b/src/components/Analysis/RunMonitor/runHelpers.js
@@ -221,6 +221,44 @@ export const getCpuForMemory = (memory) => {
   return FARGATE_CPU_OPTIONS[FARGATE_CPU_OPTIONS.length - 1];
 };
 
+// Standard (Fargate) CPU/memory selection for workflow processors.
+// Mirrors the original Create Application form exactly: CPU is offered in whole
+// CPU units (1024 = 1 CPU) and the available memory depends on the chosen CPU.
+export const STANDARD_CPU_OPTIONS = [
+  { value: "1024", label: "1 CPU" },
+  { value: "2048", label: "2 CPU" },
+  { value: "4096", label: "4 CPU" },
+  { value: "8192", label: "8 CPU" },
+];
+
+// Memory range (in GB) selectable for each CPU value: start..end stepping by `i`.
+// Extra CPU keys are kept unsurfaced for parity with the original form.
+const STANDARD_MEMORY_MAP = {
+  "256": { start: 1, end: 2, i: 1 },
+  "512": { start: 1, end: 4, i: 1 },
+  "1024": { start: 2, end: 8, i: 1 },
+  "2048": { start: 4, end: 16, i: 1 },
+  "4096": { start: 8, end: 30, i: 1 },
+  "8192": { start: 16, end: 60, i: 4 },
+  "16384": { start: 32, end: 120, i: 8 },
+};
+
+// Memory options for a given CPU value, matching the original Create Application
+// form. Values are returned in MiB (GB * 1024) with GB labels.
+export const getStandardMemoryOptions = (cpu) => {
+  const memVars = STANDARD_MEMORY_MAP[String(cpu)];
+  if (!memVars) return [];
+  const { start, end, i } = memVars;
+  const options = [];
+  if (String(cpu) === "256") {
+    options.push({ value: "512", label: "512 MiB" });
+  }
+  for (let gb = start; gb <= end; gb += i) {
+    options.push({ value: String(gb * 1024), label: `${gb} GB` });
+  }
+  return options;
+};
+
 export const formatResourceLabel = (val) => {
   const n = parseInt(val, 10);
   if (n >= 1024) return `${(n / 1024).toFixed(n % 1024 === 0 ? 0 : 1)} GB`;

--- a/src/components/Analysis/RunMonitor/runHelpers.js
+++ b/src/components/Analysis/RunMonitor/runHelpers.js
@@ -105,6 +105,41 @@ export const labelForDagNode = (d, applications, targetTypes = []) => {
   return matchedApp ? matchedApp.name : extractRepoName(d.sourceUrl) || d.type || d.id;
 };
 
+// Run name validation and display.
+// Pattern follows common cloud-resource conventions (AWS Step Functions / Kubernetes-friendly):
+//  - 3-64 characters
+//  - Letters, numbers, spaces, hyphens, underscores, periods
+//  - Must start with a letter or number
+export const RUN_NAME_MAX_LENGTH = 64;
+export const RUN_NAME_MIN_LENGTH = 3;
+const RUN_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9 _.\-]*$/;
+
+export const validateRunName = (raw) => {
+  const name = (raw == null ? "" : String(raw)).trim();
+  if (!name) return { valid: true, error: null, value: "" };
+  if (name.length < RUN_NAME_MIN_LENGTH) {
+    return { valid: false, error: `Must be at least ${RUN_NAME_MIN_LENGTH} characters`, value: name };
+  }
+  if (name.length > RUN_NAME_MAX_LENGTH) {
+    return { valid: false, error: `Must be ${RUN_NAME_MAX_LENGTH} characters or fewer`, value: name };
+  }
+  if (!RUN_NAME_PATTERN.test(name)) {
+    return {
+      valid: false,
+      error: "Use letters, numbers, spaces, hyphens, underscores, or periods (must start with a letter or number)",
+      value: name,
+    };
+  }
+  return { valid: true, error: null, value: name };
+};
+
+export const runDisplayName = (run) => {
+  if (!run) return "";
+  const name = typeof run.name === "string" ? run.name.trim() : "";
+  if (name) return name;
+  return run.workflowName || "";
+};
+
 // Time formatting
 export const formatTime = (dateStr) => {
   if (!dateStr) return "N/A";

--- a/src/components/Analysis/WorkflowBuilder/WorkflowBuilder.vue
+++ b/src/components/Analysis/WorkflowBuilder/WorkflowBuilder.vue
@@ -16,7 +16,6 @@ import IconAnalysis from "../../icons/IconAnalysis.vue";
 import IconInfoSmall from "../../icons/IconInfoSmall.vue";
 import IconPencil from "../../icons/IconPencil.vue";
 import {
-  FARGATE_CPU_OPTIONS,
   STANDARD_CPU_OPTIONS,
   getStandardMemoryOptions,
   LAMBDA_MEMORY_OPTIONS,
@@ -1492,21 +1491,9 @@ const openNodeSettings = (id) => {
                   <template v-else>
                     <div class="info-row">
                       <span class="info-label">CPU</span>
-                      <el-select
-                        v-model="selectedNode.data.cpu"
-                        size="small"
-                        disabled
-                        class="info-inline-select"
-                      >
-                        <el-option
-                          v-for="cpu in FARGATE_CPU_OPTIONS"
-                          :key="cpu"
-                          :label="`${cpu} (${(cpu / 1024).toFixed(
-                            cpu >= 1024 ? 0 : 2,
-                          )} vCPU)`"
-                          :value="cpu"
-                        />
-                      </el-select>
+                      <span class="info-auto-value">
+                        Set automatically
+                      </span>
                     </div>
                     <div class="info-row">
                       <span class="info-label">Memory</span>
@@ -1531,8 +1518,9 @@ const openNodeSettings = (id) => {
                       </el-select>
                     </div>
                     <p class="runtime-note">
-                      Lambda allocates CPU proportionally to memory. CPU and
-                      Fargate memory settings are only applied if the run is
+                      Lambda sizes CPU automatically in proportion to the
+                      memory you choose — there's no CPU to set here. The
+                      Fargate CPU/memory values only apply if the run is
                       overridden to execute as a standard processor.
                     </p>
                   </template>
@@ -2782,6 +2770,14 @@ const openNodeSettings = (id) => {
     display: flex;
     align-items: center;
   }
+}
+
+.info-auto-value {
+  width: 130px;
+  font-size: 12px;
+  color: theme.$gray_4;
+  font-style: italic;
+  text-align: right;
 }
 
 .runtime-note {

--- a/src/components/Analysis/WorkflowBuilder/WorkflowBuilder.vue
+++ b/src/components/Analysis/WorkflowBuilder/WorkflowBuilder.vue
@@ -17,7 +17,8 @@ import IconInfoSmall from "../../icons/IconInfoSmall.vue";
 import IconPencil from "../../icons/IconPencil.vue";
 import {
   FARGATE_CPU_OPTIONS,
-  getMemoryOptionsForCpu,
+  STANDARD_CPU_OPTIONS,
+  getStandardMemoryOptions,
   LAMBDA_MEMORY_OPTIONS,
   getCpuForMemory,
   formatResourceLabel,
@@ -1459,12 +1460,10 @@ const openNodeSettings = (id) => {
                         "
                       >
                         <el-option
-                          v-for="cpu in FARGATE_CPU_OPTIONS"
-                          :key="cpu"
-                          :label="`${cpu} (${(cpu / 1024).toFixed(
-                            cpu >= 1024 ? 0 : 2,
-                          )} vCPU)`"
-                          :value="cpu"
+                          v-for="opt in STANDARD_CPU_OPTIONS"
+                          :key="opt.value"
+                          :label="opt.label"
+                          :value="opt.value"
                         />
                       </el-select>
                     </div>
@@ -1473,18 +1472,18 @@ const openNodeSettings = (id) => {
                       <el-select
                         v-model="selectedNode.data.memory"
                         size="small"
-                        placeholder="Default"
+                        placeholder="Select CPU before Memory"
                         clearable
                         :disabled="!selectedNode.data.cpu"
                         class="info-inline-select"
                       >
                         <el-option
-                          v-for="mem in getMemoryOptionsForCpu(
+                          v-for="opt in getStandardMemoryOptions(
                             selectedNode.data.cpu,
                           )"
-                          :key="mem"
-                          :label="formatResourceLabel(mem)"
-                          :value="mem"
+                          :key="opt.value"
+                          :label="opt.label"
+                          :value="opt.value"
                         />
                       </el-select>
                     </div>

--- a/src/components/user/code/AppArchiveToggle.vue
+++ b/src/components/user/code/AppArchiveToggle.vue
@@ -3,10 +3,9 @@
   Shared archive/restore toggle for an App Store application.
 
   Renders an Active/Archived switch and owns the lifecycle change:
-  PATCH /applications/store/{uuid} with { status }. Archiving also turns off
-  App Store publishing for the source repository (restoring does not turn it
-  back on). The switch only flips after the backend confirms the change.
-  Emits `change` with the new status so the parent can update its local copy.
+  PATCH /applications/store/{uuid} with { status }. The switch only flips
+  after the backend confirms the change. Emits `change` with the new status
+  so the parent can update its local copy.
 */
 import { computed, ref } from 'vue'
 import { useStore } from 'vuex'
@@ -20,11 +19,6 @@ const props = defineProps({
   ownerId: {
     type: [String, Number],
     default: null,
-  },
-  // Application's source repo URL — used to turn off publishing on archive.
-  sourceUrl: {
-    type: String,
-    default: '',
   },
   // Current lifecycle status: 'active' | 'archived'.
   status: {
@@ -49,37 +43,6 @@ const isArchived = computed(() => props.status === 'archived')
 const ownerTooltip = computed(() =>
   isAppOwner.value ? '' : 'Only Application Owners Can Archive Applications'
 )
-
-const normalizeRepoUrl = (url) =>
-  (url || '').replace(/\.git$/, '').replace(/\/+$/, '').toLowerCase()
-
-// Turn off App Store publishing for the source repository. The /repositories
-// update is a full write, so we preserve the current publish_to_discover flag
-// and only clear publish_to_appstore.
-const disableAppStorePublishing = async () => {
-  if (!props.sourceUrl) return
-
-  if (!store.state.codeReposModule.myReposLoaded) {
-    await store.dispatch('codeReposModule/fetchAllMyRepos')
-  }
-
-  const target = normalizeRepoUrl(props.sourceUrl)
-  const repos = store.state.codeReposModule.myRepos || []
-  const repo = repos.find((r) =>
-    [r.html_url, r.url].some((u) => u && normalizeRepoUrl(u) === target)
-  )
-
-  if (!repo) {
-    throw new Error(`Could not find a repository matching ${props.sourceUrl}`)
-  }
-  if (!repo.publishing_to_appstore) return // already off — nothing to do
-
-  await store.dispatch('codeReposModule/updateRepoPublishingSettings', {
-    repoUrl: repo.url,
-    publish_to_discover: Boolean(repo.publishing_to_discover),
-    publish_to_appstore: false,
-  })
-}
 
 // el-switch :before-change handler. Resolve true to let the toggle flip,
 // reject (or resolve false) to keep it where it was.
@@ -106,21 +69,6 @@ const handleArchiveToggle = async () => {
     store
       .dispatch('analysisModule/fetchApplications', { force: true })
       .catch(() => {})
-
-    // Archiving must also turn off App Store publishing. Restoring does not
-    // re-enable it.
-    if (nextStatus === 'archived') {
-      try {
-        await disableAppStorePublishing()
-      } catch (pubErr) {
-        console.error('Failed to disable App Store publishing:', pubErr)
-        ElMessage.warning(
-          'Application archived, but App Store publishing could not be turned off automatically. Please disable it in the repository’s publishing settings.'
-        )
-        emit('change', nextStatus)
-        return true // archive succeeded; keep the toggle archived
-      }
-    }
 
     emit('change', nextStatus)
     ElMessage.success(

--- a/src/components/user/code/AppArchiveToggle.vue
+++ b/src/components/user/code/AppArchiveToggle.vue
@@ -1,0 +1,164 @@
+<script setup>
+/*
+  Shared archive/restore toggle for an App Store application.
+
+  Renders an Active/Archived switch and owns the lifecycle change:
+  PATCH /applications/store/{uuid} with { status }. Archiving also turns off
+  App Store publishing for the source repository (restoring does not turn it
+  back on). The switch only flips after the backend confirms the change.
+  Emits `change` with the new status so the parent can update its local copy.
+*/
+import { computed, ref } from 'vue'
+import { useStore } from 'vuex'
+import { ElMessage, ElMessageBox } from 'element-plus'
+
+const props = defineProps({
+  uuid: {
+    type: String,
+    required: true,
+  },
+  ownerId: {
+    type: [String, Number],
+    default: null,
+  },
+  // Application's source repo URL — used to turn off publishing on archive.
+  sourceUrl: {
+    type: String,
+    default: '',
+  },
+  // Current lifecycle status: 'active' | 'archived'.
+  status: {
+    type: String,
+    default: 'active',
+  },
+})
+
+const emit = defineEmits(['change'])
+
+const store = useStore()
+const profile = computed(() => store.state.profile)
+
+const isArchiving = ref(false)
+
+const isCurrentUser = (id) =>
+  !!id && (id === profile.value?.id || id === profile.value?.intId)
+
+const isAppOwner = computed(() => isCurrentUser(props.ownerId))
+const isArchived = computed(() => props.status === 'archived')
+
+const ownerTooltip = computed(() =>
+  isAppOwner.value ? '' : 'Only Application Owners Can Archive Applications'
+)
+
+const normalizeRepoUrl = (url) =>
+  (url || '').replace(/\.git$/, '').replace(/\/+$/, '').toLowerCase()
+
+// Turn off App Store publishing for the source repository. The /repositories
+// update is a full write, so we preserve the current publish_to_discover flag
+// and only clear publish_to_appstore.
+const disableAppStorePublishing = async () => {
+  if (!props.sourceUrl) return
+
+  if (!store.state.codeReposModule.myReposLoaded) {
+    await store.dispatch('codeReposModule/fetchAllMyRepos')
+  }
+
+  const target = normalizeRepoUrl(props.sourceUrl)
+  const repos = store.state.codeReposModule.myRepos || []
+  const repo = repos.find((r) =>
+    [r.html_url, r.url].some((u) => u && normalizeRepoUrl(u) === target)
+  )
+
+  if (!repo) {
+    throw new Error(`Could not find a repository matching ${props.sourceUrl}`)
+  }
+  if (!repo.publishing_to_appstore) return // already off — nothing to do
+
+  await store.dispatch('codeReposModule/updateRepoPublishingSettings', {
+    repoUrl: repo.url,
+    publish_to_discover: Boolean(repo.publishing_to_discover),
+    publish_to_appstore: false,
+  })
+}
+
+// el-switch :before-change handler. Resolve true to let the toggle flip,
+// reject (or resolve false) to keep it where it was.
+const handleArchiveToggle = async () => {
+  if (!props.uuid || !isAppOwner.value) return false
+  const nextStatus = isArchived.value ? 'active' : 'archived'
+
+  if (nextStatus === 'archived') {
+    // Rejects on cancel, which stops the toggle.
+    await ElMessageBox.confirm(
+      'Archive this application? It will be removed from active workspaces and workflows that reference it will no longer be able to run it. The underlying record is preserved and you can restore it later.',
+      'Archive Application',
+      { confirmButtonText: 'Archive', cancelButtonText: 'Cancel', type: 'warning' }
+    )
+  }
+
+  isArchiving.value = true
+  try {
+    await store.dispatch('analysisModule/setApplicationStatus', {
+      uuid: props.uuid,
+      status: nextStatus,
+    })
+    // Refresh the shared applications list so other views reflect the change.
+    store
+      .dispatch('analysisModule/fetchApplications', { force: true })
+      .catch(() => {})
+
+    // Archiving must also turn off App Store publishing. Restoring does not
+    // re-enable it.
+    if (nextStatus === 'archived') {
+      try {
+        await disableAppStorePublishing()
+      } catch (pubErr) {
+        console.error('Failed to disable App Store publishing:', pubErr)
+        ElMessage.warning(
+          'Application archived, but App Store publishing could not be turned off automatically. Please disable it in the repository’s publishing settings.'
+        )
+        emit('change', nextStatus)
+        return true // archive succeeded; keep the toggle archived
+      }
+    }
+
+    emit('change', nextStatus)
+    ElMessage.success(
+      nextStatus === 'archived' ? 'Application archived' : 'Application restored'
+    )
+    return true
+  } catch (error) {
+    console.error(error)
+    ElMessage.error('Failed to update application status. Please try again.')
+    throw error // keep the toggle in its previous position
+  } finally {
+    isArchiving.value = false
+  }
+}
+</script>
+
+<template>
+  <el-tooltip
+    :content="ownerTooltip"
+    placement="top"
+    :disabled="isAppOwner"
+  >
+    <span class="archive-toggle-wrap">
+      <el-switch
+        :model-value="!isArchived"
+        :loading="isArchiving"
+        :disabled="!isAppOwner"
+        :before-change="handleArchiveToggle"
+        active-text="Active"
+        inactive-text="Archived"
+      />
+    </span>
+  </el-tooltip>
+</template>
+
+<style scoped lang="scss">
+.archive-toggle-wrap {
+  display: inline-flex;
+  align-items: center;
+}
+</style>

--- a/src/components/user/code/AppPermissions.vue
+++ b/src/components/user/code/AppPermissions.vue
@@ -663,16 +663,17 @@ defineExpose({ reload: () => loadPermissions(props.uuid) })
 .info-content {
   .info-row {
     display: flex;
+    align-items: center;
+    flex-wrap: wrap;
     padding: 12px 0;
     border-bottom: 1px solid theme.$gray_1;
-    gap: 16px;
+    gap: 8px 10px;
 
     &:last-child {
       border-bottom: none;
     }
 
     .info-label {
-      flex: 1;
       color: theme.$gray_6;
       font-weight: 500;
       font-size: 14px;
@@ -685,6 +686,12 @@ defineExpose({ reload: () => loadPermissions(props.uuid) })
 
       &.perm-role {
         text-transform: capitalize;
+        padding: 2px 8px;
+        border-radius: 10px;
+        background: theme.$gray_1;
+        color: theme.$gray_6;
+        font-size: 12px;
+        font-weight: 500;
       }
     }
   }

--- a/src/components/user/code/AppPermissions.vue
+++ b/src/components/user/code/AppPermissions.vue
@@ -12,6 +12,8 @@ import { useStore } from 'vuex'
 import { ElMessage } from 'element-plus'
 
 import BfButton from '@/components/shared/bf-button/BfButton.vue'
+import { useGetToken } from '@/composables/useGetToken'
+import { useSendXhr } from '@/mixins/request/request_composable'
 
 const props = defineProps({
   // Application uuid whose permissions we manage.
@@ -282,6 +284,40 @@ const confirmAddWorkspace = () => {
   showAddWorkspaceDialog.value = false
 }
 
+// Members and teams power friendly-name resolution for permission entries
+// and the owner badge. They are not always preloaded — when the user opens
+// the Publishing dialog from the My Code page, getPrimaryData() in main.js
+// may not have run for the current org yet. Fall back to loading them here.
+const ensureOrgData = async () => {
+  const orgId =
+    props.organizationId ||
+    store.state.activeOrganization?.organization?.id ||
+    store.state.profile?.preferredOrganization ||
+    store.state.organizations?.[0]?.organization?.id
+  if (!orgId) return
+  const needsMembers = !store.state.orgMembers?.length
+  const needsTeams = !store.state.teams?.length
+  if (!needsMembers && !needsTeams) return
+  try {
+    const token = await useGetToken()
+    const base = `${store.state.config.apiUrl}/organizations/${orgId}`
+    await Promise.all([
+      needsMembers
+        ? useSendXhr(`${base}/members?api_key=${token}`).then((r) =>
+            store.dispatch('updateOrgMembers', r)
+          )
+        : Promise.resolve(),
+      needsTeams
+        ? useSendXhr(`${base}/teams?api_key=${token}`).then((r) =>
+            store.dispatch('updateTeams', r)
+          )
+        : Promise.resolve(),
+    ])
+  } catch (err) {
+    console.warn('Failed to load org data for permissions:', err)
+  }
+}
+
 /* Fetch + save */
 const loadPermissions = async (uuid) => {
   permissions.value = []
@@ -290,10 +326,10 @@ const loadPermissions = async (uuid) => {
   if (!uuid) return
   permissionsLoading.value = true
   try {
-    const data = await store.dispatch(
-      'analysisModule/fetchApplicationPermissions',
-      uuid
-    )
+    const [data] = await Promise.all([
+      store.dispatch('analysisModule/fetchApplicationPermissions', uuid),
+      ensureOrgData(),
+    ])
     permissions.value = Array.isArray(data)
       ? data
       : Array.isArray(data?.access)

--- a/src/components/user/code/AppPermissions.vue
+++ b/src/components/user/code/AppPermissions.vue
@@ -1,0 +1,830 @@
+<script setup>
+/*
+  Shared application permissions manager.
+
+  Renders the "Permissions" section for an App Store application: a read-only
+  list plus an edit mode for granting/removing users, teams, and workspaces.
+  Self-contained — it fetches and saves permissions itself and is reused by
+  the single app view, the My Workspace app page, and the repo settings modal.
+*/
+import { computed, ref, watch } from 'vue'
+import { useStore } from 'vuex'
+import { ElMessage } from 'element-plus'
+
+import BfButton from '@/components/shared/bf-button/BfButton.vue'
+
+const props = defineProps({
+  // Application uuid whose permissions we manage.
+  uuid: {
+    type: String,
+    required: true,
+  },
+  // Owner id of the application (used to decide who may edit).
+  ownerId: {
+    type: [String, Number],
+    default: null,
+  },
+  // Whether the application is public. Permissions are only editable for
+  // private applications owned by the current user.
+  isPublic: {
+    type: Boolean,
+    default: false,
+  },
+  // Optional org context; falls back to the permissions payload / active org.
+  organizationId: {
+    type: [String, Number],
+    default: null,
+  },
+})
+
+const emit = defineEmits(['updated'])
+
+const store = useStore()
+
+const profile = computed(() => store.state.profile)
+const orgMembers = computed(() => store.state.orgMembers || [])
+const teams = computed(() => store.state.teams || [])
+const organizations = computed(() => store.state.organizations || [])
+
+/* Permissions data */
+const permissions = ref([])
+const permissionsLoading = ref(false)
+const permissionsError = ref('')
+
+/* Edit state */
+const isEditingPermissions = ref(false)
+const editVisibility = ref('private')
+const editUsers = ref([])
+const editTeams = ref([])
+const editWorkspaces = ref([])
+const isSavingPermissions = ref(false)
+const showAddUserDialog = ref(false)
+const showAddTeamDialog = ref(false)
+const showAddWorkspaceDialog = ref(false)
+const selectedAddUserId = ref(null)
+const selectedAddTeamId = ref(null)
+const selectedAddWorkspaceId = ref(null)
+
+const activeOrgId = computed(
+  () =>
+    props.organizationId ||
+    (permissions.value || []).find((p) => p.organizationId)?.organizationId ||
+    store.state.activeOrganization?.organization?.id ||
+    null
+)
+
+const isCurrentUser = (id) =>
+  !!id && (id === profile.value?.id || id === profile.value?.intId)
+
+const isAppOwner = computed(() => isCurrentUser(props.ownerId))
+
+const canEditPermissions = computed(
+  () => isAppOwner.value && !props.isPublic
+)
+
+const editPermissionsTooltip = computed(() => {
+  if (props.isPublic) {
+    return 'Only Private Repos allow Owners to update permissions'
+  }
+  if (!isAppOwner.value) {
+    return 'Only Application Owners Can Update Permissions'
+  }
+  return ''
+})
+
+/* Name resolution */
+const getUserName = (userId) => {
+  if (!userId) return 'Unknown'
+  if (
+    profile.value &&
+    (profile.value.id === userId || profile.value.intId === userId)
+  ) {
+    return `${profile.value.firstName} ${profile.value.lastName}`.trim() || 'You'
+  }
+  const member = orgMembers.value.find(
+    (m) => m.id === userId || m.intId === userId
+  )
+  if (member) {
+    return `${member.firstName} ${member.lastName}`.trim() || 'Unknown User'
+  }
+  return String(userId).includes(':')
+    ? String(userId).split(':').pop()
+    : String(userId)
+}
+
+const getWorkspaceName = (workspaceId) => {
+  if (!workspaceId) return null
+  const match = organizations.value.find(
+    (o) =>
+      o.organization?.id === workspaceId ||
+      o.organization?.intId === workspaceId
+  )
+  return match?.organization?.name || null
+}
+
+const getTeamName = (teamId) => {
+  if (!teamId) return null
+  const match = teams.value.find(
+    (t) => t.team?.id === teamId || t.team?.intId === teamId
+  )
+  return match?.team?.name || null
+}
+
+/* Permission shape helpers (the API uses a few different field names) */
+const permissionEntityType = (perm) =>
+  perm.entityType ||
+  perm.granteeType ||
+  (perm.userId
+    ? 'user'
+    : perm.teamId
+      ? 'team'
+      : perm.organizationId || perm.workspaceId
+        ? 'workspace'
+        : null)
+
+const permissionEntityId = (perm) =>
+  perm.entityRawId ||
+  perm.userId ||
+  perm.teamId ||
+  perm.organizationId ||
+  perm.workspaceId ||
+  perm.granteeId ||
+  null
+
+const permissionLabel = (perm) => {
+  const type = permissionEntityType(perm)
+  const id = permissionEntityId(perm)
+  if (type === 'user') return getUserName(id)
+  if (type === 'team') {
+    const name = perm.teamName || getTeamName(id) || id
+    return `Team: ${name}`
+  }
+  if (type === 'workspace' || type === 'organization') {
+    const name =
+      perm.organizationName || perm.workspaceName || getWorkspaceName(id) || id
+    return `Workspace: ${name}`
+  }
+  if (id) return type ? `${type}: ${id}` : id
+  return 'Unknown'
+}
+
+const permissionRole = (perm) =>
+  perm.accessType || perm.role || perm.permission || perm.accessLevel || '—'
+
+/* Edit helpers */
+const splitPermissions = (perms) => {
+  const users = []
+  const editTeamsList = []
+  const workspaces = []
+  for (const p of perms || []) {
+    const type = permissionEntityType(p)
+    const id = permissionEntityId(p)
+    if (!id) continue
+    const organizationId = p.organizationId || activeOrgId.value
+    if (type === 'user') {
+      users.push({ entityId: id, organizationId })
+    } else if (type === 'team') {
+      editTeamsList.push({ entityId: id, organizationId, teamName: p.teamName })
+    } else if (type === 'workspace' || type === 'organization') {
+      workspaces.push({
+        entityId: id,
+        organizationId,
+        organizationName: p.organizationName || p.workspaceName,
+      })
+    }
+  }
+  return { users, teams: editTeamsList, workspaces }
+}
+
+const startEditingPermissions = () => {
+  const split = splitPermissions(permissions.value)
+  editUsers.value = split.users
+  editTeams.value = split.teams
+  editWorkspaces.value = split.workspaces
+  editVisibility.value = props.isPublic ? 'public' : 'private'
+  isEditingPermissions.value = true
+}
+
+const cancelEditingPermissions = () => {
+  isEditingPermissions.value = false
+}
+
+const removeEditUser = (idx) => {
+  const user = editUsers.value[idx]
+  if (user && isCurrentUser(user.entityId)) return
+  editUsers.value.splice(idx, 1)
+}
+const removeEditTeam = (idx) => editTeams.value.splice(idx, 1)
+const removeEditWorkspace = (idx) => editWorkspaces.value.splice(idx, 1)
+
+const availableAddableUsers = computed(() => {
+  const taken = new Set(editUsers.value.map((u) => u.entityId))
+  return orgMembers.value.filter((m) => m.id && !taken.has(m.id))
+})
+
+const availableAddableTeams = computed(() => {
+  const taken = new Set(editTeams.value.map((t) => t.entityId))
+  return teams.value.filter((t) => t.team?.id && !taken.has(t.team.id))
+})
+
+const availableAddableWorkspaces = computed(() => {
+  const taken = new Set(editWorkspaces.value.map((w) => w.entityId))
+  return organizations.value.filter(
+    (o) =>
+      o.organization?.id &&
+      !taken.has(o.organization.id) &&
+      o.organization.name?.toLowerCase() !== 'welcome'
+  )
+})
+
+const openAddUserDialog = () => {
+  selectedAddUserId.value = null
+  showAddUserDialog.value = true
+}
+const confirmAddUser = () => {
+  if (!selectedAddUserId.value) return
+  editUsers.value.push({
+    entityId: selectedAddUserId.value,
+    organizationId: activeOrgId.value,
+  })
+  showAddUserDialog.value = false
+}
+
+const openAddTeamDialog = () => {
+  selectedAddTeamId.value = null
+  showAddTeamDialog.value = true
+}
+const confirmAddTeam = () => {
+  if (!selectedAddTeamId.value) return
+  const team = teams.value.find((t) => t.team?.id === selectedAddTeamId.value)
+  editTeams.value.push({
+    entityId: selectedAddTeamId.value,
+    organizationId: activeOrgId.value,
+    teamName: team?.team?.name,
+  })
+  showAddTeamDialog.value = false
+}
+
+const openAddWorkspaceDialog = () => {
+  selectedAddWorkspaceId.value = null
+  showAddWorkspaceDialog.value = true
+}
+const confirmAddWorkspace = () => {
+  if (!selectedAddWorkspaceId.value) return
+  const org = organizations.value.find(
+    (o) => o.organization?.id === selectedAddWorkspaceId.value
+  )
+  editWorkspaces.value.push({
+    entityId: selectedAddWorkspaceId.value,
+    organizationId: selectedAddWorkspaceId.value,
+    organizationName: org?.organization?.name,
+  })
+  showAddWorkspaceDialog.value = false
+}
+
+/* Fetch + save */
+const loadPermissions = async (uuid) => {
+  permissions.value = []
+  permissionsError.value = ''
+  isEditingPermissions.value = false
+  if (!uuid) return
+  permissionsLoading.value = true
+  try {
+    const data = await store.dispatch(
+      'analysisModule/fetchApplicationPermissions',
+      uuid
+    )
+    permissions.value = Array.isArray(data)
+      ? data
+      : Array.isArray(data?.access)
+        ? data.access
+        : Array.isArray(data?.permissions)
+          ? data.permissions
+          : []
+  } catch (err) {
+    console.error(err)
+    permissionsError.value = 'Failed to load permissions'
+  } finally {
+    permissionsLoading.value = false
+  }
+}
+
+const savePermissions = async () => {
+  if (!props.uuid) return
+  isSavingPermissions.value = true
+  try {
+    const orgId = activeOrgId.value
+    const usersOut = editUsers.value.map((u) => ({
+      entityId: u.entityId,
+      organizationId: u.organizationId || orgId,
+    }))
+    // Defense-in-depth: ensure the current user stays in the users list.
+    const meId = profile.value?.id || profile.value?.intId
+    if (meId && !usersOut.some((u) => u.entityId === meId)) {
+      usersOut.push({ entityId: meId, organizationId: orgId })
+    }
+    const payload = {
+      visibility: editVisibility.value,
+      users: usersOut,
+      teams: editTeams.value.map((t) => ({
+        entityId: t.entityId,
+        organizationId: t.organizationId || orgId,
+      })),
+      workspaces: editWorkspaces.value.map((w) => ({
+        entityId: w.entityId,
+        organizationId: w.organizationId || orgId,
+      })),
+    }
+    await store.dispatch('analysisModule/updateApplicationPermissions', {
+      uuid: props.uuid,
+      payload,
+    })
+    ElMessage.success('Permissions updated')
+    isEditingPermissions.value = false
+    await loadPermissions(props.uuid)
+    emit('updated')
+  } catch (err) {
+    console.error(err)
+    ElMessage.error('Failed to update permissions')
+  } finally {
+    isSavingPermissions.value = false
+  }
+}
+
+watch(() => props.uuid, (uuid) => loadPermissions(uuid), { immediate: true })
+
+defineExpose({ reload: () => loadPermissions(props.uuid) })
+</script>
+
+<template>
+  <div class="app-permissions">
+    <div class="section-header">
+      <h2>Permissions ({{ permissions.length }})</h2>
+      <div class="section-actions">
+        <template v-if="isEditingPermissions">
+          <bf-button
+            class="secondary small"
+            :disabled="isSavingPermissions"
+            @click="cancelEditingPermissions"
+          >Cancel</bf-button>
+          <bf-button
+            class="primary small"
+            :loading="isSavingPermissions"
+            @click="savePermissions"
+          >Save</bf-button>
+        </template>
+        <el-tooltip
+          v-else
+          :content="editPermissionsTooltip"
+          placement="top"
+          :disabled="canEditPermissions"
+        >
+          <span class="edit-permissions-wrap">
+            <bf-button
+              class="secondary small"
+              :disabled="!canEditPermissions"
+              @click="canEditPermissions && startEditingPermissions()"
+            >Edit</bf-button>
+          </span>
+        </el-tooltip>
+      </div>
+    </div>
+
+    <div v-if="permissionsLoading" class="empty-state">Loading...</div>
+    <div v-else-if="permissionsError" class="empty-state">
+      {{ permissionsError }}
+    </div>
+
+    <!-- Read mode -->
+    <template v-else-if="!isEditingPermissions">
+      <div v-if="permissions.length === 0" class="empty-state">
+        No permissions configured
+      </div>
+      <div v-else class="info-content">
+        <div
+          v-for="(perm, i) in permissions"
+          :key="perm.uuid || perm.userId || perm.teamId || i"
+          class="info-row"
+        >
+          <span class="info-label">{{ permissionLabel(perm) }}</span>
+          <span class="info-value perm-role">{{ permissionRole(perm) }}</span>
+        </div>
+      </div>
+    </template>
+
+    <!-- Edit mode -->
+    <template v-else>
+      <div class="permissions-edit">
+        <div class="edit-subsection">
+          <div class="edit-subsection-header">
+            <h4>Users ({{ editUsers.length }})</h4>
+            <bf-button
+              class="secondary small"
+              :disabled="availableAddableUsers.length === 0"
+              @click="openAddUserDialog"
+            >+ Add User</bf-button>
+          </div>
+          <div v-if="editUsers.length === 0" class="edit-empty">No users</div>
+          <div
+            v-else
+            v-for="(user, i) in editUsers"
+            :key="user.entityId"
+            class="edit-permission-row"
+          >
+            <span class="edit-permission-label">
+              {{ getUserName(user.entityId) }}
+              <span v-if="isCurrentUser(user.entityId)" class="self-tag">
+                you
+              </span>
+            </span>
+            <button
+              v-if="!isCurrentUser(user.entityId)"
+              class="remove-perm-btn"
+              type="button"
+              title="Remove"
+              @click="removeEditUser(i)"
+            >&times;</button>
+            <span
+              v-else
+              class="remove-perm-btn-placeholder"
+              aria-hidden="true"
+            ></span>
+          </div>
+        </div>
+
+        <div class="edit-subsection">
+          <div class="edit-subsection-header">
+            <h4>Teams ({{ editTeams.length }})</h4>
+            <bf-button
+              class="secondary small"
+              :disabled="availableAddableTeams.length === 0"
+              @click="openAddTeamDialog"
+            >+ Add Team</bf-button>
+          </div>
+          <div v-if="editTeams.length === 0" class="edit-empty">No teams</div>
+          <div
+            v-else
+            v-for="(team, i) in editTeams"
+            :key="team.entityId"
+            class="edit-permission-row"
+          >
+            <span class="edit-permission-label">
+              {{ team.teamName || getTeamName(team.entityId) || team.entityId }}
+            </span>
+            <button
+              class="remove-perm-btn"
+              type="button"
+              title="Remove"
+              @click="removeEditTeam(i)"
+            >&times;</button>
+          </div>
+        </div>
+
+        <div class="edit-subsection">
+          <div class="edit-subsection-header">
+            <h4>Workspaces ({{ editWorkspaces.length }})</h4>
+            <bf-button
+              class="secondary small"
+              :disabled="availableAddableWorkspaces.length === 0"
+              @click="openAddWorkspaceDialog"
+            >+ Add Workspace</bf-button>
+          </div>
+          <div v-if="editWorkspaces.length === 0" class="edit-empty">
+            No workspaces
+          </div>
+          <div
+            v-else
+            v-for="(ws, i) in editWorkspaces"
+            :key="ws.entityId"
+            class="edit-permission-row"
+          >
+            <span class="edit-permission-label">
+              {{ ws.organizationName || getWorkspaceName(ws.entityId) || ws.entityId }}
+            </span>
+            <button
+              class="remove-perm-btn"
+              type="button"
+              title="Remove"
+              @click="removeEditWorkspace(i)"
+            >&times;</button>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <!-- Add User Dialog -->
+    <el-dialog
+      v-model="showAddUserDialog"
+      title="Add User"
+      width="480px"
+      :close-on-click-modal="true"
+    >
+      <div class="add-perm-dialog">
+        <p>Grant a user access to this application:</p>
+        <el-select
+          v-model="selectedAddUserId"
+          placeholder="Select a user"
+          size="default"
+          filterable
+          class="add-perm-select"
+        >
+          <el-option
+            v-for="user in availableAddableUsers"
+            :key="user.id"
+            :label="`${user.firstName} ${user.lastName}`"
+            :value="user.id"
+          >
+            <div class="user-option">
+              <span class="user-name">
+                {{ user.firstName }} {{ user.lastName }}
+              </span>
+              <span class="user-email">{{ user.email }}</span>
+            </div>
+          </el-option>
+        </el-select>
+      </div>
+      <template #footer>
+        <div class="dialog-footer">
+          <el-button @click="showAddUserDialog = false">Cancel</el-button>
+          <el-button
+            type="primary"
+            :disabled="!selectedAddUserId"
+            @click="confirmAddUser"
+          >Add</el-button>
+        </div>
+      </template>
+    </el-dialog>
+
+    <!-- Add Team Dialog -->
+    <el-dialog
+      v-model="showAddTeamDialog"
+      title="Add Team"
+      width="480px"
+      :close-on-click-modal="true"
+    >
+      <div class="add-perm-dialog">
+        <p>Grant a team access to this application:</p>
+        <el-select
+          v-model="selectedAddTeamId"
+          placeholder="Select a team"
+          size="default"
+          filterable
+          class="add-perm-select"
+        >
+          <el-option
+            v-for="t in availableAddableTeams"
+            :key="t.team.id"
+            :label="t.team.name"
+            :value="t.team.id"
+          />
+        </el-select>
+      </div>
+      <template #footer>
+        <div class="dialog-footer">
+          <el-button @click="showAddTeamDialog = false">Cancel</el-button>
+          <el-button
+            type="primary"
+            :disabled="!selectedAddTeamId"
+            @click="confirmAddTeam"
+          >Add</el-button>
+        </div>
+      </template>
+    </el-dialog>
+
+    <!-- Add Workspace Dialog -->
+    <el-dialog
+      v-model="showAddWorkspaceDialog"
+      title="Add Workspace"
+      width="480px"
+      :close-on-click-modal="true"
+    >
+      <div class="add-perm-dialog">
+        <p>Grant a workspace access to this application:</p>
+        <el-select
+          v-model="selectedAddWorkspaceId"
+          placeholder="Select a workspace"
+          size="default"
+          filterable
+          class="add-perm-select"
+        >
+          <el-option
+            v-for="o in availableAddableWorkspaces"
+            :key="o.organization.id"
+            :label="o.organization.name"
+            :value="o.organization.id"
+          />
+        </el-select>
+      </div>
+      <template #footer>
+        <div class="dialog-footer">
+          <el-button @click="showAddWorkspaceDialog = false">Cancel</el-button>
+          <el-button
+            type="primary"
+            :disabled="!selectedAddWorkspaceId"
+            @click="confirmAddWorkspace"
+          >Add</el-button>
+        </div>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@use '@/styles/theme';
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  gap: 12px;
+
+  h2 {
+    font-size: 18px;
+    font-weight: 500;
+    color: theme.$gray_6;
+    margin: 0;
+  }
+
+  .section-actions {
+    display: flex;
+    gap: 8px;
+  }
+}
+
+.empty-state {
+  padding: 20px;
+  text-align: center;
+  color: theme.$gray_4;
+  font-size: 14px;
+  font-style: italic;
+}
+
+.info-content {
+  .info-row {
+    display: flex;
+    padding: 12px 0;
+    border-bottom: 1px solid theme.$gray_1;
+    gap: 16px;
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    .info-label {
+      flex: 1;
+      color: theme.$gray_6;
+      font-weight: 500;
+      font-size: 14px;
+      word-break: break-word;
+    }
+
+    .info-value {
+      color: theme.$gray_5;
+      font-size: 14px;
+
+      &.perm-role {
+        text-transform: capitalize;
+      }
+    }
+  }
+}
+
+// Wrapper around the disabled Edit button so el-tooltip still receives hover.
+.edit-permissions-wrap {
+  display: inline-flex;
+
+  :deep(button[disabled]),
+  :deep(.bf-button:disabled),
+  :deep(.bf-button.is-disabled) {
+    opacity: 0.4;
+    background-color: theme.$gray_2 !important;
+    border-color: theme.$gray_3 !important;
+    color: theme.$gray_4 !important;
+    cursor: not-allowed;
+    box-shadow: none;
+  }
+}
+
+.permissions-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.edit-subsection {
+  border: 1px solid theme.$gray_2;
+  border-radius: 4px;
+  padding: 16px 20px;
+
+  .edit-subsection-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+
+    h4 {
+      margin: 0;
+      font-size: 14px;
+      font-weight: 500;
+      color: theme.$gray_6;
+    }
+  }
+}
+
+.edit-empty {
+  color: theme.$gray_4;
+  font-size: 13px;
+  font-style: italic;
+  padding: 8px 0;
+}
+
+.edit-permission-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid theme.$gray_1;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  .edit-permission-label {
+    flex: 1;
+    font-size: 14px;
+    color: theme.$gray_6;
+  }
+}
+
+.remove-perm-btn {
+  background: none;
+  border: none;
+  color: theme.$red_2;
+  font-size: 20px;
+  line-height: 1;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+
+  &:hover {
+    background: rgba(theme.$red_2, 0.08);
+  }
+}
+
+.remove-perm-btn-placeholder {
+  display: inline-block;
+  width: 28px;
+  height: 28px;
+}
+
+.self-tag {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: theme.$gray_5;
+  background: theme.$gray_2;
+  border-radius: 3px;
+}
+
+.add-perm-dialog {
+  p {
+    margin: 0 0 12px 0;
+    color: theme.$gray_5;
+    font-size: 14px;
+  }
+
+  .add-perm-select {
+    width: 100%;
+    margin-bottom: 12px;
+  }
+
+  .user-option {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.3;
+
+    .user-name {
+      font-size: 14px;
+      color: theme.$gray_6;
+    }
+
+    .user-email {
+      font-size: 12px;
+      color: theme.$gray_4;
+    }
+  }
+}
+
+.dialog-footer {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+</style>

--- a/src/components/user/code/CodeRepoListItem.vue
+++ b/src/components/user/code/CodeRepoListItem.vue
@@ -86,7 +86,7 @@
         View application details &rarr;
       </router-link>
       <span
-        v-else-if="repo.publishing_to_appstore && !matchedApp"
+        v-else-if="repo.publishing_to_appstore && !matchedApp && !hasReleases"
         class="card-action-hint"
       >
         Create Github release to add to app store
@@ -158,6 +158,13 @@ export default {
     // viewer doesn't own. Repos without a matched app keep the link.
     canShowExternalLinks() {
       return !this.isPrivateUnowned
+    },
+
+    // True when the repo already has at least one GitHub release. A repo that
+    // has been released doesn't need another release to reach the App Store,
+    // so the "create a release" hint should not be shown in that case.
+    hasReleases() {
+      return (this.repo?.content?.releases?.length || 0) > 0
     },
   },
 

--- a/src/components/user/code/CodeRepoListItem.vue
+++ b/src/components/user/code/CodeRepoListItem.vue
@@ -78,15 +78,8 @@
         <IconGitHub :width="14" :height="14" color="currentColor" />
         <span>View on GitHub</span>
       </a>
-      <router-link
-        v-if="matchedApp"
-        :to="{ name: 'published-app-details', params: { uuid: matchedApp.uuid } }"
-        class="card-action-link app-details-link"
-      >
-        View application details &rarr;
-      </router-link>
       <span
-        v-else-if="repo.publishing_to_appstore && !matchedApp && !hasReleases"
+        v-if="repo.publishing_to_appstore && !matchedAppRaw && !hasReleases"
         class="card-action-hint"
       >
         Create Github release to add to app store
@@ -357,12 +350,8 @@ export default {
   }
 }
 
-.app-details-link,
 .card-action-hint {
   margin-left: auto;
-}
-
-.card-action-hint {
   font-size: 13px;
   font-weight: 500;
   color: theme.$gray_4;

--- a/src/components/user/code/PublishedAppDetail.vue
+++ b/src/components/user/code/PublishedAppDetail.vue
@@ -2,7 +2,7 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useStore } from 'vuex'
-import { ElMessage } from 'element-plus'
+import { ElMessage, ElMessageBox } from 'element-plus'
 
 import BfStage from '@/components/layout/BfStage/BfStage.vue'
 import BfButton from '@/components/shared/bf-button/BfButton.vue'
@@ -523,6 +523,50 @@ const confirmDelete = async () => {
     isDeleting.value = false
   }
 }
+
+/* Archive / restore
+   PATCH /applications/store/{uuid} with { status: "active" | "archived" } */
+const isArchiving = ref(false)
+const isArchived = computed(() => detail.value?.status === 'archived')
+
+const toggleArchiveStatus = async () => {
+  if (!detail.value || !isAppOwner.value || isArchiving.value) return
+  const nextStatus = isArchived.value ? 'active' : 'archived'
+
+  if (nextStatus === 'archived') {
+    try {
+      await ElMessageBox.confirm(
+        'Archive this application? It will be removed from active workspaces and workflows that reference it will no longer be able to run it. The underlying record is preserved and you can restore it later.',
+        'Archive Application',
+        { confirmButtonText: 'Archive', cancelButtonText: 'Cancel', type: 'warning' }
+      )
+    } catch {
+      return // user cancelled
+    }
+  }
+
+  isArchiving.value = true
+  try {
+    const updated = await store.dispatch('analysisModule/setApplicationStatus', {
+      uuid: detail.value.uuid || appUuid.value,
+      status: nextStatus,
+    })
+    // Reflect the change locally (the response is the updated application).
+    detail.value = { ...detail.value, ...(updated || {}), status: nextStatus }
+    // Refresh the shared applications list so other views reflect the change.
+    store
+      .dispatch('analysisModule/fetchApplications', { force: true })
+      .catch(() => {})
+    ElMessage.success(
+      nextStatus === 'archived' ? 'Application archived' : 'Application restored'
+    )
+  } catch (error) {
+    console.error(error)
+    ElMessage.error('Failed to update application status. Please try again.')
+  } finally {
+    isArchiving.value = false
+  }
+}
 </script>
 
 <template>
@@ -858,10 +902,15 @@ const confirmDelete = async () => {
         </div>
         <div class="delete-content">
           <div class="delete-info">
-            <p>
+            <p v-if="isArchived">
+              This application is archived and hidden from active workspaces.
+              Restore it to make it available to workflows again.
+            </p>
+            <p v-else>
               Archive this application to remove it from active workspaces.
               Workflows that reference this application will no longer be
-              able to run it, but the underlying record is preserved.
+              able to run it, but the underlying record is preserved and can
+              be restored later.
             </p>
           </div>
           <div class="danger-action">
@@ -875,12 +924,19 @@ const confirmDelete = async () => {
               :disabled="isAppOwner"
             >
               <span class="archive-button-wrap">
-                <bf-button class="danger-button" disabled>
-                  Archive Application
+                <bf-button
+                  class="danger-button"
+                  :disabled="!isAppOwner || isArchiving"
+                  @click="toggleArchiveStatus"
+                >
+                  {{
+                    isArchiving
+                      ? (isArchived ? "Restoring..." : "Archiving...")
+                      : (isArchived ? "Restore Application" : "Archive Application")
+                  }}
                 </bf-button>
               </span>
             </el-tooltip>
-            <span class="coming-soon-tag">Coming Soon</span>
           </div>
         </div>
       </div>

--- a/src/components/user/code/PublishedAppDetail.vue
+++ b/src/components/user/code/PublishedAppDetail.vue
@@ -2,13 +2,14 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useStore } from 'vuex'
-import { ElMessage, ElMessageBox } from 'element-plus'
+import { ElMessage } from 'element-plus'
 
 import BfStage from '@/components/layout/BfStage/BfStage.vue'
-import BfButton from '@/components/shared/bf-button/BfButton.vue'
 import EventBus from '@/utils/event-bus'
 import { useGetToken } from '@/composables/useGetToken'
 import { useSendXhr } from '@/mixins/request/request_composable'
+import AppPermissions from './AppPermissions.vue'
+import AppArchiveToggle from './AppArchiveToggle.vue'
 
 const props = defineProps({
   uuid: {
@@ -27,9 +28,6 @@ const orgMembers = computed(() => store.state.orgMembers || [])
 const detail = ref(null)
 const isLoading = ref(false)
 const detailError = ref('')
-const permissions = ref([])
-const permissionsLoading = ref(false)
-const permissionsError = ref('')
 
 const versionsPageSize = 5
 const versionsPage = ref(1)
@@ -38,30 +36,6 @@ const showDeleteDialog = ref(false)
 const isDeleting = ref(false)
 
 const versionsExpanded = ref(true)
-
-// Permissions edit state
-const isEditingPermissions = ref(false)
-const editVisibility = ref('private')
-const editUsers = ref([])
-const editTeams = ref([])
-const editWorkspaces = ref([])
-const isSavingPermissions = ref(false)
-const showAddUserDialog = ref(false)
-const showAddTeamDialog = ref(false)
-const showAddWorkspaceDialog = ref(false)
-const selectedAddUserId = ref(null)
-const selectedAddTeamId = ref(null)
-const selectedAddWorkspaceId = ref(null)
-
-const teams = computed(() => store.state.teams || [])
-
-const activeOrgId = computed(
-  () =>
-    detail.value?.organizationId ||
-    (permissions.value || []).find((p) => p.organizationId)?.organizationId ||
-    store.state.activeOrganization?.organization?.id ||
-    null
-)
 
 const appUuid = computed(() => props.uuid || route.params.uuid)
 
@@ -152,25 +126,6 @@ const getUserName = (userId) => {
     : String(userId)
 }
 
-const organizations = computed(() => store.state.organizations || [])
-
-const getWorkspaceName = (workspaceId) => {
-  if (!workspaceId) return null
-  const match = organizations.value.find(
-    (o) => o.organization?.id === workspaceId ||
-           o.organization?.intId === workspaceId
-  )
-  return match?.organization?.name || null
-}
-
-const getTeamName = (teamId) => {
-  if (!teamId) return null
-  const match = teams.value.find(
-    (t) => t.team?.id === teamId || t.team?.intId === teamId
-  )
-  return match?.team?.name || null
-}
-
 const statusKey = (status) => {
   if (!status) return 'gray'
   const s = status.toLowerCase()
@@ -186,97 +141,12 @@ const statusLabel = (status) => {
   return status.charAt(0).toUpperCase() + status.slice(1).toLowerCase()
 }
 
-const permissionEntityType = (perm) =>
-  perm.entityType || perm.granteeType || (perm.userId
-    ? 'user'
-    : perm.teamId
-      ? 'team'
-      : perm.organizationId || perm.workspaceId
-        ? 'workspace'
-        : null)
-
-const permissionEntityId = (perm) =>
-  perm.entityRawId ||
-  perm.userId ||
-  perm.teamId ||
-  perm.organizationId ||
-  perm.workspaceId ||
-  perm.granteeId ||
-  null
-
-const permissionLabel = (perm) => {
-  const type = permissionEntityType(perm)
-  const id = permissionEntityId(perm)
-  if (type === 'user') return getUserName(id)
-  if (type === 'team') {
-    const name = perm.teamName || getTeamName(id) || id
-    return `Team: ${name}`
-  }
-  if (type === 'workspace' || type === 'organization') {
-    const name = perm.organizationName || perm.workspaceName || getWorkspaceName(id) || id
-    return `Workspace: ${name}`
-  }
-  if (id) return type ? `${type}: ${id}` : id
-  return 'Unknown'
-}
-
-const permissionRole = (perm) =>
-  perm.accessType ||
-  perm.role ||
-  perm.permission ||
-  perm.accessLevel ||
-  '—'
-
-/* Permissions edit helpers */
-const splitPermissions = (perms) => {
-  const users = []
-  const teams = []
-  const workspaces = []
-  for (const p of perms || []) {
-    const type = permissionEntityType(p)
-    const id = permissionEntityId(p)
-    if (!id) continue
-    const organizationId = p.organizationId || activeOrgId.value
-    if (type === 'user') {
-      users.push({ entityId: id, organizationId })
-    } else if (type === 'team') {
-      teams.push({ entityId: id, organizationId, teamName: p.teamName })
-    } else if (type === 'workspace' || type === 'organization') {
-      workspaces.push({
-        entityId: id,
-        organizationId,
-        organizationName: p.organizationName || p.workspaceName,
-      })
-    }
-  }
-  return { users, teams, workspaces }
-}
-
-const startEditingPermissions = () => {
-  const split = splitPermissions(permissions.value)
-  editUsers.value = split.users
-  editTeams.value = split.teams
-  editWorkspaces.value = split.workspaces
-  editVisibility.value = isAppPublic.value ? 'public' : 'private'
-  isEditingPermissions.value = true
-}
-
-const cancelEditingPermissions = () => {
-  isEditingPermissions.value = false
-}
-
 const deletingApplications = computed(
   () => store.state.analysisModule.deletingApplications || []
 )
 const isAppDeleting = computed(() =>
   deletingApplications.value.includes(appUuid.value)
 )
-
-const isCurrentUser = (id) =>
-  !!id &&
-  (id === profile.value?.id || id === profile.value?.intId)
-
-const isAppOwner = computed(() => isCurrentUser(detail.value?.ownerId))
 
 // Visibility is sourced from the `isPrivate` flag on the application.
 // `isPrivate === false` ⇒ public; everything else (true / undefined) ⇒ private.
@@ -287,152 +157,18 @@ const visibilityLabel = computed(() => {
   return detail.value.isPrivate ? 'Private' : 'Public'
 })
 
-const canEditPermissions = computed(
-  () => isAppOwner.value && !isAppPublic.value
-)
-
-const editPermissionsTooltip = computed(() => {
-  if (isAppPublic.value) {
-    return 'Only Private Repos allow Owners to update permissions'
-  }
-  if (!isAppOwner.value) {
-    return 'Only Application Owners Can Update Permissions'
-  }
-  return ''
-})
-
-const removeEditUser = (idx) => {
-  const user = editUsers.value[idx]
-  if (user && isCurrentUser(user.entityId)) return
-  editUsers.value.splice(idx, 1)
-}
-const removeEditTeam = (idx) => editTeams.value.splice(idx, 1)
-
-const availableAddableUsers = computed(() => {
-  const taken = new Set(editUsers.value.map((u) => u.entityId))
-  return orgMembers.value.filter((m) => m.id && !taken.has(m.id))
-})
-
-const availableAddableTeams = computed(() => {
-  const taken = new Set(editTeams.value.map((t) => t.entityId))
-  return teams.value.filter((t) => t.team?.id && !taken.has(t.team.id))
-})
-
-const availableAddableWorkspaces = computed(() => {
-  const taken = new Set(editWorkspaces.value.map((w) => w.entityId))
-  return organizations.value.filter(
-    (o) => o.organization?.id &&
-      !taken.has(o.organization.id) &&
-      o.organization.name?.toLowerCase() !== 'welcome'
-  )
-})
-
-const openAddUserDialog = () => {
-  selectedAddUserId.value = null
-  showAddUserDialog.value = true
-}
-
-const confirmAddUser = () => {
-  if (!selectedAddUserId.value) return
-  editUsers.value.push({
-    entityId: selectedAddUserId.value,
-    organizationId: activeOrgId.value,
-  })
-  showAddUserDialog.value = false
-}
-
-const openAddTeamDialog = () => {
-  selectedAddTeamId.value = null
-  showAddTeamDialog.value = true
-}
-
-const confirmAddTeam = () => {
-  if (!selectedAddTeamId.value) return
-  const team = teams.value.find((t) => t.team?.id === selectedAddTeamId.value)
-  editTeams.value.push({
-    entityId: selectedAddTeamId.value,
-    organizationId: activeOrgId.value,
-    teamName: team?.team?.name,
-  })
-  showAddTeamDialog.value = false
-}
-
-const openAddWorkspaceDialog = () => {
-  selectedAddWorkspaceId.value = null
-  showAddWorkspaceDialog.value = true
-}
-
-const confirmAddWorkspace = () => {
-  if (!selectedAddWorkspaceId.value) return
-  const org = organizations.value.find(
-    (o) => o.organization?.id === selectedAddWorkspaceId.value
-  )
-  editWorkspaces.value.push({
-    entityId: selectedAddWorkspaceId.value,
-    organizationId: selectedAddWorkspaceId.value,
-    organizationName: org?.organization?.name,
-  })
-  showAddWorkspaceDialog.value = false
-}
-
-const removeEditWorkspace = (idx) => editWorkspaces.value.splice(idx, 1)
-
-const savePermissions = async () => {
-  if (!appUuid.value) return
-  isSavingPermissions.value = true
-  try {
-    const orgId = activeOrgId.value
-    const usersOut = editUsers.value.map((u) => ({
-      entityId: u.entityId,
-      organizationId: u.organizationId || orgId,
-    }))
-    // Defense-in-depth: ensure the current user is in the users list.
-    const meId = profile.value?.id || profile.value?.intId
-    if (meId && !usersOut.some((u) => u.entityId === meId)) {
-      usersOut.push({ entityId: meId, organizationId: orgId })
-    }
-    const payload = {
-      visibility: editVisibility.value,
-      users: usersOut,
-      teams: editTeams.value.map((t) => ({
-        entityId: t.entityId,
-        organizationId: t.organizationId || orgId,
-      })),
-      workspaces: editWorkspaces.value.map((w) => ({
-        entityId: w.entityId,
-        organizationId: w.organizationId || orgId,
-      })),
-    }
-    await store.dispatch('analysisModule/updateApplicationPermissions', {
-      uuid: appUuid.value,
-      payload,
-    })
-    ElMessage.success('Permissions updated')
-    isEditingPermissions.value = false
-    // Refresh permissions and detail (visibility may have changed)
-    await loadDetail(appUuid.value)
-  } catch (err) {
-    console.error(err)
-    ElMessage.error('Failed to update permissions')
-  } finally {
-    isSavingPermissions.value = false
-  }
-}
-
 /* Fetch */
 const loadDetail = async (uuid) => {
   detail.value = null
-  permissions.value = []
   detailError.value = ''
-  permissionsError.value = ''
   versionsPage.value = 1
   if (!uuid) return
   isLoading.value = true
-  permissionsLoading.value = true
   try {
     // Ensure org members and teams are loaded — getPrimaryData() in main.js
     // may not have run if the user navigated here via a userRoute (e.g. my-workspace).
-    // Fall back to preferredOrganization / first org when activeOrganization is not set.
+    // The permissions editor relies on this data. Fall back to
+    // preferredOrganization / first org when activeOrganization is not set.
     const orgId = store.state.activeOrganization?.organization?.id
       || store.state.profile?.preferredOrganization
       || store.state.organizations?.[0]?.organization?.id
@@ -452,9 +188,8 @@ const loadDetail = async (uuid) => {
         }).catch((err) => console.warn('Failed to load org data:', err))
       : Promise.resolve()
 
-    const [detailResult, permsResult] = await Promise.allSettled([
+    const [detailResult] = await Promise.allSettled([
       store.dispatch('analysisModule/fetchApplication', uuid),
-      store.dispatch('analysisModule/fetchApplicationPermissions', uuid),
       orgDataPromise,
     ])
 
@@ -466,23 +201,8 @@ const loadDetail = async (uuid) => {
         'This repository is not published to the App Store yet.'
       ElMessage.error('Failed to load application details')
     }
-
-    if (permsResult.status === 'fulfilled') {
-      const data = permsResult.value
-      permissions.value = Array.isArray(data)
-        ? data
-        : Array.isArray(data?.access)
-          ? data.access
-          : Array.isArray(data?.permissions)
-            ? data.permissions
-            : []
-    } else {
-      console.error(permsResult.reason)
-      permissionsError.value = 'Failed to load permissions'
-    }
   } finally {
     isLoading.value = false
-    permissionsLoading.value = false
   }
 }
 
@@ -524,48 +244,12 @@ const confirmDelete = async () => {
   }
 }
 
-/* Archive / restore
-   PATCH /applications/store/{uuid} with { status: "active" | "archived" } */
-const isArchiving = ref(false)
+/* Archive / restore — handled by the shared AppArchiveToggle component. */
 const isArchived = computed(() => detail.value?.status === 'archived')
 
-const toggleArchiveStatus = async () => {
-  if (!detail.value || !isAppOwner.value || isArchiving.value) return
-  const nextStatus = isArchived.value ? 'active' : 'archived'
-
-  if (nextStatus === 'archived') {
-    try {
-      await ElMessageBox.confirm(
-        'Archive this application? It will be removed from active workspaces and workflows that reference it will no longer be able to run it. The underlying record is preserved and you can restore it later.',
-        'Archive Application',
-        { confirmButtonText: 'Archive', cancelButtonText: 'Cancel', type: 'warning' }
-      )
-    } catch {
-      return // user cancelled
-    }
-  }
-
-  isArchiving.value = true
-  try {
-    const updated = await store.dispatch('analysisModule/setApplicationStatus', {
-      uuid: detail.value.uuid || appUuid.value,
-      status: nextStatus,
-    })
-    // Reflect the change locally (the response is the updated application).
-    detail.value = { ...detail.value, ...(updated || {}), status: nextStatus }
-    // Refresh the shared applications list so other views reflect the change.
-    store
-      .dispatch('analysisModule/fetchApplications', { force: true })
-      .catch(() => {})
-    ElMessage.success(
-      nextStatus === 'archived' ? 'Application archived' : 'Application restored'
-    )
-  } catch (error) {
-    console.error(error)
-    ElMessage.error('Failed to update application status. Please try again.')
-  } finally {
-    isArchiving.value = false
-  }
+// Keep the local detail in sync when the archive toggle changes status.
+const onArchiveChange = (status) => {
+  if (detail.value) detail.value = { ...detail.value, status }
 }
 </script>
 
@@ -734,165 +418,13 @@ const toggleArchiveStatus = async () => {
 
       <!-- Permissions -->
       <div class="management-section">
-        <div class="section-header">
-          <h2>Permissions ({{ permissions.length }})</h2>
-          <div class="section-actions">
-            <template v-if="isEditingPermissions">
-              <bf-button
-                class="secondary small"
-                @click="cancelEditingPermissions"
-                :disabled="isSavingPermissions"
-              >Cancel</bf-button>
-              <bf-button
-                class="primary small"
-                @click="savePermissions"
-                :loading="isSavingPermissions"
-              >Save</bf-button>
-            </template>
-            <el-tooltip
-              v-else
-              :content="editPermissionsTooltip"
-              placement="top"
-              :disabled="canEditPermissions"
-            >
-              <span class="edit-permissions-wrap">
-                <bf-button
-                  class="secondary small"
-                  :disabled="!canEditPermissions"
-                  @click="canEditPermissions && startEditingPermissions()"
-                >Edit</bf-button>
-              </span>
-            </el-tooltip>
-          </div>
-        </div>
-
-        <div v-if="permissionsLoading" class="empty-state">Loading...</div>
-        <div v-else-if="permissionsError" class="empty-state">
-          {{ permissionsError }}
-        </div>
-
-        <!-- Read mode -->
-        <template v-else-if="!isEditingPermissions">
-          <div v-if="permissions.length === 0" class="empty-state">
-            No permissions configured
-          </div>
-          <div v-else class="info-content">
-            <div
-              v-for="(perm, i) in permissions"
-              :key="perm.uuid || perm.userId || perm.teamId || i"
-              class="info-row"
-            >
-              <span class="info-label">{{ permissionLabel(perm) }}</span>
-              <span class="info-value perm-role">
-                {{ permissionRole(perm) }}
-              </span>
-            </div>
-          </div>
-        </template>
-
-        <!-- Edit mode -->
-        <template v-else>
-          <div class="permissions-edit">
-            <div class="edit-subsection">
-              <div class="edit-subsection-header">
-                <h4>Users ({{ editUsers.length }})</h4>
-                <bf-button
-                  class="secondary small"
-                  @click="openAddUserDialog"
-                  :disabled="availableAddableUsers.length === 0"
-                >+ Add User</bf-button>
-              </div>
-              <div v-if="editUsers.length === 0" class="edit-empty">
-                No users
-              </div>
-              <div
-                v-else
-                v-for="(user, i) in editUsers"
-                :key="user.entityId"
-                class="edit-permission-row"
-              >
-                <span class="edit-permission-label">
-                  {{ getUserName(user.entityId) }}
-                  <span v-if="isCurrentUser(user.entityId)" class="self-tag">
-                    you
-                  </span>
-                </span>
-                <button
-                  v-if="!isCurrentUser(user.entityId)"
-                  class="remove-perm-btn"
-                  type="button"
-                  @click="removeEditUser(i)"
-                  title="Remove"
-                >&times;</button>
-                <span
-                  v-else
-                  class="remove-perm-btn-placeholder"
-                  aria-hidden="true"
-                ></span>
-              </div>
-            </div>
-
-            <div class="edit-subsection">
-              <div class="edit-subsection-header">
-                <h4>Teams ({{ editTeams.length }})</h4>
-                <bf-button
-                  class="secondary small"
-                  @click="openAddTeamDialog"
-                  :disabled="availableAddableTeams.length === 0"
-                >+ Add Team</bf-button>
-              </div>
-              <div v-if="editTeams.length === 0" class="edit-empty">
-                No teams
-              </div>
-              <div
-                v-else
-                v-for="(team, i) in editTeams"
-                :key="team.entityId"
-                class="edit-permission-row"
-              >
-                <span class="edit-permission-label">
-                  {{ team.teamName || getTeamName(team.entityId) || team.entityId }}
-                </span>
-                <button
-                  class="remove-perm-btn"
-                  type="button"
-                  @click="removeEditTeam(i)"
-                  title="Remove"
-                >&times;</button>
-              </div>
-            </div>
-
-            <div class="edit-subsection">
-              <div class="edit-subsection-header">
-                <h4>Workspaces ({{ editWorkspaces.length }})</h4>
-                <bf-button
-                  class="secondary small"
-                  @click="openAddWorkspaceDialog"
-                  :disabled="availableAddableWorkspaces.length === 0"
-                >+ Add Workspace</bf-button>
-              </div>
-              <div v-if="editWorkspaces.length === 0" class="edit-empty">
-                No workspaces
-              </div>
-              <div
-                v-else
-                v-for="(ws, i) in editWorkspaces"
-                :key="ws.entityId"
-                class="edit-permission-row"
-              >
-                <span class="edit-permission-label">
-                  {{ ws.organizationName || getWorkspaceName(ws.entityId) || ws.entityId }}
-                </span>
-                <button
-                  class="remove-perm-btn"
-                  type="button"
-                  @click="removeEditWorkspace(i)"
-                  title="Remove"
-                >&times;</button>
-              </div>
-            </div>
-          </div>
-        </template>
+        <app-permissions
+          :uuid="detail.uuid"
+          :owner-id="detail.ownerId"
+          :is-public="isAppPublic"
+          :organization-id="detail.organizationId"
+          @updated="loadDetail(appUuid)"
+        />
       </div>
 
       <!-- Danger Zone -->
@@ -914,148 +446,17 @@ const toggleArchiveStatus = async () => {
             </p>
           </div>
           <div class="danger-action">
-            <el-tooltip
-              :content="
-                isAppOwner
-                  ? ''
-                  : 'Only Application Owners Can Archive Applications'
-              "
-              placement="top"
-              :disabled="isAppOwner"
-            >
-              <span class="archive-button-wrap">
-                <bf-button
-                  class="danger-button"
-                  :disabled="!isAppOwner || isArchiving"
-                  @click="toggleArchiveStatus"
-                >
-                  {{
-                    isArchiving
-                      ? (isArchived ? "Restoring..." : "Archiving...")
-                      : (isArchived ? "Restore Application" : "Archive Application")
-                  }}
-                </bf-button>
-              </span>
-            </el-tooltip>
+            <app-archive-toggle
+              :uuid="detail.uuid"
+              :owner-id="detail.ownerId"
+              :source-url="detail.sourceUrl"
+              :status="detail.status"
+              @change="onArchiveChange"
+            />
           </div>
         </div>
       </div>
     </div>
-
-    <!-- Add User Permission Dialog -->
-    <el-dialog
-      v-model="showAddUserDialog"
-      title="Add User"
-      width="480px"
-      :close-on-click-modal="true"
-    >
-      <div class="add-perm-dialog">
-        <p>Grant a user access to this application:</p>
-        <el-select
-          v-model="selectedAddUserId"
-          placeholder="Select a user"
-          size="default"
-          filterable
-          class="add-perm-select"
-        >
-          <el-option
-            v-for="user in availableAddableUsers"
-            :key="user.id"
-            :label="`${user.firstName} ${user.lastName}`"
-            :value="user.id"
-          >
-            <div class="user-option">
-              <span class="user-name">
-                {{ user.firstName }} {{ user.lastName }}
-              </span>
-              <span class="user-email">{{ user.email }}</span>
-            </div>
-          </el-option>
-        </el-select>
-      </div>
-      <template #footer>
-        <div class="dialog-footer">
-          <el-button @click="showAddUserDialog = false">Cancel</el-button>
-          <el-button
-            type="primary"
-            :disabled="!selectedAddUserId"
-            @click="confirmAddUser"
-          >Add</el-button>
-        </div>
-      </template>
-    </el-dialog>
-
-    <!-- Add Team Permission Dialog -->
-    <el-dialog
-      v-model="showAddTeamDialog"
-      title="Add Team"
-      width="480px"
-      :close-on-click-modal="true"
-    >
-      <div class="add-perm-dialog">
-        <p>Grant a team access to this application:</p>
-        <el-select
-          v-model="selectedAddTeamId"
-          placeholder="Select a team"
-          size="default"
-          filterable
-          class="add-perm-select"
-        >
-          <el-option
-            v-for="t in availableAddableTeams"
-            :key="t.team.id"
-            :label="t.team.name"
-            :value="t.team.id"
-          />
-        </el-select>
-      </div>
-      <template #footer>
-        <div class="dialog-footer">
-          <el-button @click="showAddTeamDialog = false">Cancel</el-button>
-          <el-button
-            type="primary"
-            :disabled="!selectedAddTeamId"
-            @click="confirmAddTeam"
-          >Add</el-button>
-        </div>
-      </template>
-    </el-dialog>
-
-    <!-- Add Workspace Permission Dialog -->
-    <el-dialog
-      v-model="showAddWorkspaceDialog"
-      title="Add Workspace"
-      width="480px"
-      :close-on-click-modal="true"
-    >
-      <div class="add-perm-dialog">
-        <p>Grant a workspace access to this application:</p>
-        <el-select
-          v-model="selectedAddWorkspaceId"
-          placeholder="Select a workspace"
-          size="default"
-          filterable
-          class="add-perm-select"
-        >
-          <el-option
-            v-for="o in availableAddableWorkspaces"
-            :key="o.organization.id"
-            :label="o.organization.name"
-            :value="o.organization.id"
-          />
-        </el-select>
-      </div>
-      <template #footer>
-        <div class="dialog-footer">
-          <el-button @click="showAddWorkspaceDialog = false">Cancel</el-button>
-          <el-button
-            type="primary"
-            :disabled="!selectedAddWorkspaceId"
-            @click="confirmAddWorkspace"
-          >Add</el-button>
-        </div>
-      </template>
-    </el-dialog>
 
     <!-- Delete Confirmation Dialog -->
     <el-dialog
@@ -1304,25 +705,6 @@ const toggleArchiveStatus = async () => {
   align-items: center;
   gap: 8px;
   flex-shrink: 0;
-
-  .danger-button[disabled],
-  :deep(.bf-button.danger-button:disabled) {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-}
-
-.coming-soon-tag {
-  display: inline-block;
-  padding: 2px 8px;
-  background: #fff3cd;
-  color: #856404;
-  font-size: 11px;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  border-radius: 12px;
-  line-height: 1.2;
 }
 
 .delete-app-dialog {
@@ -1543,8 +925,7 @@ const toggleArchiveStatus = async () => {
 // Wrappers around disabled buttons so el-tooltip still receives hover
 // events (disabled buttons swallow them in some browsers). Heavily dim
 // the inner button so it reads unmistakably disabled.
-.edit-permissions-wrap,
-.archive-button-wrap {
+.edit-permissions-wrap {
   display: inline-flex;
 
   :deep(button[disabled]),
@@ -1557,6 +938,11 @@ const toggleArchiveStatus = async () => {
     cursor: not-allowed;
     box-shadow: none;
   }
+}
+
+.archive-toggle-wrap {
+  display: inline-flex;
+  align-items: center;
 }
 
 .permissions-edit {

--- a/src/components/user/code/PublishedAppDetail.vue
+++ b/src/components/user/code/PublishedAppDetail.vue
@@ -449,7 +449,6 @@ const onArchiveChange = (status) => {
             <app-archive-toggle
               :uuid="detail.uuid"
               :owner-id="detail.ownerId"
-              :source-url="detail.sourceUrl"
               :status="detail.status"
               @change="onArchiveChange"
             />

--- a/src/components/user/code/PublishingDialog.vue
+++ b/src/components/user/code/PublishingDialog.vue
@@ -13,67 +13,78 @@
           <h4>{{ repo.name }}</h4>
           <p v-if="repo.description" class="repo-description">{{ repo.description }}</p>
         </div>
-        
-        <div class="publishing-options">
-          <h5>Publishing Destinations</h5>
-          <p class="options-description">
-            Choose where you want to publish this repository when releases are created.
-          </p>
-          
-          <div class="option-group">
-            <label class="option-item">
-              <input 
-                type="checkbox" 
-                v-model="localSettings.publishToDiscover"
-                @change="onSettingsChange"
-              />
-              <div class="option-content">
-                <strong>Pennsieve Discover</strong>
-                <p>Publish to the Pennsieve Discover platform for scientific research datasets</p>
-              </div>
-            </label>
-            
-            <label class="option-item">
-              <input
-                type="checkbox"
-                v-model="localSettings.publishToAppstore"
-                @change="onSettingsChange"
-              />
-              <div class="option-content">
-                <strong>App Store</strong>
-                <p>Publish to the Pennsieve App Store for computational tools and applications</p>
-              </div>
-            </label>
-          </div>
-          
-          <div v-if="hasAnyPublishing" class="publishing-info">
-            <h6>What happens when you publish?</h6>
-            <ul>
-              <li>A DOI (Digital Object Identifier) will be generated for each release</li>
-              <li>Your repository will be archived and made citable</li>
-              <li>Metadata will be extracted and indexed for discoverability</li>
-              <li>A landing page will be created with publication details</li>
-            </ul>
-          </div>
-        </div>
 
-        <div v-if="canManagePermissions" class="permissions-section">
-          <h5>Permissions</h5>
-          <p class="options-description">
-            Manage who can access this private application.
-          </p>
-          <app-permissions
-            :uuid="matchedApp.uuid"
-            :owner-id="matchedApp.ownerId"
-            :is-public="false"
-            :organization-id="matchedApp.organizationId"
-          />
-        </div>
+        <el-tabs v-model="activeTab" class="publishing-tabs">
+          <el-tab-pane label="Destinations" name="destinations">
+            <div class="publishing-options">
+              <p class="options-description">
+                Choose where you want to publish this repository when releases are created.
+              </p>
+
+              <div class="option-group">
+                <label class="option-item">
+                  <input
+                    type="checkbox"
+                    v-model="localSettings.publishToDiscover"
+                    @change="onSettingsChange"
+                  />
+                  <div class="option-content">
+                    <strong>Pennsieve Discover</strong>
+                    <p>Publish to the Pennsieve Discover platform for scientific research datasets</p>
+                  </div>
+                </label>
+
+                <label class="option-item">
+                  <input
+                    type="checkbox"
+                    v-model="localSettings.publishToAppstore"
+                    @change="onSettingsChange"
+                  />
+                  <div class="option-content">
+                    <strong>App Store</strong>
+                    <p>Publish to the Pennsieve App Store for computational tools and applications</p>
+                  </div>
+                </label>
+              </div>
+
+              <div v-if="hasAnyPublishing" class="publishing-info">
+                <h6>What happens when you publish?</h6>
+                <ul>
+                  <li>A DOI (Digital Object Identifier) will be generated for each release</li>
+                  <li>Your repository will be archived and made citable</li>
+                  <li>Metadata will be extracted and indexed for discoverability</li>
+                  <li>A landing page will be created with publication details</li>
+                </ul>
+              </div>
+            </div>
+          </el-tab-pane>
+
+          <el-tab-pane
+            v-if="matchedApp"
+            label="Permissions"
+            name="permissions"
+          >
+            <div class="permissions-section">
+              <p class="options-description">
+                {{ permissionsDescription }}
+              </p>
+              <app-permissions
+                :uuid="matchedApp.uuid"
+                :owner-id="matchedApp.ownerId"
+                :is-public="matchedApp.isPrivate === false"
+                :organization-id="matchedApp.organizationId"
+              />
+            </div>
+          </el-tab-pane>
+        </el-tabs>
       </div>
 
       <div class="dialog-actions">
-        <bf-button class="secondary" @click="closeDialog">Cancel</bf-button>
+        <bf-button class="secondary" @click="closeDialog">
+          {{ activeTab === 'permissions' ? 'Close' : 'Cancel' }}
+        </bf-button>
         <bf-button
+          v-if="activeTab === 'destinations'"
           class="primary"
           @click="saveSettings"
           :disabled="saving"
@@ -113,6 +124,7 @@ export default {
   data() {
     return {
       saving: false,
+      activeTab: 'destinations',
       localSettings: {
         publishToDiscover: false,
         publishToAppstore: false
@@ -158,19 +170,21 @@ export default {
       return !!ownerId && (ownerId === profile.id || ownerId === profile.intId)
     },
 
-    // Permissions are only manageable for a private application you own.
-    canManagePermissions() {
-      return (
-        !!this.matchedApp &&
-        this.matchedApp.isPrivate === true &&
-        this.isMatchedAppOwner
-      )
+    // AppPermissions itself disables editing for non-owners and public apps,
+    // so the section is shown view-only in those cases. The description below
+    // matches the editability so it doesn't promise an edit you can't perform.
+    permissionsDescription() {
+      if (this.matchedApp?.isPrivate === true && this.isMatchedAppOwner) {
+        return 'Manage who can access this private application.'
+      }
+      return 'View who has access to this application.'
     }
   },
 
   watch: {
     dialogVisible(newVal) {
       if (newVal) {
+        this.activeTab = 'destinations'
         this.initializeSettings()
       }
     },
@@ -353,18 +367,35 @@ export default {
   }
 }
 
-.permissions-section {
-  margin-top: 24px;
-  padding-top: 24px;
-  border-top: 1px solid theme.$gray_2;
+.publishing-tabs {
+  margin-top: 8px;
 
-  h5 {
-    font-size: 16px;
-    font-weight: 500;
-    color: theme.$gray_6;
-    margin: 0 0 8px 0;
+  :deep(.el-tabs__header) {
+    margin-bottom: 20px;
   }
 
+  :deep(.el-tabs__item) {
+    font-size: 15px;
+    font-weight: 500;
+  }
+
+  :deep(.el-tabs__item.is-active),
+  :deep(.el-tabs__item:hover) {
+    color: theme.$purple_2;
+  }
+
+  :deep(.el-tabs__active-bar) {
+    background-color: theme.$purple_2;
+  }
+
+  // Keep the modal a stable height across tabs so switching to Permissions
+  // doesn't make the dialog shrink or grow.
+  :deep(.el-tabs__content) {
+    min-height: 460px;
+  }
+}
+
+.permissions-section {
   .options-description {
     font-size: 14px;
     color: theme.$gray_5;
@@ -374,13 +405,6 @@ export default {
 }
 
 .publishing-options {
-  h5 {
-    font-size: 16px;
-    font-weight: 500;
-    color: theme.$gray_6;
-    margin: 0 0 8px 0;
-  }
-
   .options-description {
     font-size: 14px;
     color: theme.$gray_5;

--- a/src/components/user/code/PublishingDialog.vue
+++ b/src/components/user/code/PublishingDialog.vue
@@ -56,8 +56,21 @@
             </ul>
           </div>
         </div>
+
+        <div v-if="canManagePermissions" class="permissions-section">
+          <h5>Permissions</h5>
+          <p class="options-description">
+            Manage who can access this private application.
+          </p>
+          <app-permissions
+            :uuid="matchedApp.uuid"
+            :owner-id="matchedApp.ownerId"
+            :is-public="false"
+            :organization-id="matchedApp.organizationId"
+          />
+        </div>
       </div>
-      
+
       <div class="dialog-actions">
         <bf-button class="secondary" @click="closeDialog">Cancel</bf-button>
         <bf-button
@@ -75,13 +88,15 @@
 <script>
 import IconXCircle from '../../icons/IconXCircle.vue'
 import BfButton from "@/components/shared/bf-button/BfButton.vue";
+import AppPermissions from './AppPermissions.vue'
 
 export default {
   name: 'PublishingDialog',
 
   components: {
     BfButton,
-    IconXCircle
+    IconXCircle,
+    AppPermissions
   },
 
   props: {
@@ -118,6 +133,38 @@ export default {
 
     hasAnyPublishing() {
       return this.localSettings.publishToDiscover || this.localSettings.publishToAppstore
+    },
+
+    applications() {
+      return this.$store.state.analysisModule?.applications || []
+    },
+
+    // The published application for this repo, matched by source URL.
+    matchedApp() {
+      const candidates = [this.repo?.html_url, this.repo?.url].filter(Boolean)
+      if (candidates.length === 0) return null
+      const normalize = (url) =>
+        (url || '').replace(/\.git$/, '').replace(/\/+$/, '').toLowerCase()
+      const targets = new Set(candidates.map(normalize))
+      return (
+        this.applications.find((a) => targets.has(normalize(a.sourceUrl))) ||
+        null
+      )
+    },
+
+    isMatchedAppOwner() {
+      const ownerId = this.matchedApp?.ownerId
+      const profile = this.$store.state.profile || {}
+      return !!ownerId && (ownerId === profile.id || ownerId === profile.intId)
+    },
+
+    // Permissions are only manageable for a private application you own.
+    canManagePermissions() {
+      return (
+        !!this.matchedApp &&
+        this.matchedApp.isPrivate === true &&
+        this.isMatchedAppOwner
+      )
     }
   },
 
@@ -302,6 +349,26 @@ export default {
     font-size: 14px;
     color: theme.$gray_5;
     margin: 0;
+    line-height: 1.5;
+  }
+}
+
+.permissions-section {
+  margin-top: 24px;
+  padding-top: 24px;
+  border-top: 1px solid theme.$gray_2;
+
+  h5 {
+    font-size: 16px;
+    font-weight: 500;
+    color: theme.$gray_6;
+    margin: 0 0 8px 0;
+  }
+
+  .options-description {
+    font-size: 14px;
+    color: theme.$gray_5;
+    margin: 0 0 16px 0;
     line-height: 1.5;
   }
 }

--- a/src/store/analysisModule.js
+++ b/src/store/analysisModule.js
@@ -63,6 +63,13 @@ export const mutations = {
       (u) => u !== uuid
     );
   },
+  UPDATE_APPLICATION_STATUS(state, { uuid, status }) {
+    // Applications are referenced by both the master list and the
+    // categorized (pre/processor/post) lists, so mutating the object's
+    // status keeps every view in sync.
+    const application = state.applications.find((a) => a.uuid === uuid);
+    if (application) application.status = status;
+  },
   UPDATE_PREPROCESSORS(state, preprocessors) {
     state.preprocessors = preprocessors;
   },
@@ -234,7 +241,10 @@ export const actions = {
         return Promise.reject();
       });
   },
-  fetchApplications: async ({ state, commit, rootState }, { force } = {}) => {
+  fetchApplications: async (
+    { state, commit, rootState },
+    { force, includeArchived } = {}
+  ) => {
     if (!force && state.applicationsLoaded) return;
     try {
       const userToken = await useGetToken();
@@ -246,7 +256,9 @@ export const actions = {
         || rootState.profile?.preferredOrganization
         || rootState.organizations?.[0]?.organization?.id;
       if (!orgId) return;
-      const url = `${rootState.config.api2Url}/applications/store?organization_id=${orgId}`;
+      // Archived applications are excluded by default; opt in with includeArchived.
+      let url = `${rootState.config.api2Url}/applications/store?organization_id=${orgId}`;
+      if (includeArchived) url += `&includeArchived=true`;
       const resp = await fetch(url, {
         method: "GET",
         headers: {
@@ -775,6 +787,38 @@ export const actions = {
       return result;
     } catch (err) {
       console.error("Failed to update application:", err.message);
+      throw err;
+    }
+  },
+  // Partially update an app store application's lifecycle status.
+  // status is one of "active" | "archived".
+  // PATCH /applications/store/{uuid}
+  setApplicationStatus: async ({ commit, rootState }, { uuid, status }) => {
+    if (!uuid) throw new Error("Missing application uuid");
+    const url = `${rootState.config.api2Url}/applications/store/${uuid}`;
+    const userToken = await useGetToken();
+
+    try {
+      const response = await fetch(url, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${userToken}`,
+        },
+        body: JSON.stringify({ status }),
+      });
+
+      if (!response.ok) {
+        const errorDetails = await response.text();
+        throw new Error(
+          `Error ${response.status}: ${response.statusText} - ${errorDetails}`
+        );
+      }
+
+      commit("UPDATE_APPLICATION_STATUS", { uuid, status });
+      return await response.json();
+    } catch (err) {
+      console.error("Failed to update application status:", err.message);
       throw err;
     }
   },

--- a/src/store/analysisModule.js
+++ b/src/store/analysisModule.js
@@ -914,6 +914,10 @@ export const actions = {
       throw new Error(message);
     }
     const newRun = await resp.json();
+    // Preserve the user-supplied name on the optimistic add in case the API response omits it.
+    if (payload?.name && newRun && !newRun.name) {
+      newRun.name = payload.name;
+    }
     commit("PREPEND_WORKFLOW_INSTANCE", newRun);
     return newRun;
   },


### PR DESCRIPTION

[Update flow for configuration screens](https://app.clickup.com/t/868ju3f6u)

[Bug: Cannot select CPU greater than 4 v CPU](https://app.clickup.com/t/868jqjzjt)

[fix: implements named runs and tests
](url)


- **Application archiving** — archive/unarchive apps via the new `PATCH /applications/store/{id}` endpoint, with a toggle on the single app view and the My Workspace page. Archiving also turns off App Store publishing for the source repo.
- **Reusable app permissions** — extracted a shared `AppPermissions` component (users / teams / workspaces) now used on the single app view, the repo settings modal, and the My Workspace page; removed the old "Manage in My Workspace" link.
- **Workflow CPU/memory selection** — restored the original Standard options (1 / 2 / 4 / 8 CPU + dependent GB memory). For Lambda, CPU now reads _"Set automatically"_ instead of a disabled dropdown.
- **Applications list filters** — Visibility + Status (Active / Archived / All) as compact dropdowns; archived apps hidden by default.
- **Repo cards** — no longer prompt _"Create GitHub release"_ when the repo already has a release.
- **Named workflow runs** — optional Run Name on the Configuration Summary panel (3–64 chars; letters, numbers, spaces, hyphens, underscores, periods), sent as `name` on `POST /compute/workflows/runs` and displayed on active-run cards, recent completions, the sidebar runs list, the run header, the Run Details panel, and metrics receipts.