### PR TITLE
fix(cde): point cdeCatalogUrl at friendly catalog domain (dev)

### DIFF
--- a/src/site-config/dev.json
+++ b/src/site-config/dev.json
@@ -2,7 +2,7 @@
   "app_domain": "pennsieve.net",
   "apiUrl": "https://api.pennsieve.net",
   "api2Url": "https://api2.pennsieve.net",
-  "cdeCatalogUrl": "https://d1es2ibvcs23vq.cloudfront.net",
+  "cdeCatalogUrl": "https://cde-catalog.pennsieve.net",
   "discoverUrl": "https://api.pennsieve.net/discover",
   "discoverAppUrl": "https://discover.pennsieve.net",
   "zipitUrl": "https://api.pennsieve.net/zipit",

--- a/src/site-config/local.json
+++ b/src/site-config/local.json
@@ -2,7 +2,7 @@
   "app_domain": "localhost",
   "apiUrl": "https://api.pennsieve.net",
   "api2Url": "https://api2.pennsieve.net",
-  "cdeCatalogUrl": "https://d1es2ibvcs23vq.cloudfront.net",
+  "cdeCatalogUrl": "https://cde-catalog.pennsieve.net",
   "zipitUrl": "https://api.pennsieve.net/zipit",
   "discoverUrl": "https://api.pennsieve.net/discover",
   "discoverAppUrl": "https://discover.pennsieve.net",


### PR DESCRIPTION
Follow-up to #754. Dev's `dev.json` still points `cdeCatalogUrl` at the raw CloudFront host (`d1es2ibvcs23vq.cloudfront.net`), which the app CSP no longer allows (infra #486 switched `connect-src` to the friendly domain). Result on dev: the app requests the raw host → CSP-blocked → "Failed to fetch".

This brings the friendly-domain config (`https://cde-catalog.pennsieve.net`) to dev so the fetch target matches the CSP allow-list.

After merge: rebuild/redeploy dev (and invalidate the app's CloudFront if the bundle is edge-cached) so the new `site.json` loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)