### PR TITLE
Feat thumbnail viewer

### DIFF
--- a/src/components/WorkspaceOverview/WorkspaceOverview.vue
+++ b/src/components/WorkspaceOverview/WorkspaceOverview.vue
@@ -24,7 +24,7 @@
 import { computed, markRaw, onMounted } from 'vue'
 import { useStore } from 'vuex'
 import { pathOr } from 'ramda'
-import { StaticDashboard } from 'pennsieve-dashboard'
+import { PennsieveDashboard as StaticDashboard } from 'pennsieve-dashboard'
 import 'pennsieve-dashboard/style.css'
 import ChatWidget from '@/components/Chat/ChatWidget.vue'
 import LinksWidget from './widgets/LinksWidget.vue'

--- a/src/components/datasets/DatasetOverview/DatasetOverview.vue
+++ b/src/components/datasets/DatasetOverview/DatasetOverview.vue
@@ -169,7 +169,7 @@
   import {compose, defaultTo, head, last, pathOr, propOr, split, sum, values} from 'ramda'
 
   import { markRaw } from 'vue'
-  import { StaticDashboard } from 'pennsieve-dashboard'
+  import { PennsieveDashboard as StaticDashboard } from 'pennsieve-dashboard'
   import 'pennsieve-dashboard/style.css'
   import DataCard from '../../shared/DataCard/DataCard.vue'
   import ChecklistItem from '../../shared/ChecklistItem/ChecklistItem.vue'

--- a/src/components/user/code/PublishingDialog.vue
+++ b/src/components/user/code/PublishingDialog.vue
@@ -388,10 +388,8 @@ export default {
     background-color: theme.$purple_2;
   }
 
-  // Keep the modal a stable height across tabs so switching to Permissions
-  // doesn't make the dialog shrink or grow.
   :deep(.el-tabs__content) {
-    min-height: 460px;
+    min-height: 250px;
   }
 }
 

--- a/src/components/viewer/ViewerPane/ViewerPane.vue
+++ b/src/components/viewer/ViewerPane/ViewerPane.vue
@@ -39,6 +39,11 @@
       :pkg="pkg"
       :asset="viewerAssets[parseInt(cmpViewer.split(':')[1])]"
     />
+    <ThumbnailViewer
+      v-else-if="cmpViewer === 'ThumbnailViewer'"
+      ref="viewer"
+      :asset="thumbnailAsset"
+    />
     <CSVViewer
       v-else-if="cmpViewer === 'CSVViewer'"
       ref="viewer"
@@ -127,6 +132,9 @@ export default {
     OmeViewer: defineAsyncComponent(() =>
       import("@pennsieve-viz/micro-ct").then((m) => m.OmeViewer),
     ),
+    ThumbnailViewer: defineAsyncComponent(() =>
+      import("../../viewers/ThumbnailViewer.vue"),
+    ),
   },
 
   mixins: [FileTypeMapper, GetFileProperty, ImportHref],
@@ -156,6 +164,7 @@ export default {
       cmpViewer: "",
       availableViewers: [],
       viewerAssets: [],
+      thumbnailAsset: null,
       isLoading: false,
       omeTiffSource: "",
       omeTiffSlowWarning: false,
@@ -259,6 +268,8 @@ export default {
           return ".Lay Viewer";
         case "TextViewer":
           return "Raw Text";
+        case "ThumbnailViewer":
+          return "Thumbnail";
         default:
           return viewer;
       }
@@ -286,6 +297,7 @@ export default {
       const pkgId = pathOr("", ["content", "id"], activeViewer);
       const datasetId = pathOr("", ["content", "datasetNodeId"], activeViewer);
       this.viewerAssets = [];
+      this.thumbnailAsset = null;
       this.timeseriesAsset = null;
       if (pkgId && datasetId) {
         try {
@@ -317,6 +329,15 @@ export default {
               );
               const filtered = viewers.filter((v) => v !== "UnknownViewer");
               viewers = [...ngViewerNames, ...filtered];
+            }
+
+            // Check for thumbnail asset
+            const thumbAsset = result.assets.find(
+              (a) => a.asset_type === "thumb" && a.status === "ready",
+            );
+            if (thumbAsset) {
+              this.thumbnailAsset = { ...thumbAsset, cloudfront: result.cloudfront };
+              viewers = [...viewers.filter((v) => v !== "UnknownViewer"), "ThumbnailViewer"];
             }
           }
         } catch (err) {

--- a/src/components/viewers/ThumbnailViewer.vue
+++ b/src/components/viewers/ThumbnailViewer.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="thumbnail-viewer">
+    <img
+      v-if="thumbnailUrl"
+      :src="thumbnailUrl"
+      alt="Package thumbnail"
+    >
+    <p v-else class="no-thumbnail">No thumbnail available</p>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ThumbnailViewer',
+
+  props: {
+    asset: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+
+  computed: {
+    thumbnailUrl() {
+      const url = this.asset?.asset_url
+      const id = this.asset?.id
+      const cf = this.asset?.cloudfront
+      if (!url || !id) return ''
+      if (!cf?.policy || !cf?.signature || !cf?.key_pair_id) return url
+
+      const qs = new URLSearchParams({
+        Policy: cf.policy,
+        Signature: cf.signature,
+        'Key-Pair-Id': cf.key_pair_id,
+      })
+      return `${url}thumbnail.png?${qs.toString()}`
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.thumbnail-viewer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+img {
+  display: block;
+  height: auto;
+}
+
+.no-thumbnail {
+  color: #71747c;
+  font-size: 14px;
+}
+</style>

--- a/src/store/viewerModule.js
+++ b/src/store/viewerModule.js
@@ -3,18 +3,11 @@ import {
   propOr,
   propEq,
   findIndex,
-  flatten,
   compose,
-  pluck,
-  pathOr,
-  includes,
-  remove,
   find,
-  map, otherwise
 } from 'ramda'
 import { viewerSidePanelTypes, viewerToolTypes } from '../utils/constants'
 import {useGetToken} from "@/composables/useGetToken";
-import toQueryParams from "@/utils/toQueryParams";
 
 const getLayerIndex = (key, data, viewerAnnotations) => {
   const layerId = propOr('', key, data)
@@ -37,15 +30,12 @@ const initialState = () => ({
   },
   viewerChannels: [],
   viewerAnnotations: [],
-  activeAnnotationLayer: {},
   activeAnnotation: {},
   viewerErrors: {},
   //TODO make strings enum constants
   viewerSidePanelView: viewerSidePanelTypes.INFO_PANEL,
   viewerActiveTool: viewerToolTypes.POINTER,
   viewerMontageScheme: 'NOT_MONTAGED',
-  customMontageMap: [],
-  workspaceMontages: [],
 })
 
 export const state = initialState()
@@ -76,10 +66,6 @@ export const mutations = {
     state.viewerSlideInfo = newSlideInfo
   },
 
-  SET_CHANNELS (state, channels) {
-    state.viewerChannels = channels
-  },
-
   UPDATE_CHANNEL (state, { data, channelIndex }) {
     state.viewerChannels[channelIndex] = data
   },
@@ -88,14 +74,6 @@ export const mutations = {
     state.viewerAnnotations.push(data)
   },
 
-  SET_ACTIVE_ANNOTATION_LAYER (state, data) {
-    state.activeAnnotationLayer = data
-    state.viewerAnnotations.forEach(index => index.selected = false)
-    const layerIndex = findIndex(propEq('id', data), state.viewerAnnotations)
-    state.viewerAnnotations[layerIndex].selected = true
-
-
-  },
   SET_ACTIVE_ANNOTATION (state, data) {
     state.viewerAnnotations.forEach( index =>
       index.annotations.forEach(ann =>
@@ -149,13 +127,6 @@ export const mutations = {
 
   SET_VIEWER_MONTAGE_SCHEME (state, data) {
     state.viewerMontageScheme = data
-  },
-
-  SET_CUSTOM_MONTAGE_MAP (state, data) {
-    state.customMontageMap = data
-  },
-  SET_WORKSPACE_MONTAGES (state, data) {
-    state.workspaceMontages = data
   }
 }
 
@@ -169,8 +140,6 @@ export const actions = {
     commit('SET_SIDE_PANEL', evt),
   setActiveTool: ({ commit }, evt) =>
     commit('SET_ACTIVE_TOOL', evt),
-  setChannels: ({ commit }, evt) => {
-    commit('SET_CHANNELS', evt)},
   updateChannel: ({ commit, state }, channel) => {
     const id = propOr('', 'id', channel)
     const channelIndex = findIndex(propEq('id', id), state.viewerChannels)
@@ -179,8 +148,6 @@ export const actions = {
   },
   createLayer: ({ commit }, evt) =>
     commit('CREATE_LAYER', evt),
-  setActiveAnnotationLayer: ({ commit }, evt) =>
-    commit('SET_ACTIVE_ANNOTATION_LAYER', evt),
   updateLayer: ({ commit, state }, data) => {
     const index = getLayerIndex('id', data, state.viewerAnnotations)
     const layer = Object.assign( state.viewerAnnotations[index], data)
@@ -212,41 +179,6 @@ export const actions = {
   },
   setViewerErrors: ({ commit }, evt) =>
     commit('SET_VIEWER_ERRORS', evt),
-  setViewerMontageScheme: ({commit}, evt) =>
-    commit('SET_VIEWER_MONTAGE_SCHEME', evt),
-  setCustomMontageMap: ({commit}, evt) => {
-    commit('SET_VIEWER_MONTAGE_SCHEME', evt.montageScheme)
-    commit('SET_CUSTOM_MONTAGE_MAP', JSON.parse(evt.customMontageMap))
-  },
-  fetchCloudFrontUrl: async ({rootState}, { packageId, datasetId }) => {
-    try {
-      const token = await useGetToken()
-      const queryParams = toQueryParams({
-        package_id: packageId,
-        dataset_id: datasetId
-      })
-      const url = `${rootState.config.apiUrl}/packages/cloudfront/sign?${queryParams}`
-
-      const myHeaders = new Headers()
-      myHeaders.append('Authorization', 'Bearer ' + token)
-      myHeaders.append('Accept', 'application/json')
-
-      const resp = await fetch(url, {
-        method: 'GET',
-        headers: myHeaders
-      })
-
-      if (resp.ok) {
-        const result = await resp.json()
-        return result.url
-      } else {
-        return Promise.reject(resp)
-      }
-    } catch (err) {
-      return Promise.reject(err)
-    }
-  },
-
   /**
    * Get viewer assets for a package
    * @param {String} packageId
@@ -443,74 +375,9 @@ export const actions = {
     }
   },
 
-  fetchWorkspaceMontages: async ({commit, rootState}, evt) => {
-    try {
-      let endpoint = `${rootState.config.api2Url}/timeseries/montages`
-      const token = await useGetToken()
-
-      const queryParams = toQueryParams({
-        organization_id: rootState.activeOrganization.organization.id
-      })
-
-      const url = `${endpoint}?${queryParams}`
-
-      const myHeaders = new Headers();
-      myHeaders.append('Authorization', 'Bearer ' + token)
-      myHeaders.append('Accept', 'application/json')
-
-      const resp = await fetch(url, {
-        method: 'GET',
-        headers: myHeaders
-      })
-
-      if (resp.ok) {
-        const montages = await resp.json()
-        commit('SET_WORKSPACE_MONTAGES', montages.montages)
-        return montages.montages
-      } else {
-        return Promise.reject(resp)
-      }
-    } catch (err) {
-      return Promise.reject(err)
-    }
-  }
-
 }
 
 export const getters = {
-  workspaceMontages: state => {
-    return state.workspaceMontages
-  },
-  viewerSelectedChannels: state => {
-    return state.viewerChannels.filter(channel => {
-      return channel.selected
-    })
-  },
-  getViewerActiveLayer: state => () => {
-    return find(propEq('selected', true), state.viewerAnnotations)
-  },
-  getAnnotationById: state => (id) => compose(
-    find(propEq('id', id)),
-    flatten,
-    pluck('annotations')
-  )(state.viewerAnnotations),
-
-  getMontageMessageByName: state => (montageName) => {
-
-    switch (montageName) {
-      case "NOT_MONTAGED":
-        return "NOT_MONTAGED"
-      default:
-        const m = find(propEq('name', montageName))(state.workspaceMontages)
-        const channelPairs = m.channelPairs.map(r => {
-          return r.channels
-        })
-
-        return channelPairs
-    }
-
-  },
-
   /**
    * MPP stands for Microns per Pixel
    * This is used to get the density of the slide
@@ -523,8 +390,6 @@ export const getters = {
     find(propEq('category', 'Blackfynn')),
     propOr([{}], 'properties')
   )(state.activeViewer)
-
-
 }
 
 const viewerModule = {

--- a/src/store/viewerModule.spec.js
+++ b/src/store/viewerModule.spec.js
@@ -40,11 +40,6 @@ describe('viewer module', () => {
     expect(testState.viewerSlideInfo.curZoom).toBe(1)
   })
 
-  it('Sets channels when calling setChannels', () => {
-    actions.setChannels(actionParams, [1])
-    expect(testState.viewerChannels).toMatchObject([1])
-  })
-
   it('updates channel when calling updateChannel', () => {
     testState.viewerChannels = [{ id: 123, value: 2 }]
     actions.updateChannel({ ...actionParams, state: testState }, {id: 123, value: 3});


### PR DESCRIPTION
  Title: Add thumbnail viewer for package assets                                                                                                                   
                                                                                                                                                                   
  Body:                                                                                                                                                            
                                                                                                                                                                   
  Summary                                                                                                                                                        

  - Add ThumbnailViewer component that displays thumb type assets from the /packages/assets API as a tab in ViewerPane, with CloudFront-signed URLs
  - Fix StaticDashboard import — renamed to PennsieveDashboard in the pennsieve-dashboard package
  - Remove dead code from viewerModule.js — unused actions, state, getters, and mutations that have been replaced by the Pinia tsviewer store

  Test plan

  - Navigate to a package that has a thumb asset and verify the "Thumbnail" tab appears
  - Verify the thumbnail image loads with CloudFront signing
  - Verify other viewer tabs (Neuroglancer, image, CSV, etc.) still work as expected
  - Verify clicking into a dataset no longer errors on StaticDashboard import