### PR TITLE
feat(cde): SUGGEST-1 lexical suggest in the catalog store

### DIFF
--- a/src/stores/cdeCatalogStore.js
+++ b/src/stores/cdeCatalogStore.js
@@ -131,22 +131,56 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
         return loadPromise
     }
 
-    // Free-text search over the slim list columns (name, question text, definition,
-    // source, aliases). This intentionally does NOT match text buried in the heavy
-    // blobs (permissible-value labels, references) — those aren't in the list file.
-    // Returns list records, shortest name first (more-exact matches surface first).
+    // Lexical suggest (SUGGEST-1): rank the loaded catalog against what the user
+    // typed rather than just substring-filtering. Two stages, entirely client-side
+    // over the slim list (no infra, no LLM):
+    //   1. Retrieval — DuckDB pulls candidates matching any query token, biased by a
+    //      coarse SQL score so the LIMIT keeps the best ones (recall).
+    //   2. Rank — score each candidate in JS by weighted token coverage across
+    //      name/question/aliases/definition + exact/prefix bonuses (precision).
+    // Matches only the slim columns (name, question text, definition, source,
+    // aliases) — not text buried in the heavy blobs, which aren't in the list file.
     const SEARCH_COLS = ['cde_name', 'preferred_question_text', 'cde_definition', 'cde_source', 'aliases']
-    const search = async (term, limit = 25) => {
+    // opts.dataType (optional): the property's chosen type; boosts type-compatible CDEs.
+    const search = async (term, limit = 25, opts = {}) => {
         await ensureLoaded()
         const t = (term || '').trim()
-        const n = Number.isFinite(limit) ? Math.max(1, Math.min(200, limit)) : 25
+        const n = Number.isFinite(limit) ? Math.max(1, Math.min(500, limit)) : 25
 
-        const where = t ? `WHERE ${searchPredicate(t)}` : ''
+        // No term → browse sample (shortest names first).
+        if (!t) {
+            const rows = await duck.executeQuery(
+                `SELECT * FROM ${TABLE} ORDER BY length(cde_name) NULLS LAST LIMIT ${n}`,
+                connectionId
+            )
+            return rows.map(mapListRow).filter(Boolean)
+        }
+
+        const tokens = tokenize(t).slice(0, 6)
+        const terms = tokens.length ? tokens : [t.toLowerCase()]
+        const phrase = escapeLiteral(t)
+
+        // Coarse SQL score: phrase-in-name/question dominate; then per-token field hits.
+        const scoreParts = [
+            `(CASE WHEN cde_name ILIKE '%${phrase}%' THEN 200 ELSE 0 END)`,
+            `(CASE WHEN preferred_question_text ILIKE '%${phrase}%' THEN 80 ELSE 0 END)`,
+        ]
+        const ors = []
+        for (const tok of terms) {
+            const lt = escapeLiteral(tok)
+            for (const c of SEARCH_COLS) ors.push(`${c} ILIKE '%${lt}%'`)
+            scoreParts.push(`(CASE WHEN cde_name ILIKE '%${lt}%' THEN 6 ELSE 0 END)`)
+            scoreParts.push(`(CASE WHEN preferred_question_text ILIKE '%${lt}%' THEN 4 ELSE 0 END)`)
+            scoreParts.push(`(CASE WHEN aliases ILIKE '%${lt}%' THEN 3 ELSE 0 END)`)
+            scoreParts.push(`(CASE WHEN cde_definition ILIKE '%${lt}%' THEN 1 ELSE 0 END)`)
+        }
+        const RETRIEVE = 300
         const query =
-            `SELECT * FROM ${TABLE} ${where}` +
-            ` ORDER BY length(cde_name) NULLS LAST LIMIT ${n}`
+            `SELECT * FROM ${TABLE} WHERE ${ors.join(' OR ')}` +
+            ` ORDER BY (${scoreParts.join(' + ')}) DESC, length(cde_name) NULLS LAST LIMIT ${RETRIEVE}`
         const rows = await duck.executeQuery(query, connectionId)
-        return rows.map(mapListRow).filter(Boolean)
+        const cands = rows.map(mapListRow).filter(Boolean)
+        return rankCandidates(cands, t, opts.dataType || '').slice(0, n)
     }
 
     const searchPredicate = (t) => {
@@ -541,4 +575,77 @@ function asList(v) {
 // Render a list of values as a SQL IN-list of quoted literals.
 function sqlList(vals) {
     return vals.map((v) => `'${escapeLiteral(v)}'`).join(', ')
+}
+
+// --- Lexical suggest ranking (SUGGEST-1) --------------------------------------
+
+const SUGGEST_STOP = new Set([
+    'the', 'a', 'an', 'of', 'and', 'or', 'to', 'in', 'for', 'on', 'by', 'with',
+    'is', 'are', 'at', 'as', 'de', 'per',
+])
+
+function norm(s) {
+    return String(s ?? '').toLowerCase().replace(/\s+/g, ' ').trim()
+}
+
+// Split into meaningful lowercased tokens (drop 1-char + stopwords).
+function tokenize(s) {
+    return (norm(s).match(/[a-z0-9]+/g) || []).filter((t) => t.length > 1 && !SUGGEST_STOP.has(t))
+}
+
+// Map a property's chosen type to the CDE's cde_data_type vocabulary.
+function compatibleType(propType, cdeType) {
+    const p = norm(propType)
+    const c = norm(cdeType)
+    if (!p || !c) return false
+    if (p === 'number' || p === 'integer' || p === 'long' || p === 'double') return c === 'number'
+    if (p === 'date' || p === 'datetime') return c === 'date'
+    if (p === 'boolean' || p === 'enum') return c === 'value list'
+    if (p === 'string' || p === 'text') return c === 'text' || c === 'value list'
+    return false
+}
+
+// Score one candidate against the query. Higher = more relevant.
+function scoreCandidate(c, qNorm, qTokens, dataType) {
+    const name = norm(c.cde_name)
+    const question = norm(c.preferred_question_text)
+    const aliases = Array.isArray(c.aliases) ? c.aliases.map(norm).join(' · ') : ''
+    const def = norm(c.cde_definition)
+    const source = norm(c.cde_source)
+
+    let s = 0
+    // Exact / prefix / substring on the label fields.
+    if (name === qNorm || question === qNorm) s += 120
+    else if (name.startsWith(qNorm) || question.startsWith(qNorm)) s += 50
+    else if (name.includes(qNorm) || question.includes(qNorm)) s += 25
+
+    // Weighted token coverage: a token counts once, at its best-scoring field.
+    const fields = [[name, 6], [question, 4], [aliases, 3], [def, 1], [source, 0.5]]
+    let matched = 0
+    for (const t of qTokens) {
+        let best = 0
+        for (const [text, w] of fields) if (text.includes(t)) best = Math.max(best, w)
+        if (best > 0) {
+            s += best
+            matched++
+        }
+    }
+    // Reward covering more of the query (penalize 1-of-3-token matches).
+    const coverage = qTokens.length ? matched / qTokens.length : 0
+    s *= 0.4 + 0.6 * coverage
+
+    if (dataType && compatibleType(dataType, c.cde_data_type)) s += 5
+    // Prefer concise names on ties.
+    s -= Math.min(name.length, 80) * 0.03
+    return s
+}
+
+// Rank retrieved candidates by relevance to the query (stable, best first).
+function rankCandidates(cands, query, dataType) {
+    const qNorm = norm(query)
+    const qTokens = tokenize(query)
+    return cands
+        .map((c, i) => ({ c, i, s: scoreCandidate(c, qNorm, qTokens, dataType) }))
+        .sort((a, b) => b.s - a.s || a.i - b.i)
+        .map((x) => x.c)
 }


### PR DESCRIPTION
Brings **SUGGEST-1** (client-side lexical suggest) to `dev` — it currently lives only on `feat/cde-picker` (#752), so dev was missing it.

`cdeCatalogStore.search` does **retrieve-then-rank**: DuckDB pulls candidates matching any query token (coarse SQL score so the LIMIT keeps the best), then a JS scorer ranks by weighted token coverage across name·question_text·aliases·definition·source + exact/prefix bonuses + a conciseness tiebreak. Entirely client-side over the slim list — zero infra, LLM-free.

Single file (`src/stores/cdeCatalogStore.js`); no overlap with the record-editor value-set change (#765) which is already on dev. After this + the #765 cherry-pick onto `feat/cde-picker`, dev and #752 carry the full CDE feature set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)