### PR TITLE
Fix workspace switching bug

### DIFF
--- a/src/components/Analysis/RunMonitor/RunDetail.vue
+++ b/src/components/Analysis/RunMonitor/RunDetail.vue
@@ -1109,7 +1109,7 @@ onMounted(async () => {
   await Promise.all([
     store.dispatch("analysisModule/fetchComputeNodes"),
     store.dispatch("analysisModule/fetchTargetTypes"),
-    store.dispatch("analysisModule/fetchApplications", { force: true }),
+    store.dispatch("analysisModule/fetchApplications"),
   ]);
 
   // Check for pending configure mode

--- a/src/components/Analysis/RunMonitor/RunMonitor.vue
+++ b/src/components/Analysis/RunMonitor/RunMonitor.vue
@@ -1611,7 +1611,7 @@ onMounted(async () => {
       store.dispatch("analysisModule/fetchComputeNodes"),
       store.dispatch("analysisModule/fetchWorkflows"),
       store.dispatch("analysisModule/fetchTargetTypes"),
-      store.dispatch("analysisModule/fetchApplications", { force: true }),
+      store.dispatch("analysisModule/fetchApplications"),
       fetchOrgCounters(),
     ]);
   } catch (err) {

--- a/src/composables/useGetPrimaryData.js
+++ b/src/composables/useGetPrimaryData.js
@@ -1,0 +1,101 @@
+import * as siteConfig from '@/site-config/site.json'
+import { curryN, find, propEq, propOr } from 'ramda'
+import store from '@/store'
+import { useGetToken } from '@/composables/useGetToken'
+import { useSendXhr } from '@/mixins/request/request_composable'
+
+function _isInList(member, activeOrganization, listName) {
+    const profileId = propOr(0, 'id', member)
+    const list = propOr([], listName, activeOrganization)
+    const inList = find(propEq('id', profileId), list)
+    return Boolean(inList)
+}
+const isInList = curryN(3, _isInList)
+
+function getOrgRole(member, activeOrganization) {
+    const checkList = isInList(member, activeOrganization)
+    switch (true) {
+        case checkList('administrators'):
+            return 'Administrator'
+        case checkList('owners'):
+            return 'Owner'
+        default:
+            return 'Collaborator'
+    }
+}
+
+function updateMembers(users) {
+    return users.map(member => {
+        const role = getOrgRole(member, store.getters.activeOrganization)
+        let newFields = { role }
+        if (!member.storage) {
+            newFields = { storage: 0, role }
+        }
+        return Object.assign({}, newFields, member)
+    })
+}
+
+// GetPrimaryData calls endpoints that return data that should always
+// be available on each page. This data is organization scoped and is
+// renewed on app reload and on workspace switch.
+export async function useGetPrimaryData() {
+    return useGetToken().then(async token => {
+        const activeOrganization = store.getters.activeOrganization
+
+        if (activeOrganization?.isGuest) {
+            return Promise.resolve()
+        }
+
+        const activeOrgId = activeOrganization.organization.id
+        const teamUrl = `${siteConfig.apiUrl}/organizations/${activeOrgId}/teams?api_key=${token}`
+
+        const teamAndPublishersPromise = useSendXhr(teamUrl)
+            .then(response => store.dispatch('updateTeams', response))
+            .then(() => {
+                const publisherTeam = store.getters.publisherTeam
+                const publisherTeamMembersUrl = `${siteConfig.apiUrl}/organizations/${activeOrgId}/teams/${publisherTeam.id}/members?api_key=${token}`
+                return useSendXhr(publisherTeamMembersUrl)
+                    .then(publisherTeamMembers => store.dispatch('updatePublishers', publisherTeamMembers))
+            })
+
+        const orgMembersUrl = `${siteConfig.apiUrl}/organizations/${activeOrgId}/members?api_key=${token}`
+        let orgMembersPromise
+        if (store.getters.hasFeature('sandbox_org_feature')) {
+            orgMembersPromise = Promise.resolve()
+        } else {
+            orgMembersPromise = useSendXhr(orgMembersUrl)
+                .then(orgMembersResponse => {
+                    const orgMembers = updateMembers(orgMembersResponse)
+                    store.dispatch('updateOrgMembers', orgMembers)
+                })
+                .catch(err => console.warn('Failed to load org members:', err))
+        }
+
+        const orgContributorsUrl = `${siteConfig.apiUrl}/contributors?api_key=${token}`
+        const orgContributorsPromise = useSendXhr(orgContributorsUrl)
+            .then(orgContributors => store.dispatch('setOrgContributors', orgContributors))
+            .catch(err => console.warn('Failed to load org contributors:', err))
+
+        const dataUseAgreementsUrl = `${siteConfig.apiUrl}/organizations/${activeOrgId}/data-use-agreements?api_key=${token}`
+        const dataUseAgreementsPromise = useSendXhr(dataUseAgreementsUrl)
+            .then(dataUseAgreements => store.dispatch('updateDataUseAgreements', dataUseAgreements))
+            .catch(err => console.warn('Failed to load data use agreements:', err))
+
+        const datasetStatusesUrl = `${siteConfig.apiUrl}/organizations/${activeOrgId}/dataset-status?api_key=${token}`
+        const datasetStatusesPromise = useSendXhr(datasetStatusesUrl)
+            .then(datasetStatuses => store.dispatch('updateOrgDatasetStatuses', datasetStatuses))
+            .catch(err => console.warn('Failed to load dataset statuses:', err))
+
+        const applicationsPromise = store.dispatch('analysisModule/fetchApplications', { force: true })
+            .catch(err => console.warn('Failed to load applications:', err))
+
+        return Promise.all([
+            teamAndPublishersPromise,
+            orgMembersPromise,
+            orgContributorsPromise,
+            dataUseAgreementsPromise,
+            datasetStatusesPromise,
+            applicationsPromise,
+        ])
+    })
+}

--- a/src/composables/useGetPrimaryData.js
+++ b/src/composables/useGetPrimaryData.js
@@ -86,8 +86,8 @@ export async function useGetPrimaryData() {
             .then(datasetStatuses => store.dispatch('updateOrgDatasetStatuses', datasetStatuses))
             .catch(err => console.warn('Failed to load dataset statuses:', err))
 
-        const applicationsPromise = store.dispatch('analysisModule/fetchApplications', { force: true })
-            .catch(err => console.warn('Failed to load applications:', err))
+        // Applications are loaded lazily by Analysis.vue on mount and refetched
+        // by its watcher when activeOrganization changes — no pre-warm needed here.
 
         return Promise.all([
             teamAndPublishersPromise,
@@ -95,7 +95,6 @@ export async function useGetPrimaryData() {
             orgContributorsPromise,
             dataUseAgreementsPromise,
             datasetStatusesPromise,
-            applicationsPromise,
         ])
     })
 }

--- a/src/composables/useSwitchWorkspace.js
+++ b/src/composables/useSwitchWorkspace.js
@@ -5,6 +5,7 @@ import store from "@/store";
 import {checkIsSubscribed} from "@/composables/useCheckTerms";
 import router from "@/router";
 import {useComputeResourcesStore} from "@/stores/computeResourcesStore";
+import {useGetPrimaryData} from "@/composables/useGetPrimaryData";
 
 export async function useSwitchWorkspace(org) {
     const orgId = org.organization.id
@@ -31,12 +32,14 @@ export async function useSwitchWorkspace(org) {
         // Update the active organization before refetching org-scoped data
         await store.dispatch('updateActiveOrganization', org)
 
-        // Force-refresh applications so the new org's apps are ready when the
-        // user lands on any analysis tab (avoids stale list from the previous org)
+        // Refetch org-scoped data (members, teams, publishers, contributors,
+        // data use agreements, dataset statuses, applications) so pages like
+        // /:orgId/people don't render with stale or empty state from the
+        // previous workspace.
         try {
-            await store.dispatch('analysisModule/fetchApplications', { force: true })
+            await useGetPrimaryData()
         } catch (err) {
-            console.warn('Failed to refresh applications on org switch:', err)
+            console.warn('Failed to refresh primary data on org switch:', err)
         }
 
         // Navigate to the appropriate route

--- a/src/main.js
+++ b/src/main.js
@@ -25,7 +25,8 @@ import { cognitoUserPoolsTokenProvider } from 'aws-amplify/auth/cognito';
 import {fetchAuthSession} from "aws-amplify/auth";
 import {useGetProfileAndOrg} from "@/composables/useGetProfileAndOrg";
 import {useGetToken} from "@/composables/useGetToken";
-import {curryN, find, path, pathOr, propEq, propOr} from "ramda";
+import {useGetPrimaryData} from "@/composables/useGetPrimaryData";
+import {path} from "ramda";
 import {useSendXhr} from "@/mixins/request/request_composable";
 import EventBus from "@/utils/event-bus";
 import {checkIsSubscribed} from "@/composables/useCheckTerms";
@@ -212,7 +213,7 @@ router.beforeEach(async (to, from, next) => {
                     return store.dispatch('setActiveOrgSynced')
                 })
                 .then(() => {
-                    return getPrimaryData()
+                    return useGetPrimaryData()
                 }).catch(err => {
                     console.error('Error during workspace initialization:', err)
                     EventBus.$emit('toast', {
@@ -259,7 +260,7 @@ router.beforeEach(async (to, from, next) => {
                 // Only proceed with data loading if session switch succeeded
                 await checkActiveOrg(to)
                 if (sessionSwitched) {
-                    await getPrimaryData().catch(err => {
+                    await useGetPrimaryData().catch(err => {
                         console.error('Error loading workspace data:', err)
                         EventBus.$emit('toast', {
                             detail: {
@@ -268,10 +269,6 @@ router.beforeEach(async (to, from, next) => {
                             }
                         })
                     })
-
-                    // Force-refresh applications for the new org
-                    store.dispatch('analysisModule/fetchApplications', { force: true })
-                        .catch(err => console.warn('Failed to refresh applications on org switch:', err))
                 }
             }
         }
@@ -280,7 +277,7 @@ router.beforeEach(async (to, from, next) => {
     }
 })
 
-router.afterEach((to, from) => {
+router.afterEach((to) => {
 
     // Set nav state based on routegit a
     if (topLevelRoutes.indexOf(to.name) >= 0) {
@@ -291,118 +288,6 @@ router.afterEach((to, from) => {
 })
 
 //  ------ HELPER FUNCTIONS -------
-
-// GetPrimaryData calls endpoints that return data that should always
-// be available on each page. This data is organization scoped and is
-// only renewed on reload of app.
-async function getPrimaryData() {
-
-    return useGetToken().then(async token => {
-
-        const activeOrg = store.getters.activeOrganization
-        
-        // Skip fetching primary data for guest organizations
-        if (activeOrg?.isGuest) {
-            return Promise.resolve()
-        }
-        
-        const activeOrgId = activeOrg.organization.id
-        const teamUrl = `${siteConfig.apiUrl}/organizations/${activeOrgId}/teams?api_key=${token}`
-
-        // ==== TEAM AND PUBLISHERS =====
-        const teamAndPublishersPromise = useSendXhr(teamUrl)
-            .then(response => {
-                return store.dispatch('updateTeams', response)
-            })
-            .then(() => {
-                const publisherTeam = store.getters.publisherTeam
-                const publisherUrl = `${siteConfig.apiUrl}/organizations/${activeOrgId}/teams/${publisherTeam.id}/members?api_key=${token}`
-                return useSendXhr(publisherUrl)
-                    .then(resp => {
-                        return store.dispatch('updatePublishers', resp)
-                    })
-            })
-
-        // ==== ORG MEMBERS =====
-        const orgMemberUrl = `${siteConfig.apiUrl}/organizations/${activeOrgId}/members?api_key=${token}`
-        let orgMemberPromise
-        if (store.getters.hasFeature('sandbox_org_feature')) {
-            orgMemberPromise = Promise.resolve()
-        } else {
-            orgMemberPromise = useSendXhr(orgMemberUrl)
-                .then(resp => {
-                    const orgMembers = updateMembers(resp)
-                    store.dispatch('updateOrgMembers',orgMembers)
-                }).catch(err => console.warn('Failed to load additional data:', err))
-        }
-
-        // ==== ORG CONTRIBUTORS ====
-        const orgContributorUrl =`${siteConfig.apiUrl}/contributors?api_key=${token}`
-        const contributorPromise = useSendXhr(orgContributorUrl)
-            .then(resp => {
-                store.dispatch('setOrgContributors', resp)
-            }).catch(err => console.warn('Failed to load additional data:', err))
-
-        // ==== DATA USE AGREEMENTS ====
-        const dataUseAgreementUrl =`${siteConfig.apiUrl}/organizations/${activeOrgId}/data-use-agreements?api_key=${token}`
-        const dataUseAgreementPromise = useSendXhr(dataUseAgreementUrl)
-            .then(resp => {
-                store.dispatch('updateDataUseAgreements', resp)
-            }).catch(err => console.warn('Failed to load additional data:', err))
-
-        // ==== Dataset Statuses ====
-        const datasetStatusUrl = `${siteConfig.apiUrl}/organizations/${activeOrgId}/dataset-status?api_key=${token}`
-        const datasetStatusPromise = useSendXhr(datasetStatusUrl)
-            .then(resp => {
-                store.dispatch('updateOrgDatasetStatuses', resp)
-            }).catch(err => console.warn('Failed to load additional data:', err))
-
-
-        return Promise.all(
-            [
-                teamAndPublishersPromise,
-                orgMemberPromise,
-                contributorPromise,
-                dataUseAgreementPromise,
-                datasetStatusPromise,
-            ])
-    })
-}
-
-const isInList = curryN(3, _isInList)
-
-function _isInList(member, activeOrganization, listName) {
-    const profileId = propOr(0, 'id', member)
-    const list = propOr([], listName, activeOrganization)
-    const inList =  find(propEq('id', profileId), list)
-    return Boolean(inList)
-}
-
-function getOrgRole(member, activeOrganization) {
-    const checkList = isInList(member, activeOrganization)
-    switch(true) {
-        case checkList('administrators'):
-            return 'Administrator'
-        case checkList('owners'):
-            return 'Owner'
-        default:
-            return 'Collaborator'
-    }
-}
-
-function updateMembers(users) {
-    return users.map(member => {
-        const role = getOrgRole(member, store.getters.activeOrganization)
-        let newFields = { role }
-        if (!member.storage) {
-            newFields = {
-                storage: 0,
-                role
-            }
-        }
-        return Object.assign({}, newFields, member)
-    })
-}
 
 async function checkActiveOrg(to) {
     const preferredOrgId = store.getters.profile.preferredOrganization

--- a/src/router/Analysis/Analysis.vue
+++ b/src/router/Analysis/Analysis.vue
@@ -110,18 +110,19 @@ export default {
   async mounted() {
     const p1 = this.fetchIntegrations();
     const p2 = this.fetchComputeNodes({ force: true });
-    const p3 = this.fetchApplications({ force: true });
+    const p3 = this.fetchApplications();
 
     return Promise.all([p1, p2, p3]);
   },
 
   watch: {
     // When the active org changes while Analysis is mounted (e.g. user
-    // switches orgs from a menu without leaving the page), force-refresh
-    // org-scoped data so we never display the previous org's applications.
+    // switches orgs from a menu without leaving the page), refetch
+    // org-scoped data. clearState resets analysisModule.applicationsLoaded
+    // before this fires, so the action's built-in short-circuit will not skip.
     "$store.state.activeOrganization.organization.id"(newId, oldId) {
       if (newId && newId !== oldId) {
-        this.fetchApplications({ force: true });
+        this.fetchApplications();
         this.fetchComputeNodes({ force: true });
       }
     },


### PR DESCRIPTION
- fixed workspace switching bug https://app.clickup.com/t/8664796/868jxk6vh
- removed redundant fetch applications code, and force flag calls (applications are loaded when navigating to Analysis tab). Router navigation after switching workspaces will land on Datasets page, and clicking on Analysis section would re-fetch the applications freshly with the new orgId