### PR TITLE
fix(cde): Resources hub uses shared dashboard card + page padding

### DIFF
--- a/src/components/user/dashboard/UserDashboardCard.vue
+++ b/src/components/user/dashboard/UserDashboardCard.vue
@@ -38,6 +38,8 @@ import IconPrivateEye from "@/components/icons/IconPrivateEye.vue";
 import IconRepository from '../../icons/IconRepository.vue'
 import IconProposals from '../../icons/IconProposals.vue'
 import IconIntegrations from '../../icons/IconIntegrations.vue'
+import IconCollection from '../../icons/IconCollection.vue'
+import IconOverview from '../../icons/IconOverview.vue'
 
 export default {
   name: 'UserDashboardCard',
@@ -57,6 +59,8 @@ export default {
     IconRepository,
     IconProposals,
     IconIntegrations,
+    IconCollection,
+    IconOverview,
   },
 
   props: {
@@ -97,7 +101,9 @@ export default {
         'icon-private-eye': 'IconPrivateEye',
         'repository': 'IconRepository',
         'proposals': 'IconProposals',
-        'integrations': 'IconIntegrations'
+        'integrations': 'IconIntegrations',
+        'cde-catalog': 'IconCollection',
+        'model-templates': 'IconOverview'
       }
       return iconMap[this.icon] || 'IconUser'
     }

--- a/src/router/MyWorkSpace/ResourcesList.vue
+++ b/src/router/MyWorkSpace/ResourcesList.vue
@@ -1,84 +1,62 @@
 <template>
-  <bf-stage>
-    <div class="resources">
-      <div class="resources-head">
-        <h2>Resources</h2>
-        <p class="resources-sub">
-          Shared catalogs you can browse and reuse across your datasets.
-        </p>
-      </div>
-
-      <div class="graph-management-cards">
-        <button @click="open('cde-catalog')">
-          <bf-card
-            title="CDE Catalog"
-            card-copy="Browse common data elements and bundles"
-          >
-            <template #icon>
-              <icon-collection class="card-icon" :height="48" :width="48" />
-            </template>
-          </bf-card>
-        </button>
-
-        <button class="card-disabled" disabled>
-          <bf-card
-            title="Model Templates"
-            card-copy="Browse reusable model templates — coming soon"
-          >
-            <template #icon>
-              <icon-overview class="card-icon" :height="48" :width="96" />
-            </template>
-          </bf-card>
-        </button>
-      </div>
+  <div class="resources-dashboard">
+    <div class="info-section">
+      <p>
+        Shared catalogs of standardized, reusable metadata you can browse and apply across your
+        datasets.
+      </p>
     </div>
-  </bf-stage>
+
+    <div class="dashboard-grid">
+      <user-dashboard-card
+        title="CDE Catalog"
+        description="Browse common data elements and bundles indexed from the NLM CDE Repository"
+        :route="{ name: 'cde-catalog' }"
+        icon="cde-catalog"
+      />
+
+      <user-dashboard-card
+        title="Model Templates"
+        description="Browse reusable model templates"
+        :route="{ name: 'resources' }"
+        icon="model-templates"
+        :coming-soon="true"
+      />
+    </div>
+  </div>
 </template>
 
 <script>
-import BfCard from "@/components/shared/bf-card/BfCard.vue";
-import IconCollection from "@/components/icons/IconCollection.vue";
-import IconOverview from "@/components/icons/IconOverview.vue";
+import UserDashboardCard from "@/components/user/dashboard/UserDashboardCard.vue";
 
 export default {
   name: "ResourcesList",
-  components: { BfCard, IconCollection, IconOverview },
-  methods: {
-    open(name) {
-      this.$router.push({ name });
-    }
-  }
+  components: { UserDashboardCard }
 };
 </script>
 
 <style scoped lang="scss">
 @use '@/styles/theme';
 
-.resources-head {
+.info-section {
   margin-bottom: 24px;
+
+  p {
+    color: theme.$gray_5;
+    max-width: 800px;
+    line-height: 1.5;
+    margin: 0;
+  }
 }
-.resources-sub {
-  color: theme.$gray_4;
-  margin-top: 4px;
-}
-.graph-management-cards {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-  margin-bottom: 48px;
-}
-button {
-  padding: 0;
-  border: none;
-  background: none;
-  text-align: left;
-  cursor: pointer;
-}
-.card-disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-.card-icon {
-  color: theme.$purple_2;
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 24px;
+  max-width: 800px;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/src/router/MyWorkSpace/ResourcesList.vue
+++ b/src/router/MyWorkSpace/ResourcesList.vue
@@ -38,6 +38,11 @@ export default {
 <style scoped lang="scss">
 @use '@/styles/theme';
 
+.resources-dashboard {
+  padding: 32px;
+  max-width: 1200px;
+}
+
 .info-section {
   margin-bottom: 24px;
 


### PR DESCRIPTION
Follow-up to #761 (merged) — two UI-polish commits that landed after that merge.

- **Resources cards use the shared `UserDashboardCard`** (same tile component as the Data Publishing / Account Settings pages) instead of bespoke `bf-card` buttons. Extends the card's icon map with `cde-catalog` + `model-templates`; Model Templates shown as coming-soon.
- **Page padding** on the Resources hub (`padding: 32px; max-width: 1200px`), matching the Data Publishing dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)