### PR TITLE
fix(cde): set prod cdeCatalogUrl (site config)

### DIFF
--- a/src/site-config/prod.json
+++ b/src/site-config/prod.json
@@ -2,6 +2,7 @@
   "app_domain": "pennsieve.io",
   "apiUrl": "https://api.pennsieve.io",
   "api2Url": "https://api2.pennsieve.io",
+  "cdeCatalogUrl": "https://cde-catalog.pennsieve.io",
   "zipitUrl": "https://api.pennsieve.io/zipit",
   "discoverUrl": "https://api.pennsieve.io/discover",
   "discoverAppUrl": "https://discover.pennsieve.io",


### PR DESCRIPTION
**Prod hotfix.** `src/site-config/prod.json` was missing `cdeCatalogUrl`, so the prod app errors: *"CDE catalog URL is not configured (site.cdeCatalogUrl)"*. Sets it to the prod catalog CloudFront `https://cde-catalog.pennsieve.io` (mirrors dev's `cde-catalog.pennsieve.net`).

Direct to `main` since prod deploys from main and the prod app is currently broken without it.

Note: `clin.json` is also missing `cdeCatalogUrl` — out of scope here; add if/when the clinical env needs the CDE catalog.