### PR TITLE
Fix MEF viewer logic: dedupe asset API calls and harden runtime errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@element-plus/icons-vue": "^2.3.1",
         "@pennsieve-viz/core": "^0.3.3",
         "@pennsieve-viz/micro-ct": "^1.0.72",
-        "@pennsieve-viz/tsviewer": "^1.1.11",
+        "@pennsieve-viz/tsviewer": "^1.1.15",
         "@sigma/node-border": "^3.0.0",
         "@types/d3": "^7.4.3",
         "@types/ramda": "^0.29.10",
@@ -4524,9 +4524,9 @@
       }
     },
     "node_modules/@pennsieve-viz/tsviewer": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@pennsieve-viz/tsviewer/-/tsviewer-1.1.12.tgz",
-      "integrity": "sha512-VThAQseqM8YG75jBA52XpgsZKnBu8Y/fid4wG7evwA3H3E8t6GkCQfvhhxU+se9FDAkuH3LuUl5u6XYxcf+icg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@pennsieve-viz/tsviewer/-/tsviewer-1.1.15.tgz",
+      "integrity": "sha512-Byrd/a53Vp44ePgMTQGnO72in7Z5zfnj10Ui24+b2AGFPAeO5ZwkHoVf1D+aSqevqjwyr7T0F3lYc5aORCgN+Q==",
       "license": "MIT",
       "dependencies": {
         "@element-plus/icons-vue": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@element-plus/icons-vue": "^2.3.1",
     "@pennsieve-viz/core": "^0.3.3",
     "@pennsieve-viz/micro-ct": "^1.0.72",
-    "@pennsieve-viz/tsviewer": "^1.1.11",
+    "@pennsieve-viz/tsviewer": "^1.1.15",
     "@sigma/node-border": "^3.0.0",
     "@types/d3": "^7.4.3",
     "@types/ramda": "^0.29.10",

--- a/src/components/datasets/files/FileDetails/FileDetails.vue
+++ b/src/components/datasets/files/FileDetails/FileDetails.vue
@@ -380,6 +380,7 @@ import IconArrowRight from '@/components/icons/IconArrowRight.vue';
 import IconInfo from '@/components/icons/IconInfo.vue';
 import { useRecordKeyProperties } from '@/composables/useRecordKeyProperties';
 import { useViewerInstance } from '@/composables/useViewerInstance';
+import { useViewerAssets } from '@/composables/useViewerAssets';
 
 export default {
   name: "FileDetails",
@@ -417,9 +418,12 @@ export default {
 
   setup() {
     const { formatRecordKeyValues } = useRecordKeyProperties();
-    
+    const { viewerAssets, removeViewerAsset } = useViewerAssets();
+
     return {
-      formatRecordKeyValues
+      formatRecordKeyValues,
+      viewerAssets,
+      removeViewerAsset,
     };
   },
 
@@ -482,7 +486,6 @@ export default {
       renameDialogVisible: false,
       moveDialogVisible: false,
       connectedRecords: [],
-      viewerAssets: [],
       isDeletingAsset: null,
       showDerivedData: false,
       metadataStore: useMetadataStore()
@@ -1184,20 +1187,10 @@ export default {
 
   watch: {
     fileId: {
-      handler: function (val, oldVal) {
-        if (val) {
-          this.getInstanceDetails();
-          this.fetchConnectedRecords();
-          this.fetchViewerAssets();
-        }
-      },
-      immediate: true,
-    },
-
-    packageDetailsUrl: {
       handler: function (val) {
         if (val) {
           this.getInstanceDetails();
+          this.fetchConnectedRecords();
         }
       },
       immediate: true,
@@ -1340,7 +1333,7 @@ export default {
 
     ...mapActions("filesModule", ["openOffice365File"]),
 
-    ...mapActions("viewerModule", ["setActiveViewer", "fetchPackageViewerAssets"]),
+    ...mapActions("viewerModule", ["setActiveViewer"]),
 
     /**
      * retrieves the string subtype configuration used to populate the AddEditPropertyDialog
@@ -2867,27 +2860,6 @@ export default {
     },
 
     /**
-     * Fetch viewer assets for the current package
-     */
-    async fetchViewerAssets() {
-      if (!this.fileId || !this.datasetId) {
-        this.viewerAssets = []
-        return
-      }
-
-      try {
-        const result = await this.fetchPackageViewerAssets({
-          datasetId: this.datasetId,
-          packageId: this.fileId,
-        })
-        this.viewerAssets = result?.assets || []
-      } catch (err) {
-        console.warn('Failed to fetch viewer assets:', err)
-        this.viewerAssets = []
-      }
-    },
-
-    /**
      * Delete a viewer asset after confirmation
      */
     async deleteViewerAsset(asset) {
@@ -2911,7 +2883,7 @@ export default {
           datasetId: this.datasetId,
           assetId: asset.id,
         })
-        this.viewerAssets = this.viewerAssets.filter(a => a.id !== asset.id)
+        this.removeViewerAsset(asset.id)
         this.$message.success('Asset deleted')
       } catch (err) {
         console.error('Error deleting viewer asset:', err)

--- a/src/components/datasets/files/FileDetails/FileDetails.vue
+++ b/src/components/datasets/files/FileDetails/FileDetails.vue
@@ -1314,9 +1314,6 @@ export default {
 
     // Fetch new data for a given table
     EventBus.$on("refresh-table-data", this.refreshTableData);
-    
-    // Fetch connected records when component mounts
-    this.fetchConnectedRecords();
 
     // Open proper drawer component
     EventBus.$on("add-relationship", this.handleAddRelationship);

--- a/src/components/datasets/files/FileDetails/FileDetails.vue
+++ b/src/components/datasets/files/FileDetails/FileDetails.vue
@@ -1221,13 +1221,25 @@ export default {
 
     relationshipCountsUrl: {
       handler: function (val) {
-        const newRoute = this.$route.path.indexOf("/new") > 0;
-        if (val && !newRoute) {
+        const isNewRoute = this.$route.path.indexOf("/new") > 0;
+        const hasConcepts = Array.isArray(this.concepts) && this.concepts.length > 0;
+        if (val && !isNewRoute && hasConcepts) {
           this.relationships = [];
           this.getRelationshipCounts();
         }
       },
       immediate: true,
+    },
+
+    concepts: {
+      handler: function (newConcepts) {
+        const isNewRoute = this.$route.path.indexOf("/new") > 0;
+        const hasConcepts = Array.isArray(newConcepts) && newConcepts.length > 0;
+        if (this.relationshipCountsUrl && !isNewRoute && hasConcepts) {
+          this.relationships = [];
+          this.getRelationshipCounts();
+        }
+      },
     },
 
     hasConceptsAndRelationships: {
@@ -1553,8 +1565,9 @@ export default {
      */
     getRelationshipCounts: function () {
       const url = this.relationshipCountsUrl;
+      const hasConcepts = Array.isArray(this.concepts) && this.concepts.length > 0;
 
-      if (!url) {
+      if (!url || !hasConcepts) {
         return;
       }
 
@@ -1585,8 +1598,16 @@ export default {
 
             this.isRelationshipsLoading = false;
           })
-          .catch(() => {
-            this.handleXhrError.bind(this);
+          .catch((err) => {
+            this.isRelationshipsLoading = false;
+            // A 404 here means the package has no proxied relations, which is
+            // a valid empty state — don't surface it as a user-facing error.
+            const status = err && err.status;
+            if (status === 404) {
+              this.relationships = [];
+              return;
+            }
+            useHandleXhrError(err);
           });
       });
     },

--- a/src/components/datasets/files/FileDetails/FileDetails.vue
+++ b/src/components/datasets/files/FileDetails/FileDetails.vue
@@ -1235,9 +1235,15 @@ export default {
       handler: function (newConcepts) {
         const isNewRoute = this.$route.path.indexOf("/new") > 0;
         const hasConcepts = Array.isArray(newConcepts) && newConcepts.length > 0;
-        if (this.relationshipCountsUrl && !isNewRoute && hasConcepts) {
+        if (!hasConcepts) {
+          return;
+        }
+        if (this.relationshipCountsUrl && !isNewRoute) {
           this.relationships = [];
           this.getRelationshipCounts();
+        }
+        if (this.stringSubtypeUrl) {
+          this.fetchStringSubtypes();
         }
       },
     },
@@ -1290,7 +1296,8 @@ export default {
 
     stringSubtypeUrl: {
       handler() {
-        if (this.stringSubtypeUrl) {
+        const hasConcepts = Array.isArray(this.concepts) && this.concepts.length > 0;
+        if (this.stringSubtypeUrl && hasConcepts) {
           this.fetchStringSubtypes();
         }
       },
@@ -1351,6 +1358,10 @@ export default {
      * retrieves the string subtype configuration used to populate the AddEditPropertyDialog
      */
     fetchStringSubtypes: function () {
+      const hasConcepts = Array.isArray(this.concepts) && this.concepts.length > 0;
+      if (!hasConcepts) {
+        return;
+      }
       this.stringSubtypeUrl.then((url) => {
         useSendXhr(url)
           .then((subTypes) => {
@@ -1600,13 +1611,6 @@ export default {
           })
           .catch((err) => {
             this.isRelationshipsLoading = false;
-            // A 404 here means the package has no proxied relations, which is
-            // a valid empty state — don't surface it as a user-facing error.
-            const status = err && err.status;
-            if (status === 404) {
-              this.relationships = [];
-              return;
-            }
             useHandleXhrError(err);
           });
       });

--- a/src/components/datasets/files/Metadata/FileMetadataInfo.vue
+++ b/src/components/datasets/files/Metadata/FileMetadataInfo.vue
@@ -387,21 +387,6 @@ export default {
 
 
     /**
-     * Group connected records by model
-     * @returns {Object} Records grouped by model_id
-     */
-    groupedRecords() {
-      const grouped = {};
-      this.connectedRecords.forEach(record => {
-        if (!grouped[record.model_id]) {
-          grouped[record.model_id] = [];
-        }
-        grouped[record.model_id].push(record);
-      });
-      return grouped;
-    },
-
-    /**
      * Get display name for a model
      * @param {String} modelId - The model ID
      * @returns {String} Model display name

--- a/src/components/shared/readme-doc/ReadmeDoc.vue
+++ b/src/components/shared/readme-doc/ReadmeDoc.vue
@@ -88,19 +88,21 @@ export default {
 
   methods: {
     getReadmeDocument: async function(val) {
-
-      useGetToken()
-        .then(token => {
-          const url = `${this.config.api2Url}/readme/docs/${val}`
-          this.sendXhr(url, {
-            method: 'GET',
-            header: {
-              'Authorization': `Bearer ${token}`
-            },
-          }).then( result => {
-            this.content = result
-          })
+      try {
+        const token = await useGetToken()
+        const url = `${this.config.api2Url}/readme/docs/${val}`
+        const result = await this.sendXhr(url, {
+          method: 'GET',
+          header: {
+            'Authorization': `Bearer ${token}`
+          },
         })
+        this.content = result
+      } catch (err) {
+        // No readme doc exists for this slug (commonly 404). Clear content
+        // and stay silent — the help panel just renders empty.
+        this.content = {}
+      }
     }
   }
 }

--- a/src/components/viewer/PsViewer/PsViewer.vue
+++ b/src/components/viewer/PsViewer/PsViewer.vue
@@ -201,6 +201,15 @@ export default {
   },
 
   /**
+   * Clear any stale activeViewer left over from the previous page (e.g.
+   * FileDetails preview) before ViewerPane mounts, so its immediate
+   * watcher doesn't fire a fetch for the wrong package.
+   */
+  created: function () {
+    this.openViewer({});
+  },
+
+  /**
    * Vue lifecycle method
    */
   mounted: function () {

--- a/src/components/viewer/ViewerPane/ViewerPane.vue
+++ b/src/components/viewer/ViewerPane/ViewerPane.vue
@@ -152,7 +152,7 @@ export default {
     pkg: {
       handler: async function (pkg) {
         if (pkg && Object.keys(pkg.content || {}).length > 0) {
-          this.loadViewer(pkg);
+          await this.loadViewer(pkg);
           if (
             pathOr("", ["content", "packageType"], pkg).toLowerCase() ===
             "timeseries"
@@ -264,6 +264,7 @@ export default {
       const pkgId = pathOr("", ["content", "id"], activeViewer);
       const datasetId = pathOr("", ["content", "datasetNodeId"], activeViewer);
       this.viewerAssets = [];
+      this.timeseriesAsset = null;
       if (pkgId && datasetId) {
         try {
           const result = await this.fetchPackageViewerAssets({
@@ -271,6 +272,7 @@ export default {
             packageId: pkgId,
           });
           if (result?.assets?.length > 0) {
+            this.timeseriesAsset = result.assets.find(a => a.asset_type === 'timeseries') || null
             const neuroglancerTypes = ["ome-zarr", "neuroglancer-precomputed"];
             const seen = new Set();
             const ngAssets = result.assets.filter((a) => {

--- a/src/components/viewer/ViewerPane/ViewerPane.vue
+++ b/src/components/viewer/ViewerPane/ViewerPane.vue
@@ -155,20 +155,21 @@ export default {
   },
 
   watch: {
-    pkg: {
-      handler: async function (pkg) {
-        if (pkg && Object.keys(pkg.content || {}).length > 0) {
-          await this.loadViewer(pkg);
-          if (
-            pathOr("", ["content", "packageType"], pkg).toLowerCase() ===
-            "timeseries"
-          ) {
-            this.fetchTimeseriesData();
-          }
+    "pkg.content.id": {
+      handler: async function (packageId) {
+        if (!packageId) {
+          return;
+        }
+        const pkg = this.pkg;
+        await this.loadViewer(pkg);
+        if (
+          pathOr("", ["content", "packageType"], pkg).toLowerCase() ===
+          "timeseries"
+        ) {
+          this.fetchTimeseriesData();
         }
       },
       immediate: true,
-      deep: true,
     },
   },
 

--- a/src/components/viewer/ViewerPane/ViewerPane.vue
+++ b/src/components/viewer/ViewerPane/ViewerPane.vue
@@ -69,6 +69,7 @@ import {
   cleanupViewerStore,
   useViewerInstance,
 } from "@/composables/useViewerInstance";
+import { useViewerAssets } from "@/composables/useViewerAssets";
 
 import "@pennsieve-viz/micro-ct/style.css";
 import "@pennsieve-viz/core/style.css";
@@ -120,6 +121,11 @@ export default {
 
   mixins: [FileTypeMapper, GetFileProperty, ImportHref],
 
+  setup() {
+    const { fetchViewerAssets: fetchPackageViewerAssets } = useViewerAssets();
+    return { fetchPackageViewerAssets };
+  },
+
   props: {
     isPreview: {
       type: Boolean,
@@ -170,7 +176,6 @@ export default {
     ...mapActions("viewerModule", [
       "fetchViewerAssets",
       "fetchFileUrl",
-      "fetchPackageViewerAssets",
       "fetchSourceFiles",
     ]),
 
@@ -267,10 +272,10 @@ export default {
       this.timeseriesAsset = null;
       if (pkgId && datasetId) {
         try {
-          const result = await this.fetchPackageViewerAssets({
+          const result = await this.fetchPackageViewerAssets(
             datasetId,
-            packageId: pkgId,
-          });
+            pkgId
+          );
           if (result?.assets?.length > 0) {
             this.timeseriesAsset = result.assets.find(a => a.asset_type === 'timeseries') || null
             const neuroglancerTypes = ["ome-zarr", "neuroglancer-precomputed"];

--- a/src/composables/useViewerAssets.js
+++ b/src/composables/useViewerAssets.js
@@ -1,0 +1,35 @@
+// @/composables/useViewerAssets.js
+// Single owner of the /packages/assets fetch. Module-level refs are
+// shared across consumers — only ViewerPane.loadViewer calls
+// fetchViewerAssets; FileDetails just reads viewerAssets reactively.
+
+import { ref } from 'vue'
+import { useGetToken } from '@/composables/useGetToken'
+import * as siteConfig from '@/site-config/site.json'
+
+const viewerAssets = ref([])
+
+export function useViewerAssets() {
+  const fetchViewerAssets = async (datasetId, packageId) => {
+    if (!datasetId || !packageId) {
+      viewerAssets.value = []
+      return null
+    }
+
+    const accessToken = await useGetToken()
+    const requestUrl = `${siteConfig.api2Url}/packages/assets?dataset_id=${datasetId}&package_id=${packageId}`
+    const response = await fetch(requestUrl, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    })
+    const result = response.ok ? await response.json() : null
+
+    viewerAssets.value = result?.assets || []
+    return result
+  }
+
+  const removeViewerAsset = (assetId) => {
+    viewerAssets.value = viewerAssets.value.filter((a) => a.id !== assetId)
+  }
+
+  return { viewerAssets, fetchViewerAssets, removeViewerAsset }
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -12,6 +12,7 @@ import filesModule from "./filesModule";
 import uploadModule from "./uploadModule";
 import analysisModule from "./analysisModule";
 import codeReposModule from "./codeReposModule";
+import collectionsModule from "./collectionsModule";
 
 const hashFunction = (key, list) => {
   const obj = {};
@@ -1061,7 +1062,8 @@ export default createStore({
     filesModule,
     uploadModule,
     analysisModule,
-    codeReposModule
+    codeReposModule,
+    collectionsModule
   }
 
 });


### PR DESCRIPTION
  Changes:
  - Dedupe duplicate asset/record API calls in viewer (PsViewer.vue, ViewerPane.vue, FileDetails.vue) via new useViewerAssets composable
  - Harden runtime error handling in ReadmeDoc.vue, FileDetails.vue (models + relationship counts), and collections store
  - Bump tsviewer library version
  - Remove unused method in FileMetadataInfo.vue