### PR TITLE
fix(cde): configure cdeCatalogUrl for dev/local

### DIFF
--- a/src/site-config/dev.json
+++ b/src/site-config/dev.json
@@ -2,6 +2,7 @@
   "app_domain": "pennsieve.net",
   "apiUrl": "https://api.pennsieve.net",
   "api2Url": "https://api2.pennsieve.net",
+  "cdeCatalogUrl": "https://d1es2ibvcs23vq.cloudfront.net",
   "discoverUrl": "https://api.pennsieve.net/discover",
   "discoverAppUrl": "https://discover.pennsieve.net",
   "zipitUrl": "https://api.pennsieve.net/zipit",

--- a/src/site-config/local.json
+++ b/src/site-config/local.json
@@ -2,6 +2,7 @@
   "app_domain": "localhost",
   "apiUrl": "https://api.pennsieve.net",
   "api2Url": "https://api2.pennsieve.net",
+  "cdeCatalogUrl": "https://d1es2ibvcs23vq.cloudfront.net",
   "zipitUrl": "https://api.pennsieve.net/zipit",
   "discoverUrl": "https://api.pennsieve.net/discover",
   "discoverAppUrl": "https://discover.pennsieve.net",


### PR DESCRIPTION
Follow-up to #753 (merged). The CDE catalog URL was only in the checked-in `site.json` (local copy); the dev build copies `dev.json` → `site.json`, so dev had no `cdeCatalogUrl` and the picker/gallery errored **"CDE catalog URL is not configured"**.

Adds the dev CloudFront catalog URL to `dev.json` and `local.json`. `prod.json`/`clin.json` intentionally left unset until those catalogs are published (no fabricated URL).

Redeploy dev after merge to resolve the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)