### PR TITLE
Public workflows UI: publish/unpublish + cross-workspace discovery

### DIFF
--- a/src/components/Analysis/Applications/ApplicationDetail.vue
+++ b/src/components/Analysis/Applications/ApplicationDetail.vue
@@ -54,8 +54,9 @@ const repoName = computed(
 );
 
 const visibilityLabel = computed(() => {
-  if (typeof detail.value?.isPrivate !== "boolean") return null;
-  return detail.value.isPrivate ? "Private" : "Public";
+  const visibility = detail.value?.visibility;
+  if (visibility !== "public" && visibility !== "private") return null;
+  return visibility === "private" ? "Private" : "Public";
 });
 
 const githubRepoUrl = computed(() => {

--- a/src/components/Analysis/Applications/ApplicationsGrid.vue
+++ b/src/components/Analysis/Applications/ApplicationsGrid.vue
@@ -115,8 +115,9 @@ watch(
 );
 
 const visibilityLabel = (app) => {
-  if (typeof app?.isPrivate !== "boolean") return null;
-  return app.isPrivate ? "Private" : "Public";
+  const visibility = app?.visibility;
+  if (visibility !== "public" && visibility !== "private") return null;
+  return visibility === "private" ? "Private" : "Public";
 };
 
 /*

--- a/src/components/Analysis/WorkflowBuilder/WorkflowBuilder.vue
+++ b/src/components/Analysis/WorkflowBuilder/WorkflowBuilder.vue
@@ -9,6 +9,7 @@ import { useVueFlow, VueFlow, Handle, Position } from "@vue-flow/core";
 import { Background } from "@vue-flow/background";
 import { Controls } from "@vue-flow/controls";
 import dagre from "@dagrejs/dagre";
+import { ElMessageBox } from "element-plus";
 import EventBus from "../../../utils/event-bus";
 import IconFile from "../../icons/IconFile.vue";
 import IconCollection from "../../icons/IconCollection.vue";
@@ -514,6 +515,79 @@ const toggleArchive = async () => {
   } catch {
     EventBus.$emit("toast", {
       detail: { type: "error", msg: "Failed to update workflow status." },
+    });
+  }
+};
+
+/*
+Visibility (public / private)
+*/
+const isSuperAdmin = computed(() => store.getters.isSuperAdmin === true);
+
+const isWorkflowCreator = computed(() => {
+  const wf = selectedWorkflow.value;
+  if (!wf || !profile.value) return false;
+  return (
+    profile.value.id === wf.createdBy || profile.value.intId === wf.createdBy
+  );
+});
+
+const isPublicWorkflow = computed(
+  () => selectedWorkflow.value?.visibility === "public",
+);
+
+// Only the creator may publish. The creator or a super-admin (moderation) may
+// unpublish — mirrors the workflow-service authorization rules.
+const canPublish = computed(
+  () => !isPublicWorkflow.value && isWorkflowCreator.value,
+);
+const canUnpublish = computed(
+  () => isPublicWorkflow.value && (isWorkflowCreator.value || isSuperAdmin.value),
+);
+
+const togglePublish = async () => {
+  if (!selectedWorkflow.value) return;
+  const wf = selectedWorkflow.value;
+  const goingPublic = !isPublicWorkflow.value;
+
+  try {
+    await ElMessageBox.confirm(
+      goingPublic
+        ? `Publishing "${wf.name}" makes it discoverable and runnable by anyone across all organizations. Every processor must itself be a public application.`
+        : `Unpublishing "${wf.name}" reverts it to private. It will no longer be discoverable by other users and any "Official" badge will be removed.`,
+      goingPublic ? "Publish workflow" : "Unpublish workflow",
+      {
+        confirmButtonText: goingPublic ? "Publish" : "Unpublish",
+        cancelButtonText: "Cancel",
+        type: "warning",
+      },
+    );
+  } catch {
+    return; // user cancelled
+  }
+
+  try {
+    const action = goingPublic ? "publishWorkflow" : "unpublishWorkflow";
+    const updated = await store.dispatch(`analysisModule/${action}`, {
+      uuid: wf.uuid,
+    });
+    selectedWorkflow.value = {
+      ...wf,
+      visibility: updated?.visibility ?? (goingPublic ? "public" : ""),
+      official: updated?.official ?? false,
+    };
+    EventBus.$emit("toast", {
+      detail: {
+        type: "success",
+        msg: goingPublic ? "Workflow published." : "Workflow unpublished.",
+      },
+    });
+  } catch (err) {
+    EventBus.$emit("toast", {
+      detail: {
+        type: "error",
+        msg: err?.message || "Failed to update workflow visibility.",
+      },
     });
   }
 };
@@ -1781,6 +1855,23 @@ const openNodeSettings = (id) => {
                     </span>
                   </div>
                   <div class="info-row">
+                    <span class="info-label">Visibility</span>
+                    <span class="info-value">
+                      <span
+                        class="visibility-badge"
+                        :class="isPublicWorkflow ? 'public' : 'private'"
+                      >
+                        {{ isPublicWorkflow ? "Public" : "Private" }}
+                      </span>
+                      <span
+                        v-if="selectedWorkflow.official"
+                        class="visibility-badge official"
+                      >
+                        Official
+                      </span>
+                    </span>
+                  </div>
+                  <div class="info-row">
                     <span class="info-label">Nodes</span>
                     <span class="info-value">{{
                       (selectedWorkflow.dag || []).length
@@ -1802,16 +1893,6 @@ const openNodeSettings = (id) => {
                 <div class="info-actions">
                   <button class="text-link-btn" @click="startEditDetails">
                     Edit name & description
-                  </button>
-                  <button
-                    class="text-link-btn archive-btn"
-                    @click="toggleArchive"
-                  >
-                    {{
-                      selectedWorkflow.isActive
-                        ? "Archive workflow"
-                        : "Activate workflow"
-                    }}
                   </button>
                 </div>
               </template>
@@ -1920,6 +2001,61 @@ const openNodeSettings = (id) => {
                     </template>
                   </div>
                 </div>
+              </div>
+            </div>
+          </el-collapse-item>
+
+          <!-- Danger Zone (always last) -->
+          <el-collapse-item
+            v-if="mode === 'browse' && selectedWorkflow"
+            title="Danger Zone"
+            name="danger-zone"
+            class="danger-collapse-item"
+          >
+            <div class="danger-zone">
+              <div class="danger-row">
+                <div class="danger-info">
+                  <div class="danger-row-title">
+                    {{
+                      selectedWorkflow.isActive
+                        ? "Archive workflow"
+                        : "Activate workflow"
+                    }}
+                  </div>
+                  <p class="danger-row-desc">
+                    {{
+                      selectedWorkflow.isActive
+                        ? "Archiving hides this workflow from the active list. You can reactivate it at any time."
+                        : "Reactivate this workflow so it appears in the active list and can be run."
+                    }}
+                  </p>
+                </div>
+                <bf-button class="danger-button" @click="toggleArchive">
+                  {{ selectedWorkflow.isActive ? "Archive" : "Activate" }}
+                </bf-button>
+              </div>
+
+              <div v-if="canPublish || canUnpublish" class="danger-row">
+                <div class="danger-info">
+                  <div class="danger-row-title">
+                    {{ isPublicWorkflow ? "Make private" : "Make public" }}
+                  </div>
+                  <p class="danger-row-desc">
+                    <template v-if="isPublicWorkflow">
+                      This workflow is public — discoverable and runnable by
+                      anyone across all organizations. Making it private also
+                      removes any "Official" badge.
+                    </template>
+                    <template v-else>
+                      Publishing makes this workflow discoverable and runnable by
+                      anyone across all organizations. Every processor must
+                      itself be public.
+                    </template>
+                  </p>
+                </div>
+                <bf-button class="danger-button" @click="togglePublish">
+                  {{ isPublicWorkflow ? "Make private" : "Make public" }}
+                </bf-button>
               </div>
             </div>
           </el-collapse-item>
@@ -2834,9 +2970,92 @@ const openNodeSettings = (id) => {
   &:hover {
     text-decoration: underline;
   }
+}
 
-  &.archive-btn {
-    color: theme.$status_red;
+.visibility-badge {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 16px;
+
+  &.private {
+    background-color: theme.$gray_2;
+    color: theme.$gray_5;
+  }
+
+  &.public {
+    background-color: theme.$green_tint;
+    color: theme.$status_green;
+  }
+
+  &.official {
+    margin-left: 6px;
+    background-color: theme.$purple_tint;
+    color: theme.$purple_3;
+  }
+}
+
+.danger-collapse-item {
+  :deep(.el-collapse-item__header) {
+    color: theme.$red_2;
+    font-weight: 600;
+  }
+}
+
+.danger-zone {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.danger-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+
+  &:not(:last-child) {
+    padding-bottom: 16px;
+    border-bottom: 1px solid rgba(theme.$red_2, 0.2);
+  }
+}
+
+.danger-info {
+  flex: 1;
+}
+
+.danger-row-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: theme.$gray_6;
+  margin-bottom: 4px;
+}
+
+.danger-row-desc {
+  font-size: 12px;
+  color: theme.$gray_5;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.danger-button {
+  flex-shrink: 0;
+  background: theme.$white;
+  color: theme.$red_2;
+  border: 1px solid theme.$red_2;
+  border-radius: 4px;
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: theme.$red_1;
+    color: theme.$white;
   }
 }
 

--- a/src/components/Analysis/WorkflowBuilder/WorkflowBuilder.vue
+++ b/src/components/Analysis/WorkflowBuilder/WorkflowBuilder.vue
@@ -16,6 +16,7 @@ import IconCollection from "../../icons/IconCollection.vue";
 import IconAnalysis from "../../icons/IconAnalysis.vue";
 import IconInfoSmall from "../../icons/IconInfoSmall.vue";
 import IconPencil from "../../icons/IconPencil.vue";
+import IconPennsieveMark from "../../icons/IconPennsieveMark.vue";
 import {
   FARGATE_CPU_OPTIONS,
   getMemoryOptionsForCpu,
@@ -1863,12 +1864,19 @@ const openNodeSettings = (id) => {
                       >
                         {{ isPublicWorkflow ? "Public" : "Private" }}
                       </span>
-                      <span
+                      <el-tooltip
                         v-if="selectedWorkflow.official"
-                        class="visibility-badge official"
+                        content="This workflow has been reviewed and validated by Pennsieve."
+                        placement="top"
                       >
-                        Official
-                      </span>
+                        <span class="official-mark">
+                          <IconPennsieveMark
+                            :width="15"
+                            :height="15"
+                            color="currentColor"
+                          />
+                        </span>
+                      </el-tooltip>
                     </span>
                   </div>
                   <div class="info-row">
@@ -2989,12 +2997,14 @@ const openNodeSettings = (id) => {
     background-color: theme.$green_tint;
     color: theme.$status_green;
   }
+}
 
-  &.official {
-    margin-left: 6px;
-    background-color: theme.$purple_tint;
-    color: theme.$purple_3;
-  }
+.official-mark {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 8px;
+  color: theme.$purple_3;
+  vertical-align: middle;
 }
 
 .danger-collapse-item {

--- a/src/components/Analysis/Workflows/WorkflowsGrid.vue
+++ b/src/components/Analysis/Workflows/WorkflowsGrid.vue
@@ -11,6 +11,7 @@ const router = useRouter();
 
 const searchQuery = ref("");
 const statusFilter = ref("active");
+const scopeFilter = ref("workspace"); // "workspace" | "public"
 const pageSize = ref(10);
 const currentPage = ref(1);
 const isLoadingAll = ref(false);
@@ -27,6 +28,13 @@ const filterOptions = [
   { label: "Archived", value: "archived" },
   { label: "All", value: "all" },
 ];
+
+const scopeOptions = [
+  { label: "This workspace", value: "workspace" },
+  { label: "Public", value: "public" },
+];
+
+const isPublicScope = computed(() => scopeFilter.value === "public");
 
 const filteredWorkflows = computed(() => {
   let list = [...workflows.value];
@@ -148,12 +156,14 @@ const ALL_FETCH_CAP = 50; // hard stop at 5,000 workflows
 const fetchAllWorkflows = async () => {
   if (isLoadingAll.value) return;
   isLoadingAll.value = true;
+  const visibility = isPublicScope.value ? "public" : undefined;
   try {
     // First batch replaces, subsequent batches append.
     await store.dispatch("analysisModule/fetchWorkflows", {
       cursor: undefined,
       limit: ALL_FETCH_BATCH,
       status: getStatusParam(),
+      visibility,
       append: false,
     });
     let safety = ALL_FETCH_CAP;
@@ -162,6 +172,7 @@ const fetchAllWorkflows = async () => {
         cursor: nextCursor.value,
         limit: ALL_FETCH_BATCH,
         status: getStatusParam(),
+        visibility,
         append: true,
       });
     }
@@ -170,8 +181,9 @@ const fetchAllWorkflows = async () => {
   }
 };
 
-// Re-fetch all when status filter changes
-watch(statusFilter, () => {
+// Re-fetch all when the status or scope filter changes
+watch([statusFilter, scopeFilter], () => {
+  currentPage.value = 1;
   fetchAllWorkflows();
 });
 
@@ -211,17 +223,36 @@ onMounted(async () => {
         />
       </div>
 
-      <div class="status-buttons">
-        <button
-          v-for="option in filterOptions"
-          :key="option.value"
-          class="filter-btn"
-          :class="{ active: statusFilter === option.value }"
-          @click="statusFilter = option.value"
-        >
-          {{ option.label }}
-        </button>
+      <div class="filter-row">
+        <div class="status-buttons scope-buttons">
+          <button
+            v-for="option in scopeOptions"
+            :key="option.value"
+            class="filter-btn"
+            :class="{ active: scopeFilter === option.value }"
+            @click="scopeFilter = option.value"
+          >
+            {{ option.label }}
+          </button>
+        </div>
+
+        <div class="status-buttons">
+          <button
+            v-for="option in filterOptions"
+            :key="option.value"
+            class="filter-btn"
+            :class="{ active: statusFilter === option.value }"
+            @click="statusFilter = option.value"
+          >
+            {{ option.label }}
+          </button>
+        </div>
       </div>
+
+      <p v-if="isPublicScope" class="scope-hint">
+        Public workflows published across all workspaces. They can be run from
+        any workspace; only the creator can edit or unpublish them.
+      </p>
 
       <div v-if="filteredWorkflows.length > 0" class="workflows-grid">
         <div
@@ -257,6 +288,12 @@ onMounted(async () => {
                 </span>
                 <span class="tag created">
                   {{ new Date(wf.createdAt).toLocaleDateString() }}
+                </span>
+                <span v-if="wf.visibility === 'public'" class="tag public">
+                  Public
+                </span>
+                <span v-if="wf.official" class="tag official">
+                  Official
                 </span>
               </div>
             </div>
@@ -393,11 +430,30 @@ onMounted(async () => {
   max-width: 320px;
 }
 
+.filter-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
 .status-buttons {
   display: flex;
   align-items: center;
   gap: 8px;
   margin-bottom: 16px;
+}
+
+.scope-buttons {
+  padding-right: 16px;
+  border-right: 1px solid theme.$gray_2;
+}
+
+.scope-hint {
+  margin: -8px 0 16px;
+  font-size: 12px;
+  color: theme.$gray_5;
+  line-height: 1.4;
 }
 
 .filter-btn {
@@ -565,6 +621,16 @@ onMounted(async () => {
     &.created {
       background: theme.$gray_1;
       color: theme.$gray_5;
+    }
+
+    &.public {
+      background: theme.$green_tint;
+      color: theme.$status_green;
+    }
+
+    &.official {
+      background: theme.$purple_tint;
+      color: theme.$purple_3;
     }
   }
 }

--- a/src/components/Analysis/Workflows/WorkflowsGrid.vue
+++ b/src/components/Analysis/Workflows/WorkflowsGrid.vue
@@ -5,6 +5,7 @@ import { useRouter } from "vue-router";
 
 import BfButton from "../../shared/bf-button/BfButton.vue";
 import IconAnalysis from "../../icons/IconAnalysis.vue";
+import IconPennsieveMark from "../../icons/IconPennsieveMark.vue";
 
 const store = useStore();
 const router = useRouter();
@@ -292,9 +293,15 @@ onMounted(async () => {
                 <span v-if="wf.visibility === 'public'" class="tag public">
                   Public
                 </span>
-                <span v-if="wf.official" class="tag official">
-                  Official
-                </span>
+                <el-tooltip
+                  v-if="wf.official"
+                  content="This workflow has been reviewed and validated by Pennsieve."
+                  placement="top"
+                >
+                  <span class="official-mark" @click.stop>
+                    <IconPennsieveMark :width="14" :height="14" color="currentColor" />
+                  </span>
+                </el-tooltip>
               </div>
             </div>
 
@@ -627,12 +634,13 @@ onMounted(async () => {
       background: theme.$green_tint;
       color: theme.$status_green;
     }
-
-    &.official {
-      background: theme.$purple_tint;
-      color: theme.$purple_3;
-    }
   }
+}
+
+.official-mark {
+  display: inline-flex;
+  align-items: center;
+  color: theme.$purple_3;
 }
 
 .wf-card-actions {

--- a/src/store/analysisModule.js
+++ b/src/store/analysisModule.js
@@ -1,5 +1,17 @@
 import { useGetToken, useGetAllTokens } from "@/composables/useGetToken";
 
+// extractErrorMessage pulls the workflow-service `{ "message": "..." }` body off a
+// failed response, falling back to the HTTP status when none is present.
+const extractErrorMessage = async (response) => {
+  try {
+    const body = await response.json();
+    if (body?.message) return body.message;
+  } catch {
+    /* non-JSON body */
+  }
+  return `Error ${response.status}: ${response.statusText}`;
+};
+
 const initialState = () => ({
   computeNodes: [],
   computeNodesLoaded: false,
@@ -173,6 +185,17 @@ export const mutations = {
     if (workflow) {
       if (name !== undefined) workflow.name = name;
       if (description !== undefined) workflow.description = description;
+    }
+  },
+  UPDATE_WORKFLOW_VISIBILITY(state, { uuid, visibility, official }) {
+    const apply = (w) => {
+      if (!w) return;
+      w.visibility = visibility;
+      if (official !== undefined) w.official = official;
+    };
+    apply(state.workflows.find((w) => w.uuid === uuid));
+    if (state.selectedWorkflow?.uuid === uuid) {
+      apply(state.selectedWorkflow);
     }
   },
   SET_ANALYTICS_CHANNEL(state, channel) {
@@ -525,6 +548,59 @@ export const actions = {
       console.error("Failed to update workflow:", err.message);
       throw err;
     }
+  },
+  // Publish makes a workflow public (discoverable/runnable across organizations).
+  // Backend enforces creator-only and that every processor references an App
+  // Store application; surfaces those rejections via the response message.
+  publishWorkflow: async ({ commit, rootState }, { uuid }) => {
+    const url = `${rootState.config.api2Url}/compute/workflows/definitions/${uuid}/publish`;
+    const userToken = await useGetToken();
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(await extractErrorMessage(response));
+    }
+
+    const result = await response.json();
+    commit("UPDATE_WORKFLOW_VISIBILITY", {
+      uuid,
+      visibility: result.visibility || "public",
+      official: result.official ?? false,
+    });
+    return result;
+  },
+  // Unpublish reverts a workflow to private and clears any Official badge.
+  // Backend allows the creator or a super-admin (moderation).
+  unpublishWorkflow: async ({ commit, rootState }, { uuid }) => {
+    const url = `${rootState.config.api2Url}/compute/workflows/definitions/${uuid}/unpublish`;
+    const userToken = await useGetToken();
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(await extractErrorMessage(response));
+    }
+
+    const result = await response.json();
+    commit("UPDATE_WORKFLOW_VISIBILITY", {
+      uuid,
+      visibility: result.visibility || "",
+      official: result.official ?? false,
+    });
+    return result;
   },
   // Note that this to to deploy application, there is another action for editing application
   updateApplication: async ({ commit, rootState }, newApplication) => {
@@ -929,12 +1005,18 @@ export const actions = {
       throw new Error(`Failed to fetch workflow definition: ${resp.status}`);
     }
   },
-  fetchWorkflows: async ({ commit, rootState }, { search, cursor, limit, status, append } = {}) => {
+  fetchWorkflows: async ({ commit, rootState }, { search, cursor, limit, status, append, visibility, official } = {}) => {
     try {
       const userToken = await useGetToken();
-      const params = new URLSearchParams({
-        organization_id: rootState.activeOrganization.organization.id,
-      });
+      // Public discovery lists the cross-organization catalog, so it must NOT be
+      // scoped to the active workspace. Otherwise list the active workspace.
+      const params = new URLSearchParams();
+      if (visibility === "public") {
+        params.set("visibility", "public");
+        if (official) params.set("official", "true");
+      } else {
+        params.set("organization_id", rootState.activeOrganization.organization.id);
+      }
       if (limit) params.set("limit", limit);
       if (search) params.set("search", search);
       if (cursor) params.set("cursor", cursor);


### PR DESCRIPTION
## Summary
Frontend for **public workflows** — lets a creator publish/unpublish a workflow and lets anyone discover the public catalog across workspaces. Pairs with the workflow-service backend (publish/unpublish + `visibility=public` discovery).

## Changes
**Workflow detail — `WorkflowBuilder.vue`**
- New **Danger Zone** as the last sidebar section (matching the compute-node pattern) holding **Archive/Activate** and **Make public / Make private**.
- A **Visibility** row with a `Private`/`Public` badge.
- The **official** flag renders as the **Pennsieve logomark** (not text), with an `el-tooltip`: "This workflow has been reviewed and validated by Pennsieve."
- Confirmation dialog (`ElMessageBox`) before changing visibility; backend error messages (e.g. "processor references a non-public application") surfaced as toasts.
- Authorization mirrors the backend: publish is creator-only; unpublish is creator-or-super-admin.

**Workflow list — `WorkflowsGrid.vue`**
- New **"This workspace | Public"** scope toggle. "Public" lists the cross-organization public catalog (no `organization_id`), so a workflow published in one workspace is discoverable from any workspace.
- `Public` tag on workflow cards; the **official** flag renders as the Pennsieve logomark with the same reviewed-and-validated tooltip.

**Store — `analysisModule.js`**
- `publishWorkflow` / `unpublishWorkflow` actions + `UPDATE_WORKFLOW_VISIBILITY` mutation.
- `fetchWorkflows` accepts `visibility` / `official`; for public discovery it sends `visibility=public` and omits `organization_id`.
- `extractErrorMessage` helper to surface `{ "message": ... }` bodies.

**Applications — `ApplicationDetail.vue` / `ApplicationsGrid.vue`**
- Read the `visibility` string (`"public"`/`"private"`) instead of the legacy `isPrivate` boolean.

## Backend dependencies
Cross-org discovery and publish are served by workflow-service (`visibility=public`, `/publish`, `/unpublish`), already deployed in dev. Related backend/infra PRs (App Store visibility check): Pennsieve/app-deploy-service#166, Pennsieve/infrastructure#468, Pennsieve/workflow-service#42.

The `official` badge is set super-admin-only via the workflow-service `/verify` `/unverify` endpoints (no UI here — display only).

## Test plan
- [x] SFC + ESM compile checks pass for all changed files.
- [x] Verified in dev: a workflow published in one workspace appears under the "Public" scope in a different workspace.
- Manual: publish (creator-only), unpublish (creator/super-admin), Pennsieve mark + tooltip renders for official workflows, error toast on non-public processor.
