### PR TITLE
Deploy: add GPU option to workflow run and re-run flows

### DIFF
--- a/src/components/Analysis/RunMonitor/RunDetail.vue
+++ b/src/components/Analysis/RunMonitor/RunDetail.vue
@@ -139,16 +139,31 @@ const incomingEdgeColor = (nodeId) => {
   return edge?.style?.stroke || "#cccccc";
 };
 
+const DEFAULT_COMPUTE_TYPES = ["standard", "lambda", "gpu"];
+
+// Display label for a compute type; "gpu" should read as "GPU", others Title-cased.
+const formatComputeTypeLabel = (ct) => {
+  if (!ct) return "";
+  if (ct === "gpu") return "GPU";
+  return ct.charAt(0).toUpperCase() + ct.slice(1);
+};
+
+// Ensure "gpu" is always selectable, even when the API-supplied list omits it.
+const withGpu = (types) =>
+  types.includes("gpu") ? types : [...types, "gpu"];
+
 const getComputeTypesForTarget = (targetType) => {
   if (!targetType) return [];
   const tt = targetTypes.value.find((t) => t.targetType === targetType);
-  return tt?.runtimeConfig?.computeTypes || [];
+  const types = tt?.runtimeConfig?.computeTypes;
+  return types && types.length ? withGpu(types) : [];
 };
 
 const getComputeTypesForProcessor = (sourceUrl) => {
-  if (!sourceUrl) return ["standard", "lambda"];
+  if (!sourceUrl) return DEFAULT_COMPUTE_TYPES;
   const app = availableApplications.value.find((a) => a.source?.url === sourceUrl);
-  return app?.runtimeConfig?.computeTypes || ["standard", "lambda"];
+  const types = app?.runtimeConfig?.computeTypes;
+  return types && types.length ? withGpu(types) : DEFAULT_COMPUTE_TYPES;
 };
 
 /* Version helpers — match WorkflowBuilder */
@@ -1401,7 +1416,7 @@ onUnmounted(() => {
                     <el-option
                       v-for="ct in getComputeTypesForProcessor(selectedNode.data?.sourceUrl)"
                       :key="ct"
-                      :label="ct.charAt(0).toUpperCase() + ct.slice(1)"
+                      :label="formatComputeTypeLabel(ct)"
                       :value="ct"
                     />
                   </el-select>
@@ -1575,7 +1590,7 @@ onUnmounted(() => {
                     <el-option
                       v-for="ct in getComputeTypesForTarget(selectedNode.data?.targetType)"
                       :key="ct"
-                      :label="ct"
+                      :label="formatComputeTypeLabel(ct)"
                       :value="ct"
                     />
                   </el-select>

--- a/src/components/Analysis/RunMonitor/RunMonitor.vue
+++ b/src/components/Analysis/RunMonitor/RunMonitor.vue
@@ -127,16 +127,31 @@ const incomingEdgeColor = (nodeId) => {
   return edge?.style?.stroke || "#cccccc";
 };
 
+const DEFAULT_COMPUTE_TYPES = ["standard", "lambda", "gpu"];
+
+// Display label for a compute type; "gpu" should read as "GPU", others Title-cased.
+const formatComputeTypeLabel = (ct) => {
+  if (!ct) return "";
+  if (ct === "gpu") return "GPU";
+  return ct.charAt(0).toUpperCase() + ct.slice(1);
+};
+
+// Ensure "gpu" is always selectable, even when the API-supplied list omits it.
+const withGpu = (types) =>
+  types.includes("gpu") ? types : [...types, "gpu"];
+
 const getComputeTypesForTarget = (targetType) => {
   if (!targetType) return [];
   const tt = targetTypes.value.find((t) => t.targetType === targetType);
-  return tt?.runtimeConfig?.computeTypes || [];
+  const types = tt?.runtimeConfig?.computeTypes;
+  return types && types.length ? withGpu(types) : [];
 };
 
 const getComputeTypesForProcessor = (sourceUrl) => {
-  if (!sourceUrl) return ["standard", "lambda"];
+  if (!sourceUrl) return DEFAULT_COMPUTE_TYPES;
   const app = availableApplications.value.find((a) => a.source?.url === sourceUrl);
-  return app?.runtimeConfig?.computeTypes || ["standard", "lambda"];
+  const types = app?.runtimeConfig?.computeTypes;
+  return types && types.length ? withGpu(types) : DEFAULT_COMPUTE_TYPES;
 };
 
 /* Version helpers — match WorkflowBuilder */
@@ -1972,7 +1987,7 @@ onUnmounted(() => {
                     <el-option
                       v-for="ct in getComputeTypesForProcessor(selectedNode.data?.sourceUrl)"
                       :key="ct"
-                      :label="ct.charAt(0).toUpperCase() + ct.slice(1)"
+                      :label="formatComputeTypeLabel(ct)"
                       :value="ct"
                     />
                   </el-select>
@@ -2156,7 +2171,7 @@ onUnmounted(() => {
                     <el-option
                       v-for="ct in getComputeTypesForTarget(selectedNode.data?.targetType)"
                       :key="ct"
-                      :label="ct"
+                      :label="formatComputeTypeLabel(ct)"
                       :value="ct"
                     />
                   </el-select>


### PR DESCRIPTION
# Add GPU as a Compute Type Option

Branch: `feature_add-gpu-option`

## Summary

Adds `gpu` as a selectable compute type in the Run Monitor's compute-type dropdowns, alongside `standard` and `lambda`.

## Changes

- **`RunDetail.vue`** & **`RunMonitor.vue`** (same changes in both):
  - Added a `DEFAULT_COMPUTE_TYPES` constant (`standard`, `lambda`, `gpu`).
  - Added `withGpu()` so `gpu` is always selectable even when the API-supplied compute-type list omits it.
  - Added `formatComputeTypeLabel()` to render `gpu` as **GPU** and Title-case other types.
  - Applied the new label formatter to both the processor and target compute-type dropdowns.
