### PR TITLE
chat: session history dropdown + inline figure download

### DIFF
--- a/src/components/Chat/ChatImageBlock.vue
+++ b/src/components/Chat/ChatImageBlock.vue
@@ -381,6 +381,8 @@ onMounted(async () => {
 </script>
 
 <style scoped lang="scss">
+@use '../../styles/theme';
+
 .chat-image-block {
   margin: 4px 0;
 }
@@ -392,11 +394,11 @@ onMounted(async () => {
   width: 100%;
   max-width: 480px;
   aspect-ratio: 4 / 3;
-  background: #e8eaed;
+  background: theme.$gray_2;
   border-radius: 8px;
 
   .loading-text {
-    color: #6b6b6b;
+    color: theme.$gray_5;
     font-size: 13px;
   }
 }
@@ -405,9 +407,9 @@ onMounted(async () => {
   display: inline-flex;
   align-items: center;
   padding: 10px 14px;
-  border: 1px dashed #d0d3d8;
+  border: 1px dashed theme.$gray_3;
   border-radius: 8px;
-  color: #6b6b6b;
+  color: theme.$gray_5;
   font-size: 13px;
   font-style: italic;
 }
@@ -439,17 +441,17 @@ onMounted(async () => {
   padding: 0;
   border: none;
   border-radius: 6px;
-  background: rgba(28, 28, 28, 0.6);
-  color: #fff;
+  background: rgba(theme.$black, 0.6);
+  color: theme.$white;
   cursor: pointer;
   transition: background 0.12s ease;
 
   svg { width: 16px; height: 16px; display: block; }
 
-  &:hover { background: rgba(28, 28, 28, 0.8); }
+  &:hover { background: rgba(theme.$black, 0.8); }
   &:disabled { cursor: default; opacity: 0.5; }
 
-  &--danger:hover { background: rgba(197, 48, 48, 0.9); }
+  &--danger:hover { background: rgba(theme.$red_1, 0.9); }
 }
 
 .figure-wrap:hover .actions,
@@ -464,12 +466,12 @@ onMounted(async () => {
   gap: 6px;
   padding: 8px 10px;
   border-radius: 8px;
-  background: rgba(28, 28, 28, 0.85);
+  background: rgba(theme.$black, 0.85);
   line-height: normal;
 }
 
 .confirm-text {
-  color: #fff;
+  color: theme.$white;
   font-size: 12px;
 }
 
@@ -482,19 +484,19 @@ onMounted(async () => {
   padding: 3px 10px;
   border: none;
   border-radius: 5px;
-  background: #e8eaed;
-  color: #1c1c1c;
+  background: theme.$gray_2;
+  color: theme.$gray_6;
   font-size: 12px;
   cursor: pointer;
 
-  &:hover { background: #fff; }
+  &:hover { background: theme.$white; }
   &:disabled { cursor: default; opacity: 0.6; }
 
   &--danger {
-    background: #c53030;
-    color: #fff;
+    background: theme.$red_1;
+    color: theme.$white;
 
-    &:hover { background: #b02525; }
+    &:hover { background: theme.$red_2; }
   }
 }
 
@@ -504,16 +506,16 @@ onMounted(async () => {
   width: 100%;
   height: auto;
   border-radius: 8px;
-  border: 1px solid #e0e2e6;
+  border: 1px solid theme.$gray_2;
 }
 
 .status-note {
   margin: 4px 0 0;
   font-size: 12px;
-  color: #6b6b6b;
+  color: theme.$gray_5;
   line-height: normal;
 
-  &--error { color: #c53030; }
+  &--error { color: theme.$red_2; }
 }
 
 // Source-package link beneath the figure. line-height reset because the
@@ -524,7 +526,7 @@ onMounted(async () => {
 }
 
 .source-link {
-  color: #5039f5;
+  color: theme.$purple_3;
   font-size: 12px;
   text-decoration: none;
 
@@ -533,7 +535,7 @@ onMounted(async () => {
 
 .fallback-link {
   display: inline-block;
-  color: #5039f5;
+  color: theme.$purple_3;
   font-size: 13px;
   text-decoration: underline;
 }

--- a/src/components/Chat/ChatImageBlock.vue
+++ b/src/components/Chat/ChatImageBlock.vue
@@ -4,6 +4,12 @@
       <span class="loading-text">Loading figure…</span>
     </div>
 
+    <!-- Terminal state after the user removes the figure. The viewer-asset
+         (and its S3 bytes) are gone; we don't try to re-resolve. -->
+    <div v-else-if="removed" class="figure-removed">
+      <span>Figure removed.</span>
+    </div>
+
     <div v-else-if="resolvedUrl" class="figure-wrap">
       <a
         :href="packageHref"
@@ -20,21 +26,84 @@
           @error="onImgError"
         />
       </a>
-      <!-- Download to the browser's downloads folder. Revealed on hover so
-           it doesn't clutter the figure at rest. -->
-      <button
-        type="button"
-        class="download-btn"
-        :title="`Download ${downloadName}`"
-        :aria-label="`Download ${downloadName}`"
-        :disabled="downloading"
-        @click="downloadImage"
-      >
-        <svg viewBox="0 0 16 16" aria-hidden="true">
-          <path d="M8 1.5v7.4m0 0L4.8 5.7M8 8.9l3.2-3.2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
-          <path d="M2.5 11v2a1 1 0 001 1h9a1 1 0 001-1v-2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
-        </svg>
-      </button>
+
+      <!-- Hover-revealed actions. Sits top-right so it doesn't clutter the
+           figure at rest. -->
+      <div v-if="!confirmingRemove" class="actions">
+        <button
+          type="button"
+          class="action-btn"
+          :title="`Download ${downloadName}`"
+          :aria-label="`Download ${downloadName}`"
+          :disabled="downloading"
+          @click="downloadImage"
+        >
+          <svg viewBox="0 0 16 16" aria-hidden="true">
+            <path d="M8 1.5v7.4m0 0L4.8 5.7M8 8.9l3.2-3.2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M2.5 11v2a1 1 0 001 1h9a1 1 0 001-1v-2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </button>
+
+        <!-- Promote: detach from the chat session so the figure becomes a
+             normal dataset asset. Only offered when we resolved by asset id
+             (we have something to act on) and it hasn't been promoted yet. -->
+        <button
+          v-if="assetId && !promoted"
+          type="button"
+          class="action-btn"
+          title="Save to dataset assets"
+          aria-label="Save figure to dataset assets"
+          :disabled="busy"
+          @click="promote"
+        >
+          <svg viewBox="0 0 16 16" aria-hidden="true">
+            <path d="M3.5 2.5h6.8L13 5.2V13a.5.5 0 01-.5.5h-9A.5.5 0 013 13V3a.5.5 0 01.5-.5z" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" />
+            <path d="M5.5 2.5v3h4v-3M5.5 13.5v-4h5v4" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" />
+          </svg>
+        </button>
+
+        <!-- Remove: delete just this viewer-asset by id. Never touches the
+             underlying package or dataset. Two-step (click → confirm). -->
+        <button
+          v-if="assetId"
+          type="button"
+          class="action-btn action-btn--danger"
+          title="Remove figure"
+          aria-label="Remove figure"
+          :disabled="busy"
+          @click="confirmingRemove = true"
+        >
+          <svg viewBox="0 0 16 16" aria-hidden="true">
+            <path d="M3 4.5h10M6.2 4.5V3.2a.7.7 0 01.7-.7h2.2a.7.7 0 01.7.7v1.3M4.3 4.5l.6 8a.8.8 0 00.8.7h4.6a.8.8 0 00.8-.7l.6-8" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Inline confirm overlay for the destructive remove. -->
+      <div v-else class="confirm-overlay">
+        <span class="confirm-text">Remove this figure?</span>
+        <div class="confirm-buttons">
+          <button
+            type="button"
+            class="confirm-btn confirm-btn--danger"
+            :disabled="busy"
+            @click="removeFigure"
+          >
+            {{ busy ? 'Removing…' : 'Remove' }}
+          </button>
+          <button
+            type="button"
+            class="confirm-btn"
+            :disabled="busy"
+            @click="confirmingRemove = false"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+
+      <p v-if="promoted" class="status-note">Saved to dataset assets.</p>
+      <p v-if="actionError" class="status-note status-note--error">{{ actionError }}</p>
     </div>
 
     <a
@@ -51,37 +120,42 @@
 
 <script setup>
 // ChatImageBlock — renders one inline figure produced by an MCP-triggered
-// workflow (currently just plot_file). The frame carries no URL —
-// (packageNodeId, datasetNodeId, assetName, assetType) coordinates only.
-// This component resolves to a signed CloudFront URL by:
+// workflow (currently just plot_file). The frame carries no URL — only
+// viewer-asset coordinates on `source`.
 //
-//   1. Calling the existing `fetchPackageViewerAssets` Vuex action against
-//      packages-service `/packages/assets?dataset_id=…&package_id=…`.
-//      Same call the package viewer uses for ome-zarr / neuroglancer
-//      rendering — see ViewerPane.vue.
-//   2. Picking the asset matching {name, asset_type}. When `assetName` is
-//      empty, pick the most recently created asset of the requested type.
-//   3. Building a query-string-signed URL:
-//      `${asset.asset_url}figure.png?Policy=…&Signature=…&Key-Pair-Id=…`.
-//      Query-string signing (vs. relying on the Set-Cookie machinery the
-//      assets endpoint emits) works regardless of cross-domain cookie
-//      attribute issues.
+// Resolution, in priority order:
+//
+//   1. By asset id (preferred). When the producing workflow reported the
+//      viewer-asset UUID back as a run output, the frame carries
+//      `source.assetId`. We resolve it directly via packages-service
+//      `GET /packages/assets/{id}?dataset_id=…`, which returns the asset +
+//      a signed CloudFront policy. This is the ONLY reliable path for
+//      chat-scoped figures: those are excluded from the package/dataset
+//      asset listing, so the list-and-match path (below) can't see them.
+//
+//   2. By coordinates (fallback). For older frames without `assetId`, list
+//      the package's assets via `fetchPackageViewerAssets` and match on
+//      {name, asset_type}, newest first. Works for plain (non-chat-scoped)
+//      figures only.
+//
+// Either way we build a query-string-signed URL:
+//   `${asset.asset_url}${fileName}?Policy=…&Signature=…&Key-Pair-Id=…`
+// (fileName defaults to the figure-asset convention `figure.png`).
+//
+// Actions (when resolved by id): download, promote (detach from the chat
+// session → becomes a plain dataset asset), and remove (delete just this
+// viewer-asset by id — never the package or dataset).
 //
 // On any error — API failure, no matching asset, image-load failure — the
-// component falls back to a plain text-link pointing at the package
-// viewer. Same UX older clients get from the plain-text `content` field.
-//
-// Filename convention: the `figure-asset` data-target writes `figure.png`
-// at the asset's S3 prefix root. If a future workflow ships a different
-// filename, the assets API would need to surface it; tracked as an open
-// question in compute-node-chat/docs/developer/inline-image-frames.md.
+// component falls back to a plain text-link pointing at the package viewer.
 
 import { computed, onMounted, ref } from 'vue'
 import { useStore } from 'vuex'
 
 const props = defineProps({
-  // The image block from AssistantMessage.blocks[]. Required fields on
-  // `source`: packageNodeId, datasetNodeId. Optional: assetName, assetType.
+  // The image block from AssistantMessage.blocks[]. Required on `source`:
+  // datasetNodeId, plus EITHER assetId OR packageNodeId. Optional: assetName,
+  // assetType, fileName.
   block: { type: Object, required: true },
 })
 
@@ -91,8 +165,18 @@ const loading = ref(true)
 const resolvedUrl = ref('')
 const downloading = ref(false)
 
+// Action state.
+const busy = ref(false)
+const confirmingRemove = ref(false)
+const removed = ref(false)
+const promoted = ref(false)
+const actionError = ref('')
+
 const alt = computed(() => props.block.alt || 'Inline figure')
 const source = computed(() => props.block.source || {})
+const assetId = computed(() => source.value.assetId || '')
+const datasetNodeId = computed(() => source.value.datasetNodeId || '')
+const fileName = computed(() => source.value.fileName || 'figure.png')
 
 // Filename for the downloaded file. Prefer the asset's own name; fall back
 // to the figure-asset convention (figure.png). Ensure a .png extension so
@@ -132,21 +216,61 @@ const downloadImage = async () => {
   }
 }
 
+// Promote: detach the chat session so the figure shows in the dataset's
+// asset listing. Metadata-only — the bytes don't move.
+const promote = async () => {
+  if (!assetId.value || !datasetNodeId.value || busy.value) return
+  busy.value = true
+  actionError.value = ''
+  try {
+    await store.dispatch('viewerModule/promoteViewerAsset', {
+      datasetId: datasetNodeId.value,
+      assetId: assetId.value,
+    })
+    promoted.value = true
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('[chat] ChatImageBlock: promote failed', err)
+    actionError.value = 'Could not save to dataset assets.'
+  } finally {
+    busy.value = false
+  }
+}
+
+// Remove: delete just this viewer-asset by id. The package and dataset are
+// untouched. After success we show the removed state instead of re-resolving.
+const removeFigure = async () => {
+  if (!assetId.value || !datasetNodeId.value || busy.value) return
+  busy.value = true
+  actionError.value = ''
+  try {
+    await store.dispatch('viewerModule/deleteViewerAsset', {
+      datasetId: datasetNodeId.value,
+      assetId: assetId.value,
+    })
+    removed.value = true
+    confirmingRemove.value = false
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('[chat] ChatImageBlock: remove failed', err)
+    actionError.value = 'Could not remove the figure.'
+    confirmingRemove.value = false
+  } finally {
+    busy.value = false
+  }
+}
+
 // Open-in-viewer fallback link. Matches the `file-record` route registered
 // in router/index.js (`:orgId/datasets/:datasetId/files/:fileId/details`).
-// Two pieces routinely missed when this was first built:
-//   - the org slug at the start (a /datasets/... URL with no org 404s)
-//   - the /details suffix (the route is FileDetails, not the dataset-files
-//     index)
 // Read the org from Vuex's activeOrganization rather than a route param —
-// the chat panel can be hosted in widgets (e.g. Spotlight) where the
-// current route isn't org-scoped, but activeOrganization is set globally.
+// the chat panel can be hosted in widgets (e.g. Spotlight) where the current
+// route isn't org-scoped, but activeOrganization is set globally.
 const packageHref = computed(() => {
-  const { packageNodeId, datasetNodeId } = source.value
-  if (!packageNodeId || !datasetNodeId) return '#'
+  const { packageNodeId, datasetNodeId: ds } = source.value
+  if (!packageNodeId || !ds) return '#'
   const orgId = store.state?.activeOrganization?.organization?.id
   if (!orgId) return '#'
-  return `/${orgId}/datasets/${datasetNodeId}/files/${packageNodeId}/details`
+  return `/${orgId}/datasets/${ds}/files/${packageNodeId}/details`
 })
 
 const onImgError = () => {
@@ -156,59 +280,75 @@ const onImgError = () => {
   resolvedUrl.value = ''
 }
 
-onMounted(async () => {
-  const { packageNodeId, datasetNodeId, assetName, assetType } = source.value
+// Build a query-string-signed image URL from an { asset, cloudfront }
+// response. Returns true on success.
+const buildSignedUrl = (result) => {
+  const asset = result?.asset
+  if (!asset?.asset_url) return false
+  const cf = result.cloudfront
+  if (!cf?.policy || !cf?.signature || !cf?.key_pair_id) return false
+  const qs = new URLSearchParams({
+    Policy: cf.policy,
+    Signature: cf.signature,
+    'Key-Pair-Id': cf.key_pair_id,
+  })
+  resolvedUrl.value = `${asset.asset_url}${fileName.value}?${qs.toString()}`
+  return true
+}
 
-  if (!packageNodeId || !datasetNodeId) {
+// Preferred path: resolve directly by asset id. Works for chat-scoped
+// figures, which the listing endpoint deliberately excludes.
+const resolveByAssetId = async () => {
+  const result = await store.dispatch('viewerModule/fetchViewerAssetById', {
+    datasetId: datasetNodeId.value,
+    assetId: assetId.value,
+  })
+  return buildSignedUrl(result)
+}
+
+// Fallback path: list the package's assets and match on {name, asset_type},
+// newest first. Only finds plain (non-chat-scoped) figures.
+const resolveByListing = async () => {
+  const { packageNodeId, assetName, assetType } = source.value
+  if (!packageNodeId) return false
+
+  const result = await store.dispatch('viewerModule/fetchPackageViewerAssets', {
+    datasetId: datasetNodeId.value,
+    packageId: packageNodeId,
+  })
+  if (!result?.assets?.length) return false
+
+  const typeFilter = assetType || 'PNG'
+  const candidates = result.assets
+    .filter((a) => a.status === 'ready')
+    .filter((a) => a.asset_type === typeFilter)
+    .filter((a) => !assetName || a.name === assetName)
+    .sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''))
+
+  const asset = candidates[0]
+  if (!asset) return false
+  return buildSignedUrl({ asset, cloudfront: result.cloudfront })
+}
+
+onMounted(async () => {
+  // datasetNodeId is required for both paths.
+  if (!datasetNodeId.value) {
+    loading.value = false
+    return
+  }
+  // Need at least one resolution key.
+  if (!assetId.value && !source.value.packageNodeId) {
     loading.value = false
     return
   }
 
   try {
-    const result = await store.dispatch('viewerModule/fetchPackageViewerAssets', {
-      datasetId: datasetNodeId,
-      packageId: packageNodeId,
-    })
-
-    if (!result?.assets?.length) {
-      loading.value = false
-      return
+    if (assetId.value) {
+      if (await resolveByAssetId()) return
     }
-
-    // Pick the right asset. Match on name + asset_type when both are
-    // specified; fall back to asset_type only if name is empty; fall back
-    // to "any ready asset" as a last resort. Sort by created_at desc so
-    // the most recent run wins when a user plotted the same package
-    // multiple times.
-    const typeFilter = assetType || 'PNG'
-    const candidates = result.assets
-      .filter((a) => a.status === 'ready')
-      .filter((a) => a.asset_type === typeFilter)
-      .filter((a) => !assetName || a.name === assetName)
-      .sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''))
-
-    const asset = candidates[0]
-    if (!asset || !asset.asset_url) {
-      loading.value = false
-      return
-    }
-
-    // Build the signed image URL. asset.asset_url ends with the asset's
-    // S3-prefix slash; the figure-asset data-target writes `figure.png`
-    // there. Sign with CloudFront query-string params from the API
-    // response.
-    const cf = result.cloudfront
-    if (!cf?.policy || !cf?.signature || !cf?.key_pair_id) {
-      // Asset exists but signing failed server-side — fall back.
-      loading.value = false
-      return
-    }
-    const qs = new URLSearchParams({
-      Policy: cf.policy,
-      Signature: cf.signature,
-      'Key-Pair-Id': cf.key_pair_id,
-    })
-    resolvedUrl.value = `${asset.asset_url}figure.png?${qs.toString()}`
+    // Fall back to the coordinate listing path (older frames / no assetId,
+    // or an asset-id lookup that returned nothing).
+    await resolveByListing()
   } catch (err) {
     // Permission denied / network / shape change — log and degrade.
     // eslint-disable-next-line no-console
@@ -240,8 +380,19 @@ onMounted(async () => {
   }
 }
 
-// Positioning context for the hover download button, sized to the image
-// (inline-block) so the button hugs the figure's top-right, not the bubble.
+.figure-removed {
+  display: inline-flex;
+  align-items: center;
+  padding: 10px 14px;
+  border: 1px dashed #d0d3d8;
+  border-radius: 8px;
+  color: #6b6b6b;
+  font-size: 13px;
+  font-style: italic;
+}
+
+// Positioning context for the hover actions, sized to the image
+// (inline-block) so the buttons hug the figure's top-right, not the bubble.
 .figure-wrap {
   position: relative;
   display: inline-block;
@@ -253,10 +404,17 @@ onMounted(async () => {
   line-height: 0; // collapse the anchor's text-baseline gap below the img
 }
 
-.download-btn {
+.actions {
   position: absolute;
   top: 8px;
   right: 8px;
+  display: inline-flex;
+  gap: 6px;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.action-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -268,17 +426,61 @@ onMounted(async () => {
   background: rgba(28, 28, 28, 0.6);
   color: #fff;
   cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.12s ease, background 0.12s ease;
+  transition: background 0.12s ease;
 
   svg { width: 16px; height: 16px; display: block; }
 
   &:hover { background: rgba(28, 28, 28, 0.8); }
   &:disabled { cursor: default; opacity: 0.5; }
+
+  &--danger:hover { background: rgba(197, 48, 48, 0.9); }
 }
 
-.figure-wrap:hover .download-btn,
-.download-btn:focus-visible { opacity: 1; }
+.figure-wrap:hover .actions,
+.actions:focus-within { opacity: 1; }
+
+.confirm-overlay {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: rgba(28, 28, 28, 0.85);
+  line-height: normal;
+}
+
+.confirm-text {
+  color: #fff;
+  font-size: 12px;
+}
+
+.confirm-buttons {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.confirm-btn {
+  padding: 3px 10px;
+  border: none;
+  border-radius: 5px;
+  background: #e8eaed;
+  color: #1c1c1c;
+  font-size: 12px;
+  cursor: pointer;
+
+  &:hover { background: #fff; }
+  &:disabled { cursor: default; opacity: 0.6; }
+
+  &--danger {
+    background: #c53030;
+    color: #fff;
+
+    &:hover { background: #b02525; }
+  }
+}
 
 .figure {
   display: block;
@@ -287,6 +489,15 @@ onMounted(async () => {
   height: auto;
   border-radius: 8px;
   border: 1px solid #e0e2e6;
+}
+
+.status-note {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: #6b6b6b;
+  line-height: normal;
+
+  &--error { color: #c53030; }
 }
 
 .fallback-link {

--- a/src/components/Chat/ChatImageBlock.vue
+++ b/src/components/Chat/ChatImageBlock.vue
@@ -45,14 +45,16 @@
         </button>
 
         <!-- Promote: detach from the chat session so the figure becomes a
-             normal dataset asset. Only offered when we resolved by asset id
-             (we have something to act on) and it hasn't been promoted yet. -->
+             normal asset. It lands wherever its package link points: a
+             package-scoped asset when the figure came from a package
+             (plot_file always does), else a plain dataset asset. Only offered
+             when we resolved by asset id and it hasn't been promoted yet. -->
         <button
           v-if="assetId && !promoted"
           type="button"
           class="action-btn"
-          title="Save to dataset assets"
-          aria-label="Save figure to dataset assets"
+          :title="promoteTitle"
+          :aria-label="promoteTitle"
           :disabled="busy"
           @click="promote"
         >
@@ -102,7 +104,7 @@
         </div>
       </div>
 
-      <p v-if="promoted" class="status-note">Saved to dataset assets.</p>
+      <p v-if="promoted" class="status-note">{{ promotedNote }}</p>
       <p v-if="actionError" class="status-note status-note--error">{{ actionError }}</p>
     </div>
 
@@ -177,6 +179,18 @@ const source = computed(() => props.block.source || {})
 const assetId = computed(() => source.value.assetId || '')
 const datasetNodeId = computed(() => source.value.datasetNodeId || '')
 const fileName = computed(() => source.value.fileName || 'figure.png')
+
+// A chat figure carries its package link through promote (clear_chat_session
+// only nulls the chat scope), so it lands as a package-scoped asset whenever
+// it came from a package — which plot_file figures always do. Word the promote
+// affordance to match where the figure actually ends up.
+const hasPackage = computed(() => !!source.value.packageNodeId)
+const promoteTitle = computed(() =>
+  hasPackage.value ? 'Save to package' : 'Save to dataset assets'
+)
+const promotedNote = computed(() =>
+  hasPackage.value ? 'Saved to package.' : 'Saved to dataset assets.'
+)
 
 // Filename for the downloaded file. Prefer the asset's own name; fall back
 // to the figure-asset convention (figure.png). Ensure a .png extension so

--- a/src/components/Chat/ChatImageBlock.vue
+++ b/src/components/Chat/ChatImageBlock.vue
@@ -11,21 +11,17 @@
     </div>
 
     <div v-else-if="resolvedUrl" class="figure-wrap">
-      <a
-        :href="packageHref"
-        target="_blank"
-        rel="noopener"
-        class="image-link"
-        :aria-label="alt + ' — open package'"
-      >
-        <img
-          :src="resolvedUrl"
-          :alt="alt"
-          loading="lazy"
-          class="figure"
-          @error="onImgError"
-        />
-      </a>
+      <!-- The figure renders inline here. We don't link the image to the
+           package: the figure is chat-scoped until promoted, so it isn't
+           viewable in the package viewer yet. The source-package router-link
+           below points at where the data came from. -->
+      <img
+        :src="resolvedUrl"
+        :alt="alt"
+        loading="lazy"
+        class="figure"
+        @error="onImgError"
+      />
 
       <!-- Hover-revealed actions. Sits top-right so it doesn't clutter the
            figure at rest. -->
@@ -106,17 +102,24 @@
 
       <p v-if="promoted" class="status-note">{{ promotedNote }}</p>
       <p v-if="actionError" class="status-note status-note--error">{{ actionError }}</p>
+
+      <!-- Link to the source package (where the plotted data lives) as an
+           in-app router navigation. Not "where the figure is" — the figure
+           shows inline above and isn't in the package until promoted. -->
+      <p v-if="packageRoute" class="source-note">
+        <router-link :to="packageRoute" class="source-link">Open source package →</router-link>
+      </p>
     </div>
 
-    <a
-      v-else
-      :href="packageHref"
-      target="_blank"
-      rel="noopener"
+    <!-- Figure couldn't be resolved/rendered. Fall back to a router-link to
+         the source package so the user can still get there. -->
+    <router-link
+      v-else-if="packageRoute"
+      :to="packageRoute"
       class="fallback-link"
     >
-      View plot in package →
-    </a>
+      Open source package →
+    </router-link>
   </div>
 </template>
 
@@ -274,17 +277,21 @@ const removeFigure = async () => {
   }
 }
 
-// Open-in-viewer fallback link. Matches the `file-record` route registered
-// in router/index.js (`:orgId/datasets/:datasetId/files/:fileId/details`).
-// Read the org from Vuex's activeOrganization rather than a route param —
-// the chat panel can be hosted in widgets (e.g. Spotlight) where the current
-// route isn't org-scoped, but activeOrganization is set globally.
-const packageHref = computed(() => {
+// vue-router target for the source package (the `file-record` route, same one
+// ChatMessage's attachment chips use). Returns null when we can't build it —
+// the template degrades by hiding the link rather than rendering a dead one.
+// Read the org from Vuex's activeOrganization rather than a route param: the
+// chat panel can be hosted in widgets (e.g. Spotlight) where the current route
+// isn't org-scoped, but activeOrganization is set globally.
+const packageRoute = computed(() => {
   const { packageNodeId, datasetNodeId: ds } = source.value
-  if (!packageNodeId || !ds) return '#'
+  if (!packageNodeId || !ds) return null
   const orgId = store.state?.activeOrganization?.organization?.id
-  if (!orgId) return '#'
-  return `/${orgId}/datasets/${ds}/files/${packageNodeId}/details`
+  if (!orgId) return null
+  return {
+    name: 'file-record',
+    params: { orgId, datasetId: ds, fileId: packageNodeId },
+  }
 })
 
 const onImgError = () => {
@@ -413,11 +420,6 @@ onMounted(async () => {
   line-height: 0;
 }
 
-.image-link {
-  display: inline-block;
-  line-height: 0; // collapse the anchor's text-baseline gap below the img
-}
-
 .actions {
   position: absolute;
   top: 8px;
@@ -512,6 +514,21 @@ onMounted(async () => {
   line-height: normal;
 
   &--error { color: #c53030; }
+}
+
+// Source-package link beneath the figure. line-height reset because the
+// .figure-wrap container collapses it to 0 to hug the image.
+.source-note {
+  margin: 4px 0 0;
+  line-height: normal;
+}
+
+.source-link {
+  color: #5039f5;
+  font-size: 12px;
+  text-decoration: none;
+
+  &:hover { text-decoration: underline; }
 }
 
 .fallback-link {

--- a/src/components/Chat/ChatImageBlock.vue
+++ b/src/components/Chat/ChatImageBlock.vue
@@ -177,6 +177,11 @@ const removed = ref(false)
 const promoted = ref(false)
 const actionError = ref('')
 
+// Resolved-asset state, populated from the by-id lookup. `resolvedPackageIds`
+// is null until we've resolved (so hasPackage can fall back to the frame's
+// packageNodeId for the listing path / older frames).
+const resolvedPackageIds = ref(null)
+
 const alt = computed(() => props.block.alt || 'Inline figure')
 const source = computed(() => props.block.source || {})
 const assetId = computed(() => source.value.assetId || '')
@@ -186,13 +191,21 @@ const fileName = computed(() => source.value.fileName || 'figure.png')
 // A chat figure carries its package link through promote (clear_chat_session
 // only nulls the chat scope), so it lands as a package-scoped asset whenever
 // it came from a package — which plot_file figures always do. Word the promote
-// affordance to match where the figure actually ends up.
-const hasPackage = computed(() => !!source.value.packageNodeId)
+// affordance to match where the figure actually ends up. Prefer the resolved
+// asset's real package links; fall back to the frame's packageNodeId before
+// resolution completes (and for the listing path, where we don't fetch by id).
+const hasPackage = computed(() => {
+  if (resolvedPackageIds.value !== null) return resolvedPackageIds.value.length > 0
+  return !!source.value.packageNodeId
+})
 const promoteTitle = computed(() =>
   hasPackage.value ? 'Save to package' : 'Save to dataset assets'
 )
 const promotedNote = computed(() =>
   hasPackage.value ? 'Saved to package.' : 'Saved to dataset assets.'
+)
+const promoteFailNote = computed(() =>
+  hasPackage.value ? 'Could not save to package.' : 'Could not save to dataset assets.'
 )
 
 // Filename for the downloaded file. Prefer the asset's own name; fall back
@@ -248,7 +261,7 @@ const promote = async () => {
   } catch (err) {
     // eslint-disable-next-line no-console
     console.warn('[chat] ChatImageBlock: promote failed', err)
-    actionError.value = 'Could not save to dataset assets.'
+    actionError.value = promoteFailNote.value
   } finally {
     busy.value = false
   }
@@ -308,6 +321,14 @@ const buildSignedUrl = (result) => {
   if (!asset?.asset_url) return false
   const cf = result.cloudfront
   if (!cf?.policy || !cf?.signature || !cf?.key_pair_id) return false
+
+  // Capture the asset's real state so the actions reflect it: package links
+  // decide the promote wording/target, and the presence of chat_session_id
+  // tells us whether it's still a chat figure (offer promote) or already
+  // promoted (don't — re-promoting would 404 once the chat link is gone).
+  resolvedPackageIds.value = Array.isArray(asset.package_ids) ? asset.package_ids : []
+  if (!asset.chat_session_id) promoted.value = true
+
   const qs = new URLSearchParams({
     Policy: cf.policy,
     Signature: cf.signature,

--- a/src/components/Chat/ChatImageBlock.vue
+++ b/src/components/Chat/ChatImageBlock.vue
@@ -4,22 +4,38 @@
       <span class="loading-text">Loading figure…</span>
     </div>
 
-    <a
-      v-else-if="resolvedUrl"
-      :href="packageHref"
-      target="_blank"
-      rel="noopener"
-      class="image-link"
-      :aria-label="alt + ' — open package'"
-    >
-      <img
-        :src="resolvedUrl"
-        :alt="alt"
-        loading="lazy"
-        class="figure"
-        @error="onImgError"
-      />
-    </a>
+    <div v-else-if="resolvedUrl" class="figure-wrap">
+      <a
+        :href="packageHref"
+        target="_blank"
+        rel="noopener"
+        class="image-link"
+        :aria-label="alt + ' — open package'"
+      >
+        <img
+          :src="resolvedUrl"
+          :alt="alt"
+          loading="lazy"
+          class="figure"
+          @error="onImgError"
+        />
+      </a>
+      <!-- Download to the browser's downloads folder. Revealed on hover so
+           it doesn't clutter the figure at rest. -->
+      <button
+        type="button"
+        class="download-btn"
+        :title="`Download ${downloadName}`"
+        :aria-label="`Download ${downloadName}`"
+        :disabled="downloading"
+        @click="downloadImage"
+      >
+        <svg viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M8 1.5v7.4m0 0L4.8 5.7M8 8.9l3.2-3.2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+          <path d="M2.5 11v2a1 1 0 001 1h9a1 1 0 001-1v-2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      </button>
+    </div>
 
     <a
       v-else
@@ -73,9 +89,48 @@ const store = useStore()
 
 const loading = ref(true)
 const resolvedUrl = ref('')
+const downloading = ref(false)
 
 const alt = computed(() => props.block.alt || 'Inline figure')
 const source = computed(() => props.block.source || {})
+
+// Filename for the downloaded file. Prefer the asset's own name; fall back
+// to the figure-asset convention (figure.png). Ensure a .png extension so
+// the OS treats it as an image.
+const downloadName = computed(() => {
+  const name = (source.value.assetName || '').trim()
+  if (!name) return 'figure.png'
+  return /\.[a-z0-9]+$/i.test(name) ? name : `${name}.png`
+})
+
+// Download the figure to the browser's downloads folder. The signed
+// CloudFront URL is cross-origin, so a plain <a download> would be ignored
+// (the browser would navigate instead). Fetch the bytes and save via an
+// object URL. If the fetch is blocked (e.g. CORS), fall back to opening the
+// image in a new tab so the user can still save it manually.
+const downloadImage = async () => {
+  if (!resolvedUrl.value || downloading.value) return
+  downloading.value = true
+  try {
+    const resp = await fetch(resolvedUrl.value)
+    if (!resp.ok) throw new Error(`status ${resp.status}`)
+    const blob = await resp.blob()
+    const objUrl = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = objUrl
+    a.download = downloadName.value
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    URL.revokeObjectURL(objUrl)
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('[chat] ChatImageBlock: download failed, opening in new tab', err)
+    window.open(resolvedUrl.value, '_blank', 'noopener')
+  } finally {
+    downloading.value = false
+  }
+}
 
 // Open-in-viewer fallback link. Matches the `file-record` route registered
 // in router/index.js (`:orgId/datasets/:datasetId/files/:fileId/details`).
@@ -185,10 +240,45 @@ onMounted(async () => {
   }
 }
 
+// Positioning context for the hover download button, sized to the image
+// (inline-block) so the button hugs the figure's top-right, not the bubble.
+.figure-wrap {
+  position: relative;
+  display: inline-block;
+  line-height: 0;
+}
+
 .image-link {
   display: inline-block;
   line-height: 0; // collapse the anchor's text-baseline gap below the img
 }
+
+.download-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: rgba(28, 28, 28, 0.6);
+  color: #fff;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.12s ease, background 0.12s ease;
+
+  svg { width: 16px; height: 16px; display: block; }
+
+  &:hover { background: rgba(28, 28, 28, 0.8); }
+  &:disabled { cursor: default; opacity: 0.5; }
+}
+
+.figure-wrap:hover .download-btn,
+.download-btn:focus-visible { opacity: 1; }
 
 .figure {
   display: block;

--- a/src/components/Chat/ChatMessageList.vue
+++ b/src/components/Chat/ChatMessageList.vue
@@ -1,7 +1,15 @@
 <template>
   <div ref="scrollEl" class="chat-message-list">
-    <slot name="empty" v-if="!messages.length && !pending" />
-    <ChatMessage v-for="(msg, idx) in messages" :key="idx" :message="msg" />
+    <!-- Empty state and the message list are mutually exclusive branches.
+         Putting v-if on a wrapper element (rather than directly on <slot>)
+         avoids a Vue fragment/anchor patch bug that crashed on the
+         empty→populated transition when resuming a session. -->
+    <div v-if="!messages.length && !pending" class="empty-slot">
+      <slot name="empty" />
+    </div>
+    <template v-else>
+      <ChatMessage v-for="(msg, idx) in messages" :key="msg.id ?? idx" :message="msg" />
+    </template>
     <ChatToolProgress v-if="activeTools.length" :tools="activeTools" />
     <div v-if="pending && !hasRunningTool" class="thinking">
       <span class="dot" />
@@ -45,6 +53,15 @@ watch(() => props.pending, scrollToBottom)
   padding: 16px;
   display: flex;
   flex-direction: column;
+}
+
+// Wrapper around the #empty slot. Forwards the flex sizing so the slotted
+// empty-state (which uses flex:1 to center itself) still fills the list.
+.empty-slot {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .thinking {

--- a/src/components/Chat/ChatPanel.vue
+++ b/src/components/Chat/ChatPanel.vue
@@ -59,6 +59,23 @@
         >
           <span class="kbd-inline" aria-hidden="true">{{ cmdKLabel }}</span>
         </button>
+        <!-- History dropdown: resume a saved server-side session. Anchored
+             relative to this wrapper so the popover drops below the button. -->
+        <div class="history-wrap">
+          <button
+            type="button"
+            class="header-btn"
+            :class="{ active: historyOpen }"
+            @click="toggleHistory"
+            aria-label="Chat history"
+            title="Chat history"
+          >History</button>
+          <ChatSessionMenu
+            v-model:visible="historyOpen"
+            :active-id="convo?.sessionId || null"
+            @resume="resumeSession"
+          />
+        </div>
         <button
           v-if="messageCount"
           type="button"
@@ -157,10 +174,12 @@ import ChatMessageList from './ChatMessageList.vue'
 import ChatInput from './ChatInput.vue'
 import ChatStarterPrompts from './ChatStarterPrompts.vue'
 import ComputeNodePicker from './ComputeNodePicker.vue'
+import ChatSessionMenu from './ChatSessionMenu.vue'
 import EventBus from '@/utils/event-bus'
 import { cmdKLabel } from '@/utils/platform'
 import ChatQuotaHeader from './ChatQuotaHeader.vue'
 import { useChatQuota } from '@/composables/useChatQuota'
+import { useChatSessions } from '@/composables/useChatSessions'
 
 const props = defineProps({
   mode: { type: String, required: true }, // 'workspace' | 'dataset'
@@ -175,6 +194,7 @@ const chatStore = useChatStore()
 const computeStore = useComputeResourcesStore()
 const vuexStore = useStore()
 const { sendUserMessage, disconnect } = useChatSocket()
+const { listMessages } = useChatSessions()
 
 const hasAdminRights = computed(() => {
   const org = vuexStore.state?.activeOrganization
@@ -367,6 +387,56 @@ const onPickPrompt = (prompt) => onSubmit(prompt)
 
 const onResetConversation = () => chatStore.resetConversation(key.value)
 
+const historyOpen = ref(false)
+const toggleHistory = () => { historyOpen.value = !historyOpen.value }
+
+// Resume a persisted server-side session: fetch its history (oldest-first),
+// hydrate the conversation so the panel renders the prior turns, and close
+// the current socket so the next send reconnects on the resumed sessionId
+// (the URL carries `sessionId`, so the server continues that session).
+const resumeSession = async (session) => {
+  historyOpen.value = false
+  const id = session?.id
+  if (!id) return
+
+  // Fetch history FIRST, before mutating any store state. This avoids an
+  // intermediate render where the conversation exists but is empty (which
+  // would flash the empty state and force an extra 0→N list transition).
+  let messages = []
+  try {
+    // No cursor/direction → server returns the first page oldest-first
+    // (ascending), which is the order the panel renders top-to-bottom.
+    const res = await listMessages(id)
+    messages = res?.messages || []
+  } catch (e) {
+    console.error('chat: failed to resume session', e)
+    return
+  }
+
+  // Continue the session on the node it ran on, when that node is still
+  // available here and LLM-capable. Otherwise keep the current selection.
+  const sessionNode = nodes.value.find(
+    (n) => n.uuid === session.computeNodeId && n.enableLLMAccess
+  )
+  if (sessionNode) {
+    selectedNodeId.value = sessionNode.uuid
+    rememberComputeNode(props.orgId, sessionNode.uuid)
+  }
+
+  // Create-if-missing then hydrate, both synchronous so Vue batches them
+  // into a single update (existing messages → resumed messages) with no
+  // empty render in between. ensureConversation also guards the case where
+  // the user resumes before ever sending a message in this panel.
+  chatStore.ensureConversation({
+    mode: props.mode,
+    orgId: props.orgId,
+    datasetId: props.datasetId,
+    computeNodeId: selectedNodeId.value,
+  })
+  chatStore.hydrateConversation(key.value, { sessionId: id, messages })
+  disconnect({ mode: props.mode, orgId: props.orgId, datasetId: props.datasetId })
+}
+
 // Open the global Spotlight compose modal (the same one bound to
 // Cmd+K). Available from inside the chat panel too as a discoverable
 // trigger for users who don't reach for keyboard shortcuts. App.vue
@@ -476,7 +546,12 @@ watch(nodes, (list) => {
   cursor: pointer;
 
   &:hover { background: #f0f2f5; }
+  &.active { background: #f0f2f5; border-color: theme.$purple_3; }
 }
+
+// Anchor for the History popover. The ChatSessionMenu positions itself
+// absolutely against this wrapper so it drops below the History button.
+.history-wrap { position: relative; }
 
 // Quick-compose button is a tighter, icon-style trigger. The label
 // ("⌘K" / "Ctrl+K") doubles as both the affordance and the keyboard-

--- a/src/components/Chat/ChatSessionMenu.vue
+++ b/src/components/Chat/ChatSessionMenu.vue
@@ -1,0 +1,443 @@
+<template>
+  <!-- History dropdown: a compact popover listing recent chat sessions for
+       the active workspace. Self-loads its data from the chat-sessions REST
+       API on open; emits `resume` with a session id when a row is clicked.
+       Rename is inline; pin/delete act in place. Kept intentionally small so
+       it doesn't crowd the chat header. -->
+  <div v-if="visible" class="session-menu" ref="root">
+    <div class="menu-header">
+      <span class="menu-title">Chat history</span>
+      <button type="button" class="icon-btn" aria-label="Close" @click="close">×</button>
+    </div>
+
+    <div v-if="loading && !sessions.length" class="menu-state">Loading…</div>
+    <div v-else-if="error" class="menu-state error">
+      Couldn't load history.
+      <button type="button" class="link-btn" @click="reload">Retry</button>
+    </div>
+    <div v-else-if="!sessions.length" class="menu-state">No saved chats yet.</div>
+
+    <ul v-else class="session-list">
+      <li
+        v-for="s in sortedSessions"
+        :key="s.id"
+        class="session-row"
+        :class="{ pinned: s.pinned, active: s.id === activeId }"
+        @mouseleave="resetConfirm(s.id)"
+      >
+        <!-- Inline rename mode replaces the row's clickable label. -->
+        <template v-if="editingId === s.id">
+          <input
+            ref="editInput"
+            v-model="editTitle"
+            class="edit-input"
+            type="text"
+            :placeholder="placeholderFor(s)"
+            @keydown.enter.prevent="commitRename(s)"
+            @keydown.esc.prevent="cancelRename"
+            @blur="commitRename(s)"
+          />
+        </template>
+        <template v-else>
+          <button
+            type="button"
+            class="row-main"
+            :title="titleFor(s)"
+            @click="$emit('resume', s)"
+          >
+            <span v-if="s.pinned" class="pin-star" aria-hidden="true">★</span>
+            <span class="row-title">{{ titleFor(s) }}</span>
+            <span class="row-time">{{ relativeTime(s.lastActiveAt) }}</span>
+          </button>
+
+          <!-- Inline actions, revealed on row hover/focus. No nested popover
+               (which got clipped by the dropdown's overflow) — just three
+               icon buttons that sit in the row's trailing edge. -->
+          <div class="row-actions">
+            <button
+              type="button"
+              class="icon-btn"
+              :class="{ on: s.pinned }"
+              :title="s.pinned ? 'Unpin' : 'Pin'"
+              :aria-label="s.pinned ? `Unpin ${titleFor(s)}` : `Pin ${titleFor(s)}`"
+              @click.stop="togglePin(s)"
+            >
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M8 1l2.06 4.18 4.61.67-3.34 3.25.79 4.6L8 11.6 3.88 13.7l.79-4.6L1.33 5.85l4.61-.67z" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              class="icon-btn"
+              title="Rename"
+              :aria-label="`Rename ${titleFor(s)}`"
+              @click.stop="startRename(s)"
+            >
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M2 11.5V14h2.5l7.37-7.37-2.5-2.5L2 11.5zM13.7 4.2a.66.66 0 000-.94l-1.56-1.56a.66.66 0 00-.94 0l-1.22 1.22 2.5 2.5 1.22-1.22z" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              class="icon-btn danger"
+              :class="{ confirm: confirmingDeleteId === s.id }"
+              :title="confirmingDeleteId === s.id ? 'Click again to delete' : 'Delete'"
+              :aria-label="confirmingDeleteId === s.id ? `Confirm delete ${titleFor(s)}` : `Delete ${titleFor(s)}`"
+              @click.stop="onDelete(s)"
+            >
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M6 2V1h4v1h3v1.5H3V2h3zm-2.2 3h8.4l-.7 8.1a1 1 0 01-1 .9H5.5a1 1 0 01-1-.9L3.8 5z" />
+              </svg>
+            </button>
+          </div>
+        </template>
+      </li>
+    </ul>
+
+    <button
+      v-if="nextCursor && !loading"
+      type="button"
+      class="load-more"
+      @click="loadMore"
+    >Load older…</button>
+    <div v-else-if="loading && sessions.length" class="menu-state">Loading…</div>
+  </div>
+</template>
+
+<script setup>
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import { useChatSessions } from '@/composables/useChatSessions'
+
+const props = defineProps({
+  visible: { type: Boolean, default: false },
+  // The sessionId of the conversation currently loaded in the panel, so the
+  // matching row can be marked as active.
+  activeId: { type: String, default: null },
+})
+const emit = defineEmits(['update:visible', 'resume'])
+
+const { listSessions, renameSession, setPinned, deleteSession } = useChatSessions()
+
+const sessions = ref([])
+const nextCursor = ref(null)
+const loading = ref(false)
+const error = ref(false)
+
+const editingId = ref(null)
+const editTitle = ref('')
+const editInput = ref(null)
+const confirmingDeleteId = ref(null)
+const root = ref(null)
+
+// Pinned sessions float to the top; within each group most-recently-active
+// first. The server may already order this way, but we don't rely on it.
+const sortedSessions = computed(() =>
+  [...sessions.value].sort((a, b) => {
+    if (!!a.pinned !== !!b.pinned) return a.pinned ? -1 : 1
+    return new Date(b.lastActiveAt) - new Date(a.lastActiveAt)
+  })
+)
+
+const placeholderFor = (s) => s.lastMessagePreview || 'Untitled chat'
+const titleFor = (s) =>
+  (s.title && s.title.trim()) || s.lastMessagePreview || 'Untitled chat'
+
+const relativeTime = (iso) => {
+  if (!iso) return ''
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return ''
+  const secs = Math.round((Date.now() - then) / 1000)
+  if (secs < 60) return 'just now'
+  const mins = Math.round(secs / 60)
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.round(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.round(hours / 24)
+  if (days < 7) return `${days}d ago`
+  return new Date(iso).toLocaleDateString()
+}
+
+const load = async ({ append = false } = {}) => {
+  loading.value = true
+  error.value = false
+  try {
+    const res = await listSessions({ cursor: append ? nextCursor.value : undefined })
+    const incoming = res?.sessions || []
+    sessions.value = append ? [...sessions.value, ...incoming] : incoming
+    nextCursor.value = res?.nextCursor || null
+  } catch (e) {
+    console.error('chat: failed to load sessions', e)
+    error.value = true
+  } finally {
+    loading.value = false
+  }
+}
+
+const reload = () => load()
+const loadMore = () => load({ append: true })
+
+const close = () => emit('update:visible', false)
+
+// Disarm a pending delete-confirm when the pointer leaves the row, so an
+// armed trash icon doesn't linger after the user moves on.
+const resetConfirm = (id) => {
+  if (confirmingDeleteId.value === id) confirmingDeleteId.value = null
+}
+
+const startRename = async (s) => {
+  editingId.value = s.id
+  editTitle.value = (s.title && s.title.trim()) || ''
+  await nextTick()
+  const el = Array.isArray(editInput.value) ? editInput.value[0] : editInput.value
+  el?.focus()
+  el?.select()
+}
+
+const cancelRename = () => {
+  editingId.value = null
+  editTitle.value = ''
+}
+
+const commitRename = async (s) => {
+  if (editingId.value !== s.id) return
+  const next = editTitle.value.trim()
+  editingId.value = null
+  // No change (or cleared to match an already-empty title) — skip the call.
+  if (next === ((s.title && s.title.trim()) || '')) return
+  try {
+    const updated = await renameSession(s.id, next)
+    patchSession(s.id, updated || { ...s, title: next })
+  } catch (e) {
+    console.error('chat: rename failed', e)
+  }
+}
+
+const togglePin = async (s) => {
+  try {
+    const updated = await setPinned(s.id, !s.pinned)
+    patchSession(s.id, updated || { ...s, pinned: !s.pinned })
+  } catch (e) {
+    console.error('chat: pin toggle failed', e)
+  }
+}
+
+const onDelete = async (s) => {
+  // Two-step confirm in place: first click arms, second click deletes.
+  if (confirmingDeleteId.value !== s.id) {
+    confirmingDeleteId.value = s.id
+    return
+  }
+  confirmingDeleteId.value = null
+  try {
+    await deleteSession(s.id)
+    sessions.value = sessions.value.filter((x) => x.id !== s.id)
+  } catch (e) {
+    console.error('chat: delete failed', e)
+  }
+}
+
+const patchSession = (id, next) => {
+  const idx = sessions.value.findIndex((x) => x.id === id)
+  if (idx !== -1) sessions.value[idx] = { ...sessions.value[idx], ...next }
+}
+
+// Click outside the popover closes it. Inside clicks are left alone — the
+// delete-confirm is a two-step (arm → confirm), and this runs in the capture
+// phase ahead of the button handlers, so disarming here would cancel the
+// confirm before onDelete sees it. Disarming is handled by row mouseleave
+// and by arming a different row instead.
+const onDocClick = (e) => {
+  if (root.value && !root.value.contains(e.target)) {
+    emit('update:visible', false)
+  }
+}
+
+watch(
+  () => props.visible,
+  (open) => {
+    if (open) {
+      load()
+      document.addEventListener('click', onDocClick, true)
+    } else {
+      document.removeEventListener('click', onDocClick, true)
+      cancelRename()
+      confirmingDeleteId.value = null
+    }
+  }
+)
+
+onBeforeUnmount(() => document.removeEventListener('click', onDocClick, true))
+</script>
+
+<style scoped lang="scss">
+@use '../../styles/theme';
+
+.session-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 30;
+  width: 300px;
+  max-height: 380px;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  border: 1px solid #e0e2e5;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  overflow: hidden;
+}
+
+.menu-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid #eef0f2;
+}
+.menu-title { font-size: 12px; font-weight: 600; color: #1c1c1c; }
+
+.menu-state {
+  padding: 16px 12px;
+  font-size: 13px;
+  color: #888;
+  text-align: center;
+
+  &.error { color: #9b1c1c; }
+}
+
+.session-list {
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  overflow-y: auto;
+}
+
+.session-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 6px;
+  position: relative;
+
+  &:hover { background: #f5f6f8; }
+  &.pinned .row-title { font-weight: 500; }
+
+  // The session currently loaded in the panel — a left accent + tint so
+  // it reads as "you're here" without competing with hover.
+  &.active {
+    // Square off the corners — the left accent bar reads as a clipped
+    // sliver against the row's rounded corners otherwise.
+    border-radius: 0;
+    background: rgba(theme.$purple_3, 0.08);
+    box-shadow: inset 3px 0 0 theme.$purple_3;
+
+    .row-title { color: theme.$purple_3; font-weight: 500; }
+  }
+}
+
+.row-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  text-align: left;
+  padding: 8px;
+  cursor: pointer;
+  font: inherit;
+}
+
+.pin-star { color: theme.$purple_3; font-size: 11px; flex: none; }
+
+.row-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  color: #1c1c1c;
+}
+
+.row-time { flex: none; font-size: 11px; color: #9aa0a6; }
+
+// Trailing inline action cluster. Hidden until the row is hovered or has
+// keyboard focus inside, so resting rows stay clean. Sits in-flow at the
+// row's edge — no popover to clip or overlay neighbouring rows.
+.row-actions {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding-right: 4px;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.session-row:hover .row-actions,
+.session-row:focus-within .row-actions { opacity: 1; }
+
+// Keep an armed delete visible even if the pointer drifts off the icon
+// (still within the row), so the confirm affordance doesn't vanish.
+.row-actions:has(.danger.confirm) { opacity: 1; }
+
+// The close (×) button in the header is also an .icon-btn.
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: #888;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 4px;
+  border-radius: 4px;
+
+  svg { width: 14px; height: 14px; fill: currentColor; display: block; }
+
+  &:hover { background: #e8eaed; color: #1c1c1c; }
+  &.on { color: theme.$purple_3; }
+  &.danger:hover { background: #fde8e8; color: #9b1c1c; }
+  &.danger.confirm {
+    background: #9b1c1c;
+    color: #fff;
+  }
+}
+
+.edit-input {
+  flex: 1;
+  margin: 4px 8px;
+  padding: 6px 8px;
+  font: inherit;
+  font-size: 13px;
+  border: 1px solid theme.$purple_3;
+  border-radius: 4px;
+  outline: none;
+}
+
+.load-more {
+  background: none;
+  border: none;
+  border-top: 1px solid #eef0f2;
+  padding: 8px;
+  font-size: 12px;
+  color: theme.$purple_3;
+  cursor: pointer;
+
+  &:hover { background: #f5f6f8; }
+}
+
+.link-btn {
+  background: none;
+  border: none;
+  color: theme.$purple_3;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: underline;
+  padding: 0 0 0 4px;
+}
+</style>

--- a/src/composables/useChatSessions.js
+++ b/src/composables/useChatSessions.js
@@ -1,0 +1,94 @@
+// @/composables/useChatSessions.js
+//
+// Thin client for the compute-node-chat "chat-sessions" REST API
+// (api2.pennsieve.{net,io}/chat). Backs the chat panel's session-history
+// dropdown: list recent sessions, load a session's message history on
+// resume, and rename / pin / delete.
+//
+// Auth mirrors the other api2 callers (see useMetricsCounters): a Cognito
+// bearer token from useGetToken plus the workspace `organization_id` query
+// param the shared pennsieve-go-api authorizer requires on every request.
+//
+// All methods throw on a non-2xx response; callers surface the error in the
+// dropdown. This is intentionally NOT a Pinia store — it's stateless request
+// plumbing. Resumed history is written into the chat store via
+// hydrateConversation.
+
+import { useStore } from 'vuex'
+import { useGetToken } from '@/composables/useGetToken'
+import * as siteConfig from '@/site-config/site.json'
+
+export function useChatSessions() {
+  const store = useStore()
+
+  // Base URL + the two things every request needs: bearer token and the
+  // org identity source. Resolved per-call so a workspace switch is picked
+  // up without re-instantiating the composable.
+  const authParts = async () => {
+    const token = await useGetToken()
+    const orgId = store.state.activeOrganization?.organization?.id
+    // Prefer runtime config (vuex), fall back to the bundled site.json.
+    const base = store.state.config?.chatRestUrl || siteConfig.chatRestUrl
+    if (!base) throw new Error('chatRestUrl is not configured')
+    if (!orgId) throw new Error('No active organization')
+    return { token, orgId, base }
+  }
+
+  const request = async (path, { method = 'GET', query = {}, body } = {}) => {
+    const { token, orgId, base } = await authParts()
+    const params = new URLSearchParams({ organization_id: orgId, ...query })
+    const resp = await fetch(`${base}${path}?${params}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(body ? { 'Content-Type': 'application/json' } : {}),
+      },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    })
+    if (!resp.ok) {
+      throw new Error(`chat-sessions ${method} ${path} failed (${resp.status})`)
+    }
+    // 204 No Content (delete) has no body to parse.
+    if (resp.status === 204) return null
+    return resp.json()
+  }
+
+  // GET /chat-sessions?cursor=&limit= → { sessions, nextCursor }
+  const listSessions = ({ cursor, limit = 20 } = {}) =>
+    request('/chat-sessions', { query: { limit, ...(cursor ? { cursor } : {}) } })
+
+  // GET /chat-sessions/{id} → session
+  const getSession = (id) => request(`/chat-sessions/${id}`)
+
+  // GET /chat-sessions/{id}/messages?cursor=&limit=&direction=
+  //   → { messages, nextCursor }
+  const listMessages = (id, { cursor, limit = 50, direction } = {}) =>
+    request(`/chat-sessions/${id}/messages`, {
+      query: {
+        limit,
+        ...(cursor ? { cursor } : {}),
+        ...(direction ? { direction } : {}),
+      },
+    })
+
+  // PATCH /chat-sessions/{id} {title} → session
+  const renameSession = (id, title) =>
+    request(`/chat-sessions/${id}`, { method: 'PATCH', body: { title } })
+
+  // PATCH /chat-sessions/{id} {pinned} → session
+  const setPinned = (id, pinned) =>
+    request(`/chat-sessions/${id}`, { method: 'PATCH', body: { pinned } })
+
+  // DELETE /chat-sessions/{id} → 204
+  const deleteSession = (id) =>
+    request(`/chat-sessions/${id}`, { method: 'DELETE' })
+
+  return {
+    listSessions,
+    getSession,
+    listMessages,
+    renameSession,
+    setPinned,
+    deleteSession,
+  }
+}

--- a/src/site-config/dev.json
+++ b/src/site-config/dev.json
@@ -42,5 +42,6 @@
   "GitHubAppUrl": "https://github.com/apps/pennsieve-test/installations/new",
   "reCAPTCHASiteKey": "6Le2Wr0aAAAAAHouFUEmy7UwN6b9wa_PPRGrWxAG",
   "neuroglancerUrl": "https://orthogonal-viewer.pennsieve.net",
-  "chatWsUrl": "wss://szgl9urld5.execute-api.us-east-1.amazonaws.com/dev"
+  "chatWsUrl": "wss://szgl9urld5.execute-api.us-east-1.amazonaws.com/dev",
+  "chatRestUrl": "https://api2.pennsieve.net/chat"
 }

--- a/src/site-config/local.json
+++ b/src/site-config/local.json
@@ -43,5 +43,6 @@
   },
   "reCAPTCHASiteKey": "6Le2Wr0aAAAAAHouFUEmy7UwN6b9wa_PPRGrWxAG",
   "neuroglancerUrl": "https://orthogonal-viewer.pennsieve.net",
-  "chatWsUrl": "wss://szgl9urld5.execute-api.us-east-1.amazonaws.com/dev"
+  "chatWsUrl": "wss://szgl9urld5.execute-api.us-east-1.amazonaws.com/dev",
+  "chatRestUrl": "https://api2.pennsieve.net/chat"
 }

--- a/src/site-config/prod.json
+++ b/src/site-config/prod.json
@@ -41,6 +41,7 @@
   "GitHubAppUrl": "https://github.com/apps/pennsieve/installations/new",
   "reCAPTCHASiteKey": "6Le2Wr0aAAAAAHouFUEmy7UwN6b9wa_PPRGrWxAG",
   "neuroglancerUrl": "https://orthogonal-viewer.pennsieve.io",
-  "chatWsUrl": "wss://chat.pennsieve.io"
+  "chatWsUrl": "wss://chat.pennsieve.io",
+  "chatRestUrl": "https://api2.pennsieve.io/chat"
 
 }

--- a/src/store/viewerModule.js
+++ b/src/store/viewerModule.js
@@ -275,8 +275,6 @@ export const actions = {
   },
 
   /**
-<<<<<<< HEAD
-=======
    * Get source files for a package (the original uploaded files,
    * not processed viewer assets). Used by OmeViewer to get the
    * original .ome.tiff source file.
@@ -307,7 +305,6 @@ export const actions = {
   },
 
   /**
->>>>>>> main
    * Get viewer assets from the packages service (api2)
    * Returns { assets, cloudfront } with signed CloudFront policy
    */
@@ -331,8 +328,62 @@ export const actions = {
   },
 
   /**
-<<<<<<< HEAD
-=======
+   * Get a single viewer asset by its UUID from the packages service (api2).
+   * Returns { asset, cloudfront } with a signed CloudFront policy. Unlike
+   * fetchPackageViewerAssets (which lists a package's assets and is subject
+   * to the chat-scoped exclusion filter), this resolves by id directly — the
+   * only reliable way to reach a chat-scoped figure, which is omitted from
+   * the dataset/package listing. Returns null on any failure (caller degrades
+   * to a fallback link).
+   * @param {String} datasetId
+   * @param {String} assetId
+   */
+  fetchViewerAssetById: async ({rootState}, { datasetId, assetId }) => {
+    try {
+      const token = await useGetToken()
+      const url = `${rootState.config.api2Url}/packages/assets/${assetId}?dataset_id=${datasetId}`
+      const resp = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
+      if (resp.ok) {
+        return await resp.json()
+      }
+      return null
+    } catch (err) {
+      console.warn('Failed to fetch viewer asset by id:', err)
+      return null
+    }
+  },
+
+  /**
+   * Promote a chat-scoped viewer asset to a plain dataset asset by detaching
+   * its chat session (PATCH clear_chat_session). Metadata-only: the asset's
+   * bytes never move (dataset_id is unchanged), it simply starts appearing in
+   * the dataset's asset listing and is no longer reclaimed when the chat
+   * session is deleted. Idempotent — a no-op on an already-unscoped asset.
+   * @param {String} datasetId
+   * @param {String} assetId
+   */
+  promoteViewerAsset: async ({rootState}, { datasetId, assetId }) => {
+    const token = await useGetToken()
+    const url = `${rootState.config.api2Url}/packages/assets/${assetId}?dataset_id=${datasetId}`
+    const resp = await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ clear_chat_session: true }),
+    })
+    if (!resp.ok) {
+      throw new Error(`Failed to promote viewer asset: ${resp.status}`)
+    }
+    return await resp.json()
+  },
+
+  /**
    * Delete a viewer asset
    * @param {String} datasetId
    * @param {String} assetId
@@ -352,7 +403,6 @@ export const actions = {
   },
 
   /**
->>>>>>> main
    * Get presigned URL for a file
    * @param {String} packageId
    * @param {String} fileId

--- a/src/stores/chatStore.js
+++ b/src/stores/chatStore.js
@@ -77,6 +77,42 @@ export const useChatStore = defineStore('chat', () => {
     }))
   }
 
+  // Resume a persisted server-side session into the named conversation.
+  //
+  // Adopts the persisted `sessionId` and replaces the in-memory message
+  // list with the history fetched from the chat-sessions REST API. The
+  // existing socket is closed by the caller (useChatSocket.disconnect) so
+  // the next send reconnects on this sessionId, continuing that server
+  // session.
+  //
+  // `messages` are REST `ChatMessageRecord`s (oldest-first) and get mapped
+  // into the same shape handleIncomingFrame produces, so the panel renders
+  // resumed turns identically to live ones.
+  const hydrateConversation = (key, { sessionId, messages = [] }) => {
+    const convo = conversations.value.get(key)
+    if (!convo) return
+    if (sessionId) convo.sessionId = sessionId
+    convo.messages = (Array.isArray(messages) ? messages : []).map((m) => {
+      if (m.role === 'user') {
+        return { id: m.id, role: 'user', content: m.content || '' }
+      }
+      return {
+        id: m.id,
+        role: 'assistant',
+        content: m.content || '',
+        usage: m.usage || undefined,
+        referencedDatasets: Array.isArray(m.referencedDatasets)
+          ? m.referencedDatasets
+          : [],
+        blocks: Array.isArray(m.blocks) ? m.blocks : null,
+        pendingTasks: [],
+      }
+    })
+    convo.pending = false
+    convo.activeTools = []
+    convo.lastError = null
+  }
+
   // Append a user turn to the named conversation.
   //
   // `attachments` (optional) is the structured form of context the user
@@ -228,6 +264,7 @@ export const useChatStore = defineStore('chat', () => {
     getConversation,
     ensureConversation,
     resetConversation,
+    hydrateConversation,
     appendUserMessage,
     handleIncomingFrame,
     setConnectionState,


### PR DESCRIPTION
## Summary

Adds chat **session history** to the chat panel and a **download button** on inline figures (phase 2, step 5 of compute-node-chat session persistence).

### Session history dropdown
- New **History** button in the chat header opens a popover listing the user's recent server-side chat sessions (compute-node-chat `chat-sessions` REST API).
- **Resume** a session — loads its message history and reconnects the socket on the persisted `sessionId` so the next turn continues that server session, on the session's own compute node when still available.
- **Rename** inline, **pin/unpin** (persisted server-side, sorted to top), and **delete** (two-step confirm).
- Per-row actions are inline hover icons (no nested popover to clip), and the currently-loaded session is marked active.

### Inline figure download
- Hover/focus an inline chat figure to reveal a download button that saves the image to the browser's downloads folder. Cross-origin signed URL → fetch-as-blob + object URL, with a new-tab fallback if CORS blocks the fetch.

### Plumbing
- `useChatSessions` — stateless REST client (list / get / messages / rename / pin / delete).
- `chatStore.hydrateConversation` — adopt a persisted `sessionId` and replace messages.
- `ChatMessageList` — stable per-message keys + wrapped empty-state `v-if` to avoid a Vue patch crash on the empty→populated transition.
- `site-config` — add `chatRestUrl` for dev/local/prod.

## Dependencies
- Requires infrastructure change setting `api_domain_name` so `api2.pennsieve.{net,io}/chat` resolves (custom-domain mapping), and the compute-node-chat NULL-JSONB scan fix for message resume.

## Test plan
- [ ] Open the History dropdown; recent sessions list, pinned sorted to top.
- [ ] Resume a session (from both a fresh panel and an active conversation) — messages render, no console errors.
- [ ] Rename inline; pin/unpin persists across reload; delete with confirm.
- [ ] Active row is highlighted when reopening history.
- [ ] Hover an inline figure and download it to the downloads folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
