### PR TITLE
chat: resolve inline figures by asset id + promote/remove actions

### DIFF
--- a/src/components/Chat/ChatImageBlock.vue
+++ b/src/components/Chat/ChatImageBlock.vue
@@ -381,6 +381,8 @@ onMounted(async () => {
 </script>
 
 <style scoped lang="scss">
+@use '../../styles/theme';
+
 .chat-image-block {
   margin: 4px 0;
 }
@@ -392,11 +394,11 @@ onMounted(async () => {
   width: 100%;
   max-width: 480px;
   aspect-ratio: 4 / 3;
-  background: #e8eaed;
+  background: theme.$gray_2;
   border-radius: 8px;
 
   .loading-text {
-    color: #6b6b6b;
+    color: theme.$gray_5;
     font-size: 13px;
   }
 }
@@ -405,9 +407,9 @@ onMounted(async () => {
   display: inline-flex;
   align-items: center;
   padding: 10px 14px;
-  border: 1px dashed #d0d3d8;
+  border: 1px dashed theme.$gray_3;
   border-radius: 8px;
-  color: #6b6b6b;
+  color: theme.$gray_5;
   font-size: 13px;
   font-style: italic;
 }
@@ -439,17 +441,17 @@ onMounted(async () => {
   padding: 0;
   border: none;
   border-radius: 6px;
-  background: rgba(28, 28, 28, 0.6);
-  color: #fff;
+  background: rgba(theme.$black, 0.6);
+  color: theme.$white;
   cursor: pointer;
   transition: background 0.12s ease;
 
   svg { width: 16px; height: 16px; display: block; }
 
-  &:hover { background: rgba(28, 28, 28, 0.8); }
+  &:hover { background: rgba(theme.$black, 0.8); }
   &:disabled { cursor: default; opacity: 0.5; }
 
-  &--danger:hover { background: rgba(197, 48, 48, 0.9); }
+  &--danger:hover { background: rgba(theme.$red_1, 0.9); }
 }
 
 .figure-wrap:hover .actions,
@@ -464,12 +466,12 @@ onMounted(async () => {
   gap: 6px;
   padding: 8px 10px;
   border-radius: 8px;
-  background: rgba(28, 28, 28, 0.85);
+  background: rgba(theme.$black, 0.85);
   line-height: normal;
 }
 
 .confirm-text {
-  color: #fff;
+  color: theme.$white;
   font-size: 12px;
 }
 
@@ -482,19 +484,19 @@ onMounted(async () => {
   padding: 3px 10px;
   border: none;
   border-radius: 5px;
-  background: #e8eaed;
-  color: #1c1c1c;
+  background: theme.$gray_2;
+  color: theme.$gray_6;
   font-size: 12px;
   cursor: pointer;
 
-  &:hover { background: #fff; }
+  &:hover { background: theme.$white; }
   &:disabled { cursor: default; opacity: 0.6; }
 
   &--danger {
-    background: #c53030;
-    color: #fff;
+    background: theme.$red_1;
+    color: theme.$white;
 
-    &:hover { background: #b02525; }
+    &:hover { background: theme.$red_2; }
   }
 }
 
@@ -504,16 +506,16 @@ onMounted(async () => {
   width: 100%;
   height: auto;
   border-radius: 8px;
-  border: 1px solid #e0e2e6;
+  border: 1px solid theme.$gray_2;
 }
 
 .status-note {
   margin: 4px 0 0;
   font-size: 12px;
-  color: #6b6b6b;
+  color: theme.$gray_5;
   line-height: normal;
 
-  &--error { color: #c53030; }
+  &--error { color: theme.$red_2; }
 }
 
 // Source-package link beneath the figure. line-height reset because the
@@ -524,7 +526,7 @@ onMounted(async () => {
 }
 
 .source-link {
-  color: #5039f5;
+  color: theme.$purple_3;
   font-size: 12px;
   text-decoration: none;
 
@@ -533,7 +535,7 @@ onMounted(async () => {
 
 .fallback-link {
   display: inline-block;
-  color: #5039f5;
+  color: theme.$purple_3;
   font-size: 13px;
   text-decoration: underline;
 }

--- a/src/components/Chat/ChatImageBlock.vue
+++ b/src/components/Chat/ChatImageBlock.vue
@@ -4,6 +4,12 @@
       <span class="loading-text">Loading figure…</span>
     </div>
 
+    <!-- Terminal state after the user removes the figure. The viewer-asset
+         (and its S3 bytes) are gone; we don't try to re-resolve. -->
+    <div v-else-if="removed" class="figure-removed">
+      <span>Figure removed.</span>
+    </div>
+
     <div v-else-if="resolvedUrl" class="figure-wrap">
       <a
         :href="packageHref"
@@ -20,21 +26,84 @@
           @error="onImgError"
         />
       </a>
-      <!-- Download to the browser's downloads folder. Revealed on hover so
-           it doesn't clutter the figure at rest. -->
-      <button
-        type="button"
-        class="download-btn"
-        :title="`Download ${downloadName}`"
-        :aria-label="`Download ${downloadName}`"
-        :disabled="downloading"
-        @click="downloadImage"
-      >
-        <svg viewBox="0 0 16 16" aria-hidden="true">
-          <path d="M8 1.5v7.4m0 0L4.8 5.7M8 8.9l3.2-3.2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
-          <path d="M2.5 11v2a1 1 0 001 1h9a1 1 0 001-1v-2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
-        </svg>
-      </button>
+
+      <!-- Hover-revealed actions. Sits top-right so it doesn't clutter the
+           figure at rest. -->
+      <div v-if="!confirmingRemove" class="actions">
+        <button
+          type="button"
+          class="action-btn"
+          :title="`Download ${downloadName}`"
+          :aria-label="`Download ${downloadName}`"
+          :disabled="downloading"
+          @click="downloadImage"
+        >
+          <svg viewBox="0 0 16 16" aria-hidden="true">
+            <path d="M8 1.5v7.4m0 0L4.8 5.7M8 8.9l3.2-3.2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M2.5 11v2a1 1 0 001 1h9a1 1 0 001-1v-2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </button>
+
+        <!-- Promote: detach from the chat session so the figure becomes a
+             normal dataset asset. Only offered when we resolved by asset id
+             (we have something to act on) and it hasn't been promoted yet. -->
+        <button
+          v-if="assetId && !promoted"
+          type="button"
+          class="action-btn"
+          title="Save to dataset assets"
+          aria-label="Save figure to dataset assets"
+          :disabled="busy"
+          @click="promote"
+        >
+          <svg viewBox="0 0 16 16" aria-hidden="true">
+            <path d="M3.5 2.5h6.8L13 5.2V13a.5.5 0 01-.5.5h-9A.5.5 0 013 13V3a.5.5 0 01.5-.5z" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" />
+            <path d="M5.5 2.5v3h4v-3M5.5 13.5v-4h5v4" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" />
+          </svg>
+        </button>
+
+        <!-- Remove: delete just this viewer-asset by id. Never touches the
+             underlying package or dataset. Two-step (click → confirm). -->
+        <button
+          v-if="assetId"
+          type="button"
+          class="action-btn action-btn--danger"
+          title="Remove figure"
+          aria-label="Remove figure"
+          :disabled="busy"
+          @click="confirmingRemove = true"
+        >
+          <svg viewBox="0 0 16 16" aria-hidden="true">
+            <path d="M3 4.5h10M6.2 4.5V3.2a.7.7 0 01.7-.7h2.2a.7.7 0 01.7.7v1.3M4.3 4.5l.6 8a.8.8 0 00.8.7h4.6a.8.8 0 00.8-.7l.6-8" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Inline confirm overlay for the destructive remove. -->
+      <div v-else class="confirm-overlay">
+        <span class="confirm-text">Remove this figure?</span>
+        <div class="confirm-buttons">
+          <button
+            type="button"
+            class="confirm-btn confirm-btn--danger"
+            :disabled="busy"
+            @click="removeFigure"
+          >
+            {{ busy ? 'Removing…' : 'Remove' }}
+          </button>
+          <button
+            type="button"
+            class="confirm-btn"
+            :disabled="busy"
+            @click="confirmingRemove = false"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+
+      <p v-if="promoted" class="status-note">Saved to dataset assets.</p>
+      <p v-if="actionError" class="status-note status-note--error">{{ actionError }}</p>
     </div>
 
     <a
@@ -51,37 +120,42 @@
 
 <script setup>
 // ChatImageBlock — renders one inline figure produced by an MCP-triggered
-// workflow (currently just plot_file). The frame carries no URL —
-// (packageNodeId, datasetNodeId, assetName, assetType) coordinates only.
-// This component resolves to a signed CloudFront URL by:
+// workflow (currently just plot_file). The frame carries no URL — only
+// viewer-asset coordinates on `source`.
 //
-//   1. Calling the existing `fetchPackageViewerAssets` Vuex action against
-//      packages-service `/packages/assets?dataset_id=…&package_id=…`.
-//      Same call the package viewer uses for ome-zarr / neuroglancer
-//      rendering — see ViewerPane.vue.
-//   2. Picking the asset matching {name, asset_type}. When `assetName` is
-//      empty, pick the most recently created asset of the requested type.
-//   3. Building a query-string-signed URL:
-//      `${asset.asset_url}figure.png?Policy=…&Signature=…&Key-Pair-Id=…`.
-//      Query-string signing (vs. relying on the Set-Cookie machinery the
-//      assets endpoint emits) works regardless of cross-domain cookie
-//      attribute issues.
+// Resolution, in priority order:
+//
+//   1. By asset id (preferred). When the producing workflow reported the
+//      viewer-asset UUID back as a run output, the frame carries
+//      `source.assetId`. We resolve it directly via packages-service
+//      `GET /packages/assets/{id}?dataset_id=…`, which returns the asset +
+//      a signed CloudFront policy. This is the ONLY reliable path for
+//      chat-scoped figures: those are excluded from the package/dataset
+//      asset listing, so the list-and-match path (below) can't see them.
+//
+//   2. By coordinates (fallback). For older frames without `assetId`, list
+//      the package's assets via `fetchPackageViewerAssets` and match on
+//      {name, asset_type}, newest first. Works for plain (non-chat-scoped)
+//      figures only.
+//
+// Either way we build a query-string-signed URL:
+//   `${asset.asset_url}${fileName}?Policy=…&Signature=…&Key-Pair-Id=…`
+// (fileName defaults to the figure-asset convention `figure.png`).
+//
+// Actions (when resolved by id): download, promote (detach from the chat
+// session → becomes a plain dataset asset), and remove (delete just this
+// viewer-asset by id — never the package or dataset).
 //
 // On any error — API failure, no matching asset, image-load failure — the
-// component falls back to a plain text-link pointing at the package
-// viewer. Same UX older clients get from the plain-text `content` field.
-//
-// Filename convention: the `figure-asset` data-target writes `figure.png`
-// at the asset's S3 prefix root. If a future workflow ships a different
-// filename, the assets API would need to surface it; tracked as an open
-// question in compute-node-chat/docs/developer/inline-image-frames.md.
+// component falls back to a plain text-link pointing at the package viewer.
 
 import { computed, onMounted, ref } from 'vue'
 import { useStore } from 'vuex'
 
 const props = defineProps({
-  // The image block from AssistantMessage.blocks[]. Required fields on
-  // `source`: packageNodeId, datasetNodeId. Optional: assetName, assetType.
+  // The image block from AssistantMessage.blocks[]. Required on `source`:
+  // datasetNodeId, plus EITHER assetId OR packageNodeId. Optional: assetName,
+  // assetType, fileName.
   block: { type: Object, required: true },
 })
 
@@ -91,8 +165,18 @@ const loading = ref(true)
 const resolvedUrl = ref('')
 const downloading = ref(false)
 
+// Action state.
+const busy = ref(false)
+const confirmingRemove = ref(false)
+const removed = ref(false)
+const promoted = ref(false)
+const actionError = ref('')
+
 const alt = computed(() => props.block.alt || 'Inline figure')
 const source = computed(() => props.block.source || {})
+const assetId = computed(() => source.value.assetId || '')
+const datasetNodeId = computed(() => source.value.datasetNodeId || '')
+const fileName = computed(() => source.value.fileName || 'figure.png')
 
 // Filename for the downloaded file. Prefer the asset's own name; fall back
 // to the figure-asset convention (figure.png). Ensure a .png extension so
@@ -132,21 +216,61 @@ const downloadImage = async () => {
   }
 }
 
+// Promote: detach the chat session so the figure shows in the dataset's
+// asset listing. Metadata-only — the bytes don't move.
+const promote = async () => {
+  if (!assetId.value || !datasetNodeId.value || busy.value) return
+  busy.value = true
+  actionError.value = ''
+  try {
+    await store.dispatch('viewerModule/promoteViewerAsset', {
+      datasetId: datasetNodeId.value,
+      assetId: assetId.value,
+    })
+    promoted.value = true
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('[chat] ChatImageBlock: promote failed', err)
+    actionError.value = 'Could not save to dataset assets.'
+  } finally {
+    busy.value = false
+  }
+}
+
+// Remove: delete just this viewer-asset by id. The package and dataset are
+// untouched. After success we show the removed state instead of re-resolving.
+const removeFigure = async () => {
+  if (!assetId.value || !datasetNodeId.value || busy.value) return
+  busy.value = true
+  actionError.value = ''
+  try {
+    await store.dispatch('viewerModule/deleteViewerAsset', {
+      datasetId: datasetNodeId.value,
+      assetId: assetId.value,
+    })
+    removed.value = true
+    confirmingRemove.value = false
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('[chat] ChatImageBlock: remove failed', err)
+    actionError.value = 'Could not remove the figure.'
+    confirmingRemove.value = false
+  } finally {
+    busy.value = false
+  }
+}
+
 // Open-in-viewer fallback link. Matches the `file-record` route registered
 // in router/index.js (`:orgId/datasets/:datasetId/files/:fileId/details`).
-// Two pieces routinely missed when this was first built:
-//   - the org slug at the start (a /datasets/... URL with no org 404s)
-//   - the /details suffix (the route is FileDetails, not the dataset-files
-//     index)
 // Read the org from Vuex's activeOrganization rather than a route param —
-// the chat panel can be hosted in widgets (e.g. Spotlight) where the
-// current route isn't org-scoped, but activeOrganization is set globally.
+// the chat panel can be hosted in widgets (e.g. Spotlight) where the current
+// route isn't org-scoped, but activeOrganization is set globally.
 const packageHref = computed(() => {
-  const { packageNodeId, datasetNodeId } = source.value
-  if (!packageNodeId || !datasetNodeId) return '#'
+  const { packageNodeId, datasetNodeId: ds } = source.value
+  if (!packageNodeId || !ds) return '#'
   const orgId = store.state?.activeOrganization?.organization?.id
   if (!orgId) return '#'
-  return `/${orgId}/datasets/${datasetNodeId}/files/${packageNodeId}/details`
+  return `/${orgId}/datasets/${ds}/files/${packageNodeId}/details`
 })
 
 const onImgError = () => {
@@ -156,59 +280,75 @@ const onImgError = () => {
   resolvedUrl.value = ''
 }
 
-onMounted(async () => {
-  const { packageNodeId, datasetNodeId, assetName, assetType } = source.value
+// Build a query-string-signed image URL from an { asset, cloudfront }
+// response. Returns true on success.
+const buildSignedUrl = (result) => {
+  const asset = result?.asset
+  if (!asset?.asset_url) return false
+  const cf = result.cloudfront
+  if (!cf?.policy || !cf?.signature || !cf?.key_pair_id) return false
+  const qs = new URLSearchParams({
+    Policy: cf.policy,
+    Signature: cf.signature,
+    'Key-Pair-Id': cf.key_pair_id,
+  })
+  resolvedUrl.value = `${asset.asset_url}${fileName.value}?${qs.toString()}`
+  return true
+}
 
-  if (!packageNodeId || !datasetNodeId) {
+// Preferred path: resolve directly by asset id. Works for chat-scoped
+// figures, which the listing endpoint deliberately excludes.
+const resolveByAssetId = async () => {
+  const result = await store.dispatch('viewerModule/fetchViewerAssetById', {
+    datasetId: datasetNodeId.value,
+    assetId: assetId.value,
+  })
+  return buildSignedUrl(result)
+}
+
+// Fallback path: list the package's assets and match on {name, asset_type},
+// newest first. Only finds plain (non-chat-scoped) figures.
+const resolveByListing = async () => {
+  const { packageNodeId, assetName, assetType } = source.value
+  if (!packageNodeId) return false
+
+  const result = await store.dispatch('viewerModule/fetchPackageViewerAssets', {
+    datasetId: datasetNodeId.value,
+    packageId: packageNodeId,
+  })
+  if (!result?.assets?.length) return false
+
+  const typeFilter = assetType || 'PNG'
+  const candidates = result.assets
+    .filter((a) => a.status === 'ready')
+    .filter((a) => a.asset_type === typeFilter)
+    .filter((a) => !assetName || a.name === assetName)
+    .sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''))
+
+  const asset = candidates[0]
+  if (!asset) return false
+  return buildSignedUrl({ asset, cloudfront: result.cloudfront })
+}
+
+onMounted(async () => {
+  // datasetNodeId is required for both paths.
+  if (!datasetNodeId.value) {
+    loading.value = false
+    return
+  }
+  // Need at least one resolution key.
+  if (!assetId.value && !source.value.packageNodeId) {
     loading.value = false
     return
   }
 
   try {
-    const result = await store.dispatch('viewerModule/fetchPackageViewerAssets', {
-      datasetId: datasetNodeId,
-      packageId: packageNodeId,
-    })
-
-    if (!result?.assets?.length) {
-      loading.value = false
-      return
+    if (assetId.value) {
+      if (await resolveByAssetId()) return
     }
-
-    // Pick the right asset. Match on name + asset_type when both are
-    // specified; fall back to asset_type only if name is empty; fall back
-    // to "any ready asset" as a last resort. Sort by created_at desc so
-    // the most recent run wins when a user plotted the same package
-    // multiple times.
-    const typeFilter = assetType || 'PNG'
-    const candidates = result.assets
-      .filter((a) => a.status === 'ready')
-      .filter((a) => a.asset_type === typeFilter)
-      .filter((a) => !assetName || a.name === assetName)
-      .sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''))
-
-    const asset = candidates[0]
-    if (!asset || !asset.asset_url) {
-      loading.value = false
-      return
-    }
-
-    // Build the signed image URL. asset.asset_url ends with the asset's
-    // S3-prefix slash; the figure-asset data-target writes `figure.png`
-    // there. Sign with CloudFront query-string params from the API
-    // response.
-    const cf = result.cloudfront
-    if (!cf?.policy || !cf?.signature || !cf?.key_pair_id) {
-      // Asset exists but signing failed server-side — fall back.
-      loading.value = false
-      return
-    }
-    const qs = new URLSearchParams({
-      Policy: cf.policy,
-      Signature: cf.signature,
-      'Key-Pair-Id': cf.key_pair_id,
-    })
-    resolvedUrl.value = `${asset.asset_url}figure.png?${qs.toString()}`
+    // Fall back to the coordinate listing path (older frames / no assetId,
+    // or an asset-id lookup that returned nothing).
+    await resolveByListing()
   } catch (err) {
     // Permission denied / network / shape change — log and degrade.
     // eslint-disable-next-line no-console
@@ -240,8 +380,19 @@ onMounted(async () => {
   }
 }
 
-// Positioning context for the hover download button, sized to the image
-// (inline-block) so the button hugs the figure's top-right, not the bubble.
+.figure-removed {
+  display: inline-flex;
+  align-items: center;
+  padding: 10px 14px;
+  border: 1px dashed #d0d3d8;
+  border-radius: 8px;
+  color: #6b6b6b;
+  font-size: 13px;
+  font-style: italic;
+}
+
+// Positioning context for the hover actions, sized to the image
+// (inline-block) so the buttons hug the figure's top-right, not the bubble.
 .figure-wrap {
   position: relative;
   display: inline-block;
@@ -253,10 +404,17 @@ onMounted(async () => {
   line-height: 0; // collapse the anchor's text-baseline gap below the img
 }
 
-.download-btn {
+.actions {
   position: absolute;
   top: 8px;
   right: 8px;
+  display: inline-flex;
+  gap: 6px;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.action-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -268,17 +426,61 @@ onMounted(async () => {
   background: rgba(28, 28, 28, 0.6);
   color: #fff;
   cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.12s ease, background 0.12s ease;
+  transition: background 0.12s ease;
 
   svg { width: 16px; height: 16px; display: block; }
 
   &:hover { background: rgba(28, 28, 28, 0.8); }
   &:disabled { cursor: default; opacity: 0.5; }
+
+  &--danger:hover { background: rgba(197, 48, 48, 0.9); }
 }
 
-.figure-wrap:hover .download-btn,
-.download-btn:focus-visible { opacity: 1; }
+.figure-wrap:hover .actions,
+.actions:focus-within { opacity: 1; }
+
+.confirm-overlay {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: rgba(28, 28, 28, 0.85);
+  line-height: normal;
+}
+
+.confirm-text {
+  color: #fff;
+  font-size: 12px;
+}
+
+.confirm-buttons {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.confirm-btn {
+  padding: 3px 10px;
+  border: none;
+  border-radius: 5px;
+  background: #e8eaed;
+  color: #1c1c1c;
+  font-size: 12px;
+  cursor: pointer;
+
+  &:hover { background: #fff; }
+  &:disabled { cursor: default; opacity: 0.6; }
+
+  &--danger {
+    background: #c53030;
+    color: #fff;
+
+    &:hover { background: #b02525; }
+  }
+}
 
 .figure {
   display: block;
@@ -287,6 +489,15 @@ onMounted(async () => {
   height: auto;
   border-radius: 8px;
   border: 1px solid #e0e2e6;
+}
+
+.status-note {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: #6b6b6b;
+  line-height: normal;
+
+  &--error { color: #c53030; }
 }
 
 .fallback-link {

--- a/src/components/Chat/ChatImageBlock.vue
+++ b/src/components/Chat/ChatImageBlock.vue
@@ -45,14 +45,16 @@
         </button>
 
         <!-- Promote: detach from the chat session so the figure becomes a
-             normal dataset asset. Only offered when we resolved by asset id
-             (we have something to act on) and it hasn't been promoted yet. -->
+             normal asset. It lands wherever its package link points: a
+             package-scoped asset when the figure came from a package
+             (plot_file always does), else a plain dataset asset. Only offered
+             when we resolved by asset id and it hasn't been promoted yet. -->
         <button
           v-if="assetId && !promoted"
           type="button"
           class="action-btn"
-          title="Save to dataset assets"
-          aria-label="Save figure to dataset assets"
+          :title="promoteTitle"
+          :aria-label="promoteTitle"
           :disabled="busy"
           @click="promote"
         >
@@ -102,7 +104,7 @@
         </div>
       </div>
 
-      <p v-if="promoted" class="status-note">Saved to dataset assets.</p>
+      <p v-if="promoted" class="status-note">{{ promotedNote }}</p>
       <p v-if="actionError" class="status-note status-note--error">{{ actionError }}</p>
     </div>
 
@@ -177,6 +179,18 @@ const source = computed(() => props.block.source || {})
 const assetId = computed(() => source.value.assetId || '')
 const datasetNodeId = computed(() => source.value.datasetNodeId || '')
 const fileName = computed(() => source.value.fileName || 'figure.png')
+
+// A chat figure carries its package link through promote (clear_chat_session
+// only nulls the chat scope), so it lands as a package-scoped asset whenever
+// it came from a package — which plot_file figures always do. Word the promote
+// affordance to match where the figure actually ends up.
+const hasPackage = computed(() => !!source.value.packageNodeId)
+const promoteTitle = computed(() =>
+  hasPackage.value ? 'Save to package' : 'Save to dataset assets'
+)
+const promotedNote = computed(() =>
+  hasPackage.value ? 'Saved to package.' : 'Saved to dataset assets.'
+)
 
 // Filename for the downloaded file. Prefer the asset's own name; fall back
 // to the figure-asset convention (figure.png). Ensure a .png extension so

--- a/src/components/Chat/ChatImageBlock.vue
+++ b/src/components/Chat/ChatImageBlock.vue
@@ -11,21 +11,17 @@
     </div>
 
     <div v-else-if="resolvedUrl" class="figure-wrap">
-      <a
-        :href="packageHref"
-        target="_blank"
-        rel="noopener"
-        class="image-link"
-        :aria-label="alt + ' — open package'"
-      >
-        <img
-          :src="resolvedUrl"
-          :alt="alt"
-          loading="lazy"
-          class="figure"
-          @error="onImgError"
-        />
-      </a>
+      <!-- The figure renders inline here. We don't link the image to the
+           package: the figure is chat-scoped until promoted, so it isn't
+           viewable in the package viewer yet. The source-package router-link
+           below points at where the data came from. -->
+      <img
+        :src="resolvedUrl"
+        :alt="alt"
+        loading="lazy"
+        class="figure"
+        @error="onImgError"
+      />
 
       <!-- Hover-revealed actions. Sits top-right so it doesn't clutter the
            figure at rest. -->
@@ -106,17 +102,24 @@
 
       <p v-if="promoted" class="status-note">{{ promotedNote }}</p>
       <p v-if="actionError" class="status-note status-note--error">{{ actionError }}</p>
+
+      <!-- Link to the source package (where the plotted data lives) as an
+           in-app router navigation. Not "where the figure is" — the figure
+           shows inline above and isn't in the package until promoted. -->
+      <p v-if="packageRoute" class="source-note">
+        <router-link :to="packageRoute" class="source-link">Open source package →</router-link>
+      </p>
     </div>
 
-    <a
-      v-else
-      :href="packageHref"
-      target="_blank"
-      rel="noopener"
+    <!-- Figure couldn't be resolved/rendered. Fall back to a router-link to
+         the source package so the user can still get there. -->
+    <router-link
+      v-else-if="packageRoute"
+      :to="packageRoute"
       class="fallback-link"
     >
-      View plot in package →
-    </a>
+      Open source package →
+    </router-link>
   </div>
 </template>
 
@@ -274,17 +277,21 @@ const removeFigure = async () => {
   }
 }
 
-// Open-in-viewer fallback link. Matches the `file-record` route registered
-// in router/index.js (`:orgId/datasets/:datasetId/files/:fileId/details`).
-// Read the org from Vuex's activeOrganization rather than a route param —
-// the chat panel can be hosted in widgets (e.g. Spotlight) where the current
-// route isn't org-scoped, but activeOrganization is set globally.
-const packageHref = computed(() => {
+// vue-router target for the source package (the `file-record` route, same one
+// ChatMessage's attachment chips use). Returns null when we can't build it —
+// the template degrades by hiding the link rather than rendering a dead one.
+// Read the org from Vuex's activeOrganization rather than a route param: the
+// chat panel can be hosted in widgets (e.g. Spotlight) where the current route
+// isn't org-scoped, but activeOrganization is set globally.
+const packageRoute = computed(() => {
   const { packageNodeId, datasetNodeId: ds } = source.value
-  if (!packageNodeId || !ds) return '#'
+  if (!packageNodeId || !ds) return null
   const orgId = store.state?.activeOrganization?.organization?.id
-  if (!orgId) return '#'
-  return `/${orgId}/datasets/${ds}/files/${packageNodeId}/details`
+  if (!orgId) return null
+  return {
+    name: 'file-record',
+    params: { orgId, datasetId: ds, fileId: packageNodeId },
+  }
 })
 
 const onImgError = () => {
@@ -413,11 +420,6 @@ onMounted(async () => {
   line-height: 0;
 }
 
-.image-link {
-  display: inline-block;
-  line-height: 0; // collapse the anchor's text-baseline gap below the img
-}
-
 .actions {
   position: absolute;
   top: 8px;
@@ -512,6 +514,21 @@ onMounted(async () => {
   line-height: normal;
 
   &--error { color: #c53030; }
+}
+
+// Source-package link beneath the figure. line-height reset because the
+// .figure-wrap container collapses it to 0 to hug the image.
+.source-note {
+  margin: 4px 0 0;
+  line-height: normal;
+}
+
+.source-link {
+  color: #5039f5;
+  font-size: 12px;
+  text-decoration: none;
+
+  &:hover { text-decoration: underline; }
 }
 
 .fallback-link {

--- a/src/components/Chat/ChatImageBlock.vue
+++ b/src/components/Chat/ChatImageBlock.vue
@@ -177,6 +177,11 @@ const removed = ref(false)
 const promoted = ref(false)
 const actionError = ref('')
 
+// Resolved-asset state, populated from the by-id lookup. `resolvedPackageIds`
+// is null until we've resolved (so hasPackage can fall back to the frame's
+// packageNodeId for the listing path / older frames).
+const resolvedPackageIds = ref(null)
+
 const alt = computed(() => props.block.alt || 'Inline figure')
 const source = computed(() => props.block.source || {})
 const assetId = computed(() => source.value.assetId || '')
@@ -186,13 +191,21 @@ const fileName = computed(() => source.value.fileName || 'figure.png')
 // A chat figure carries its package link through promote (clear_chat_session
 // only nulls the chat scope), so it lands as a package-scoped asset whenever
 // it came from a package — which plot_file figures always do. Word the promote
-// affordance to match where the figure actually ends up.
-const hasPackage = computed(() => !!source.value.packageNodeId)
+// affordance to match where the figure actually ends up. Prefer the resolved
+// asset's real package links; fall back to the frame's packageNodeId before
+// resolution completes (and for the listing path, where we don't fetch by id).
+const hasPackage = computed(() => {
+  if (resolvedPackageIds.value !== null) return resolvedPackageIds.value.length > 0
+  return !!source.value.packageNodeId
+})
 const promoteTitle = computed(() =>
   hasPackage.value ? 'Save to package' : 'Save to dataset assets'
 )
 const promotedNote = computed(() =>
   hasPackage.value ? 'Saved to package.' : 'Saved to dataset assets.'
+)
+const promoteFailNote = computed(() =>
+  hasPackage.value ? 'Could not save to package.' : 'Could not save to dataset assets.'
 )
 
 // Filename for the downloaded file. Prefer the asset's own name; fall back
@@ -248,7 +261,7 @@ const promote = async () => {
   } catch (err) {
     // eslint-disable-next-line no-console
     console.warn('[chat] ChatImageBlock: promote failed', err)
-    actionError.value = 'Could not save to dataset assets.'
+    actionError.value = promoteFailNote.value
   } finally {
     busy.value = false
   }
@@ -308,6 +321,14 @@ const buildSignedUrl = (result) => {
   if (!asset?.asset_url) return false
   const cf = result.cloudfront
   if (!cf?.policy || !cf?.signature || !cf?.key_pair_id) return false
+
+  // Capture the asset's real state so the actions reflect it: package links
+  // decide the promote wording/target, and the presence of chat_session_id
+  // tells us whether it's still a chat figure (offer promote) or already
+  // promoted (don't — re-promoting would 404 once the chat link is gone).
+  resolvedPackageIds.value = Array.isArray(asset.package_ids) ? asset.package_ids : []
+  if (!asset.chat_session_id) promoted.value = true
+
   const qs = new URLSearchParams({
     Policy: cf.policy,
     Signature: cf.signature,

--- a/src/store/viewerModule.js
+++ b/src/store/viewerModule.js
@@ -275,8 +275,6 @@ export const actions = {
   },
 
   /**
-<<<<<<< HEAD
-=======
    * Get source files for a package (the original uploaded files,
    * not processed viewer assets). Used by OmeViewer to get the
    * original .ome.tiff source file.
@@ -307,7 +305,6 @@ export const actions = {
   },
 
   /**
->>>>>>> main
    * Get viewer assets from the packages service (api2)
    * Returns { assets, cloudfront } with signed CloudFront policy
    */
@@ -331,8 +328,62 @@ export const actions = {
   },
 
   /**
-<<<<<<< HEAD
-=======
+   * Get a single viewer asset by its UUID from the packages service (api2).
+   * Returns { asset, cloudfront } with a signed CloudFront policy. Unlike
+   * fetchPackageViewerAssets (which lists a package's assets and is subject
+   * to the chat-scoped exclusion filter), this resolves by id directly — the
+   * only reliable way to reach a chat-scoped figure, which is omitted from
+   * the dataset/package listing. Returns null on any failure (caller degrades
+   * to a fallback link).
+   * @param {String} datasetId
+   * @param {String} assetId
+   */
+  fetchViewerAssetById: async ({rootState}, { datasetId, assetId }) => {
+    try {
+      const token = await useGetToken()
+      const url = `${rootState.config.api2Url}/packages/assets/${assetId}?dataset_id=${datasetId}`
+      const resp = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
+      if (resp.ok) {
+        return await resp.json()
+      }
+      return null
+    } catch (err) {
+      console.warn('Failed to fetch viewer asset by id:', err)
+      return null
+    }
+  },
+
+  /**
+   * Promote a chat-scoped viewer asset to a plain dataset asset by detaching
+   * its chat session (PATCH clear_chat_session). Metadata-only: the asset's
+   * bytes never move (dataset_id is unchanged), it simply starts appearing in
+   * the dataset's asset listing and is no longer reclaimed when the chat
+   * session is deleted. Idempotent — a no-op on an already-unscoped asset.
+   * @param {String} datasetId
+   * @param {String} assetId
+   */
+  promoteViewerAsset: async ({rootState}, { datasetId, assetId }) => {
+    const token = await useGetToken()
+    const url = `${rootState.config.api2Url}/packages/assets/${assetId}?dataset_id=${datasetId}`
+    const resp = await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ clear_chat_session: true }),
+    })
+    if (!resp.ok) {
+      throw new Error(`Failed to promote viewer asset: ${resp.status}`)
+    }
+    return await resp.json()
+  },
+
+  /**
    * Delete a viewer asset
    * @param {String} datasetId
    * @param {String} assetId
@@ -352,7 +403,6 @@ export const actions = {
   },
 
   /**
->>>>>>> main
    * Get presigned URL for a file
    * @param {String} packageId
    * @param {String} fileId


### PR DESCRIPTION
## Summary
- Resolve chat figures by viewer-asset UUID (`source.assetId`) via `GET /packages/assets/{id}?dataset_id=…`, the only reliable path for **chat-scoped** figures (those are excluded from the package/dataset asset listing). Falls back to the listing match on `{name, asset_type}` (newest-first) for older frames that carry no `assetId`.
- Add hover-revealed **promote** and **remove** actions, gated on a resolved `assetId`:
  - **Promote** → `PATCH /packages/assets/{id}` with `{clear_chat_session: true}`. Metadata-only; the bytes never move. The figure detaches from the chat session and joins the dataset asset listing.
  - **Remove** → `DELETE /packages/assets/{id}`, behind a two-step inline confirm. Deletes **only** this viewer-asset — never the underlying package, never the dataset.
- New `viewerModule` store actions: `fetchViewerAssetById`, `promoteViewerAsset`.

## Build prerequisite
Also resolves committed git conflict markers in `src/store/viewerModule.js` that were present on the base branch (literal `<<<<<<< / ======= / >>>>>>>` → JS syntax error / broken build). Both conflict regions were additive; kept `fetchSourceFiles` and `deleteViewerAsset`.

## Notes
- Targets `feat/chat-session-history` (not `main`) — this builds on the chat session history work.
- This is the frontend end of the figure↔chat-session linkage: the producer chain (compute-node-chat → pennsieve-mcp → workflow-service → data-target-assets) stamps `chat_session_id` and reports the asset UUID back; this PR consumes it.

## Test plan
- [ ] Inline figure with `source.assetId` resolves and renders via GET-by-id.
- [ ] Older frame without `assetId` still resolves via the listing fallback.
- [ ] Promote detaches the figure (appears in dataset assets; status note shown).
- [ ] Remove deletes only the viewer-asset (package + dataset intact); shows "Figure removed."
- [ ] Resolution failure degrades to the "View plot in package →" link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)