### PR TITLE
Deploy - Show Images on Readme 

### DIFF
--- a/src/components/Analysis/Applications/ApplicationDetail.vue
+++ b/src/components/Analysis/Applications/ApplicationDetail.vue
@@ -84,6 +84,10 @@ const isPrivateRepo = computed(
   () => detail.value?.visibility === "private" || detail.value?.isPrivate === true
 );
 
+// Anyone can open a public repo on GitHub. A private repo is only viewable by
+// the owner (others must request permission from the repo owner).
+const canViewOnGitHub = computed(() => !isPrivateRepo.value || isAppOwner.value);
+
 // Keep the local detail in sync when the archive toggle changes status.
 const onArchiveChange = (status) => {
   if (detail.value) detail.value = { ...detail.value, status };
@@ -335,13 +339,13 @@ watch(
             <span class="readme-title">README</span>
             <el-tooltip
               v-if="githubRepoUrl"
-              :content="isAppOwner ? '' : 'This repo is private. Request permission from repo owner to view on Github.'"
+              :content="canViewOnGitHub ? '' : 'This repo is private. Request permission from repo owner to view on Github.'"
               placement="top"
-              :disabled="isAppOwner"
+              :disabled="canViewOnGitHub"
             >
               <span class="github-link-wrap">
                 <a
-                  v-if="isAppOwner"
+                  v-if="canViewOnGitHub"
                   :href="githubRepoUrl"
                   target="_blank"
                   rel="noopener noreferrer"

--- a/src/components/Analysis/Applications/ApplicationDetail.vue
+++ b/src/components/Analysis/Applications/ApplicationDetail.vue
@@ -78,6 +78,12 @@ const isAppOwner = computed(() => {
 // Permissions only apply to private applications.
 const isPublic = computed(() => detail.value?.isPrivate === false);
 
+// Private GitHub repos return 401 from raw.githubusercontent.com, so we can't
+// render their README (or its images) in the browser. Show a link instead.
+const isPrivateRepo = computed(
+  () => detail.value?.visibility === "private" || detail.value?.isPrivate === true
+);
+
 // Keep the local detail in sync when the archive toggle changes status.
 const onArchiveChange = (status) => {
   if (detail.value) detail.value = { ...detail.value, status };
@@ -257,7 +263,14 @@ const loadDetail = async (uuid) => {
 
     if (detailResult.status === "fulfilled") {
       detail.value = detailResult.value;
-      renderReadme(getReadmeContent(detailResult.value?.assets));
+      // Only render the README for public repos. Private repo assets aren't
+      // reachable from the browser, so we surface a GitHub link instead.
+      const detailIsPrivate =
+        detailResult.value?.visibility === "private" ||
+        detailResult.value?.isPrivate === true;
+      if (!detailIsPrivate) {
+        renderReadme(getReadmeContent(detailResult.value?.assets));
+      }
     } else {
       console.error(detailResult.reason);
       detailError.value = "Failed to load application";
@@ -346,7 +359,19 @@ watch(
               </span>
             </el-tooltip>
           </div>
-          <div v-if="!readmeHtml" class="readme-empty">
+          <div v-if="isPrivateRepo" class="readme-empty readme-private">
+            <p>README preview isn't available for private repositories.</p>
+            <a
+              v-if="githubRepoUrl"
+              :href="githubRepoUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="readme-github-link"
+            >
+              View README on GitHub
+            </a>
+          </div>
+          <div v-else-if="!readmeHtml" class="readme-empty">
             No README available
           </div>
           <div v-else class="readme-content" v-html="readmeHtml" />
@@ -641,6 +666,17 @@ watch(
   text-align: center;
   color: theme.$gray_4;
   font-size: 14px;
+}
+
+.readme-private {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+
+  p {
+    margin: 0;
+  }
 }
 
 .readme-content {


### PR DESCRIPTION
# Branch: `feature_show-images-readme`

Handles README rendering for **private GitHub repos** on the Application Detail page.

- **Adds two computed flags:**
  - `isPrivateRepo` — true when `visibility === "private"` or `isPrivate === true`
  - `canViewOnGitHub` — true for public repos, or for the app owner on a private repo
- **Skips README rendering for private repos** in `loadDetail()` — only public repos call `renderReadme(...)`.
- **Shows a fallback panel** for private repos instead of broken markdown: "README preview isn't available for private repositories" plus a "View README on GitHub" link.
- **Gates the GitHub link** by `canViewOnGitHub` (was previously `isAppOwner`), with the existing "request permission from repo owner" tooltip shown to non-owners.
- **Adds `.readme-private` styling** (centered column layout for the fallback message + link).
