### PR TITLE
feat(cde): SUGGEST-3 offline eval harness + extract suggest ranker

### DIFF
--- a/eval/cde-suggest/README.md
+++ b/eval/cde-suggest/README.md
@@ -1,0 +1,122 @@
+# CDE suggest eval (SUGGEST-3)
+
+An offline harness that measures the **shipped** CDE lexical-suggest pipeline and
+tells us whether lexical retrieval is good enough, or whether SUGGEST-2
+(embeddings) / SUGGEST-4 (LLM re-rank) are worth building.
+
+It reuses the production ranker directly — `src/stores/cdeSuggestRanker.mjs`, the
+same module `cdeCatalogStore` uses — so the numbers reflect what users actually
+get, not a re-implementation.
+
+## Why this design
+
+- **No human labels needed.** The catalog labels itself: a CDE's own
+  `preferred_question_text` and its `aliases` are exactly what a user would type
+  to find it. Fixtures are derived from the published records.
+- **Circularity guard (the crux).** If the query is a candidate's field and we
+  score that field, the target trivially wins. Every field-set is run in two
+  modes:
+  - `hot` — all fields scored. Upper bound; the field is present verbatim.
+  - `cold` — the queried field is **excluded** from both retrieval and ranking.
+    Measures whether the *other* fields recover the CDE. **Cold is the number
+    that matters.**
+- **Two-stage split.** Recall is decomposed so we know *what* to fix:
+  - `retrieval-recall@RETRIEVE` — did stage-1 (coarse) keep the target at all?
+    Low → the target never enters the candidate set → semantic recall gap →
+    **SUGGEST-2 embeddings**.
+  - `rank-recall@k | retrieved` — given it was retrieved, did stage-2 rank it
+    top-k? Low while retrieval is high → ordering problem → **SUGGEST-4 re-rank**.
+
+## Fidelity
+
+- **Ranking (stage 2)** calls the shipped `rankCandidates` — byte-for-byte the
+  production ranker.
+- **Retrieval (stage 1)** is substring-faithful to the app's DuckDB SQL: same
+  `COARSE` weights, same `ILIKE '%token%'` substring semantics, same
+  `ORDER BY score DESC, length(cde_name)` and `LIMIT RETRIEVE`. It runs as a full
+  JS scan instead of SQL — identical *selection*, just slower. (The app's SQL
+  coarse-score is built from the same `COARSE` constants, so the two cannot
+  drift.)
+
+## Run
+
+```bash
+# Production catalog (the shipped release):
+node eval/cde-suggest/run-eval.mjs --base https://cde-catalog.pennsieve.io
+
+# Dev catalog (default base):
+node eval/cde-suggest/run-eval.mjs
+
+# Full (no sampling) — slower, definitive:
+node eval/cde-suggest/run-eval.mjs --base https://cde-catalog.pennsieve.io --sample 0
+
+# From a local file (e.g. on VPN, where the CDN is unreachable):
+node eval/cde-suggest/run-eval.mjs --jsonl ./cde-records.jsonl
+```
+
+### Options
+
+| flag | default | meaning |
+|---|---|---|
+| `--base <url>` | `https://cde-catalog.pennsieve.net` | catalog CDN base |
+| `--jsonl <path\|url>` | — | explicit `cde` records.jsonl; skips latest/manifest resolution |
+| `--sample <n>` | `1000` | labeled queries per field-set; `0` = all |
+| `--max-aliases <n>` | `8` | aliases considered per CDE |
+| `--seed <n>` | `1337` | PRNG seed (sampling is deterministic) |
+| `--ks <a,b,c>` | `1,5,10,20` | recall@k cutoffs |
+| `--out <path>` | `eval/cde-suggest/last-report.json` | JSON report path |
+
+### Getting a local records.jsonl (VPN)
+
+The catalog CDN is blocked on the Pennsieve VPN. Off-VPN, download once:
+
+```bash
+BASE=https://cde-catalog.pennsieve.io
+CV=$(curl -s $BASE/cde/latest.json | python3 -c 'import sys,json;print(json.load(sys.stdin)["catalog_version"])')
+V=$(curl -s $BASE/cde/versions/$CV/manifest.json | python3 -c 'import sys,json;print(next(m["version"] for m in json.load(sys.stdin)["models"] if m["name"]=="cde"))')
+curl -s -o cde-records.jsonl $BASE/cde/versions/$CV/metadata/models/cde/versions/$V/records.jsonl
+```
+
+## Output
+
+A table (per field-set × mode), field fill-rates (SUGGEST-5 signal — how many
+CDEs even have a question / aliases to match on), and a decision verdict with
+bottleneck attribution. Full detail is written to the `--out` JSON.
+
+Interpreting the verdict (driven by **cold** recall@5):
+
+| cold recall@5 | verdict |
+|---|---|
+| ≥ 85% | lexical sufficient — ship SUGGEST-1; SUGGEST-2/4 low priority |
+| 60–85% | lexical decent — invest in the tail (SUGGEST-2 and/or SUGGEST-4) |
+| < 60% | lexical insufficient — prioritize SUGGEST-2 (embeddings) |
+
+`report-prod.json` in this directory is a checked-in snapshot from a
+representative run (see below).
+
+## Results — prod `20260715T161304Z` (23,350 CDEs, 1,500 sampled queries/set)
+
+| field-set | mode | recall@1 | recall@5 | recall@20 | MRR | retrieval-recall@300 |
+|---|---|---|---|---|---|---|
+| question | hot | 98.7% | 100.0% | 100.0% | 0.993 | 100.0% |
+| question | **cold** | 69.7% | 79.4% | 82.4% | 0.740 | 84.5% |
+| aliases | hot | 85.1% | 97.5% | 99.2% | 0.909 | 99.7% |
+| aliases | **cold** | 62.3% | 82.0% | 89.5% | 0.711 | 95.3% |
+
+**Verdict: LEXICAL DECENT** (cold recall@5 ≈ 80.7%) — good enough to ship as the
+default, with a clear, *field-specific* upgrade path:
+
+- **question text is RETRIEVAL-limited** — cold retrieval-recall caps at 84.5%, so
+  ~15% of the time the right CDE never enters the candidate set. Substring lexical
+  can't bridge paraphrase/synonymy (a user's phrasing vs. the curated question).
+  → **SUGGEST-2 (embeddings)** is where the return is.
+- **aliases are RANKING-limited** — the target is retrieved 95.3% of the time but
+  only ranked #1 for 62.3% of queries (rank-recall@5|retrieved ≈ 86%). Candidates
+  are present, just mis-ordered. → **SUGGEST-4 (LLM re-rank of the top-N)** would
+  lift precision@1 without new recall infrastructure.
+
+**Fill-rate caveat (SUGGEST-5).** Only **29.6%** of CDEs have a
+`preferred_question_text` and **7.8%** have `aliases`; every CDE has a name +
+definition. So the suggest quality above is measured on the minority of CDEs that
+carry rich matchable text — improving field coverage (SUGGEST-5) likely moves the
+needle as much as a better model.

--- a/eval/cde-suggest/report-prod.json
+++ b/eval/cde-suggest/report-prod.json
@@ -1,0 +1,159 @@
+{
+  "generated_at": "2026-07-15T22:04:08.770Z",
+  "catalog_version": "20260715T161304Z",
+  "catalog_records": 23350,
+  "candidates_with_pid": 23350,
+  "retrieve_depth": 300,
+  "sample_per_field": 1500,
+  "ks": [
+    1,
+    5,
+    10,
+    20
+  ],
+  "field_fill_rates": {
+    "cde_name": {
+      "filled": 23350,
+      "total": 23350,
+      "pct": 100
+    },
+    "preferred_question_text": {
+      "filled": 6909,
+      "total": 23350,
+      "pct": 29.6
+    },
+    "cde_definition": {
+      "filled": 23350,
+      "total": 23350,
+      "pct": 100
+    },
+    "cde_source": {
+      "filled": 23350,
+      "total": 23350,
+      "pct": 100
+    },
+    "aliases": {
+      "filled": 1811,
+      "total": 23350,
+      "pct": 7.8
+    },
+    "cde_data_type": {
+      "filled": 23350,
+      "total": 23350,
+      "pct": 100
+    }
+  },
+  "results": [
+    {
+      "field": "preferred_question_text",
+      "mode": "hot",
+      "n_queries": 1500,
+      "recall": {
+        "1": 0.9867,
+        "5": 1,
+        "10": 1,
+        "20": 1
+      },
+      "precision_at_1": 0.9867,
+      "mrr": 0.9927,
+      "retrieval_recall_at_RETRIEVE": 1,
+      "rank_recall_given_retrieved": {
+        "1": 0.9867,
+        "5": 1,
+        "10": 1,
+        "20": 1
+      },
+      "labeled_total": 6556
+    },
+    {
+      "field": "preferred_question_text",
+      "mode": "cold",
+      "n_queries": 1500,
+      "recall": {
+        "1": 0.6967,
+        "5": 0.794,
+        "10": 0.8113,
+        "20": 0.824
+      },
+      "precision_at_1": 0.6967,
+      "mrr": 0.74,
+      "retrieval_recall_at_RETRIEVE": 0.8453,
+      "rank_recall_given_retrieved": {
+        "1": 0.8241,
+        "5": 0.9393,
+        "10": 0.9598,
+        "20": 0.9748
+      },
+      "labeled_total": 6556
+    },
+    {
+      "field": "aliases",
+      "mode": "hot",
+      "n_queries": 1500,
+      "recall": {
+        "1": 0.8507,
+        "5": 0.9753,
+        "10": 0.9867,
+        "20": 0.992
+      },
+      "precision_at_1": 0.8507,
+      "mrr": 0.9094,
+      "retrieval_recall_at_RETRIEVE": 0.9973,
+      "rank_recall_given_retrieved": {
+        "1": 0.8529,
+        "5": 0.9779,
+        "10": 0.9893,
+        "20": 0.9947
+      },
+      "labeled_total": 1901
+    },
+    {
+      "field": "aliases",
+      "mode": "cold",
+      "n_queries": 1500,
+      "recall": {
+        "1": 0.6227,
+        "5": 0.82,
+        "10": 0.8587,
+        "20": 0.8947
+      },
+      "precision_at_1": 0.6227,
+      "mrr": 0.7114,
+      "retrieval_recall_at_RETRIEVE": 0.9533,
+      "rank_recall_given_retrieved": {
+        "1": 0.6531,
+        "5": 0.8601,
+        "10": 0.9007,
+        "20": 0.9385
+      },
+      "labeled_total": 1901
+    }
+  ],
+  "decision": {
+    "verdict": "LEXICAL DECENT — worth investing in the tail (SUGGEST-2 embeddings and/or SUGGEST-4 re-rank).",
+    "cold_recall_at_5": 0.807,
+    "cold_recall_at_20": 0.8594,
+    "cold_mrr": 0.7257,
+    "bottlenecks": [
+      {
+        "field": "preferred_question_text",
+        "kind": "retrieval",
+        "retrieval_recall": 0.8453,
+        "rank_recall_at_5_given_retrieved": 0.9393,
+        "hit_at_1": 0.6967
+      },
+      {
+        "field": "aliases",
+        "kind": "ranking",
+        "retrieval_recall": 0.9533,
+        "rank_recall_at_5_given_retrieved": 0.8601,
+        "hit_at_1": 0.6227
+      }
+    ],
+    "notes": [
+      "question: RETRIEVAL-limited — cold retrieval-recall@300=84.5% (target absent from candidates 15.5% of the time). Substring lexical misses paraphrase/synonymy → SUGGEST-2 embeddings.",
+      "aliases: RANKING-limited — target retrieved 95.3% of the time, but rank-recall@5|retrieved=86.0% and hit@1=62.3%. Candidates present, mis-ordered → SUGGEST-4 LLM re-rank of the top-N.",
+      "overall (cold, avg of field-sets): recall@5=80.7%  recall@20=85.9%  MRR=0.726"
+    ]
+  }
+}

--- a/eval/cde-suggest/run-eval.mjs
+++ b/eval/cde-suggest/run-eval.mjs
@@ -1,0 +1,478 @@
+#!/usr/bin/env node
+// SUGGEST-3 — offline eval harness for the CDE lexical suggest.
+//
+// Measures the SHIPPED retrieve-then-rank pipeline (src/stores/cdeSuggestRanker.mjs,
+// the same module the picker uses) against labeled fixtures derived from the
+// published catalog itself, and prints a decision rubric: is lexical good enough,
+// or is the return on SUGGEST-2 (embeddings) / SUGGEST-4 (LLM re-rank) worth it?
+//
+// Labels (no human annotation needed — the catalog supplies them):
+//   • preferred_question_text → CDE : typing a CDE's own question text should
+//     surface that CDE. This is what the picker's "suggest as you type" does.
+//   • aliases → CDE                 : typing a known alias should surface the CDE.
+//
+// Circularity guard (the crux). If the query IS a candidate's field and we score
+// that field, the target trivially wins — a meaningless 100%. So we run two modes:
+//   • hot  : all fields scored (upper bound; the field is present verbatim).
+//   • cold : the queried field is EXCLUDED from retrieval + ranking, measuring
+//            whether the OTHER fields (name/definition/source/[aliases]) recover
+//            the CDE. Cold is the number that should drive the decision.
+//
+// Two-stage split. recall is decomposed into:
+//   • retrieval-recall@RETRIEVE : did stage-1 (coarse) keep the target at all?
+//   • rank-recall@k | retrieved : given it was retrieved, did stage-2 rank it top-k?
+// If retrieval is the bottleneck → better recall wanted (embeddings, SUGGEST-2).
+// If ranking is the bottleneck → better ordering wanted (LLM re-rank, SUGGEST-4).
+//
+// Pure Node, no new deps. Data source: the published records.jsonl (fetched from
+// the catalog CDN or a local file). See eval/cde-suggest/README.md.
+//
+// NOTE: retrieval here is substring-faithful to the app's SQL WHERE/coarse-score
+// (same COARSE weights, same ILIKE-substring semantics) but runs a full JS scan
+// instead of DuckDB — identical selection, just slower. Ranking calls the shipped
+// rankCandidates directly, so stage-2 is byte-for-byte the production ranker.
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+    SEARCH_COLS,
+    RETRIEVE,
+    COARSE,
+    norm,
+    tokenize,
+    rankCandidates,
+} from '../../src/stores/cdeSuggestRanker.mjs'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+
+// ---- args -------------------------------------------------------------------
+function parseArgs(argv) {
+    const a = {
+        base: 'https://cde-catalog.pennsieve.net', // dev catalog CDN
+        jsonl: '', // explicit records.jsonl path/url (overrides base resolution)
+        cv: '', // catalog_version label when using --jsonl (else resolved from base)
+        sample: 1000, // labeled queries per field-set (0 = all)
+        maxAliases: 8, // aliases considered per CDE (bounds alias fixtures)
+        seed: 1337,
+        ks: [1, 5, 10, 20],
+        out: resolve(HERE, 'last-report.json'),
+    }
+    for (let i = 2; i < argv.length; i++) {
+        const [k, vRaw] = argv[i].includes('=') ? argv[i].split(/=(.*)/s) : [argv[i], argv[i + 1]]
+        const takeNext = () => (argv[i].includes('=') ? vRaw : argv[++i])
+        switch (k) {
+            case '--base': a.base = takeNext(); break
+            case '--jsonl': a.jsonl = takeNext(); break
+            case '--cv': a.cv = takeNext(); break
+            case '--sample': a.sample = Number(takeNext()); break
+            case '--max-aliases': a.maxAliases = Number(takeNext()); break
+            case '--seed': a.seed = Number(takeNext()); break
+            case '--ks': a.ks = takeNext().split(',').map(Number).filter((n) => n > 0); break
+            case '--out': a.out = resolve(process.cwd(), takeNext()); break
+            case '--help': case '-h': a.help = true; break
+            default: if (k.startsWith('--')) console.error(`(ignoring unknown arg ${k})`)
+        }
+    }
+    return a
+}
+
+const HELP = `SUGGEST-3 CDE suggest eval
+
+Usage: node eval/cde-suggest/run-eval.mjs [options]
+
+  --base <url>        catalog CDN base (default https://cde-catalog.pennsieve.net)
+  --jsonl <path|url>  explicit cde records.jsonl (skips latest/manifest resolution)
+  --cv <version>      catalog_version label for the report when using --jsonl
+  --sample <n>        labeled queries per field-set; 0 = all (default 1000)
+  --max-aliases <n>   aliases considered per CDE (default 8)
+  --seed <n>          PRNG seed for sampling (default 1337)
+  --ks <a,b,c>        recall@k cutoffs (default 1,5,10,20)
+  --out <path>        JSON report output (default eval/cde-suggest/last-report.json)
+
+Data: fetches {base}/cde/latest.json -> manifest.json -> the cde model's
+records.jsonl, or reads --jsonl directly. A local file may be plain .jsonl.`
+
+// ---- deterministic sampling -------------------------------------------------
+function mulberry32(seed) {
+    let s = seed >>> 0
+    return () => {
+        s |= 0; s = (s + 0x6d2b79f5) | 0
+        let t = Math.imul(s ^ (s >>> 15), 1 | s)
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    }
+}
+function sampleN(arr, n, rnd) {
+    if (!n || n >= arr.length) return arr
+    // Partial Fisher-Yates on a copy — first n are a uniform sample.
+    const a = arr.slice()
+    for (let i = 0; i < n; i++) {
+        const j = i + Math.floor(rnd() * (a.length - i))
+        ;[a[i], a[j]] = [a[j], a[i]]
+    }
+    return a.slice(0, n)
+}
+
+// ---- load catalog -----------------------------------------------------------
+async function fetchText(url) {
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(`GET ${url} -> ${res.status} ${res.statusText}`)
+    return res.text()
+}
+async function fetchJson(url) {
+    return JSON.parse(await fetchText(url))
+}
+
+async function resolveJsonlUrl(base) {
+    const b = base.replace(/\/+$/, '')
+    const latest = await fetchJson(`${b}/cde/latest.json`)
+    const cv = latest.catalog_version
+    if (!cv) throw new Error('latest.json has no catalog_version')
+    const manifest = await fetchJson(`${b}/cde/versions/${cv}/manifest.json`)
+    const models = Object.fromEntries((manifest.models || []).map((m) => [m.name, m.version]))
+    if (!models.cde) throw new Error('manifest has no cde model')
+    return {
+        cv,
+        url: `${b}/cde/versions/${cv}/metadata/models/cde/versions/${models.cde}/records.jsonl`,
+    }
+}
+
+// Parse one records.jsonl body → array of the `data` payloads (the CDE records).
+// Publish format is one {"id":..,"data":<record>} object per line; tolerate a
+// bare record object per line too.
+function parseJsonl(text) {
+    const out = []
+    for (const line of text.split('\n')) {
+        const s = line.trim()
+        if (!s) continue
+        let obj
+        try {
+            obj = JSON.parse(s)
+        } catch {
+            continue
+        }
+        const rec = obj && typeof obj === 'object' && 'data' in obj ? obj.data : obj
+        if (rec && typeof rec === 'object') out.push(rec)
+    }
+    return out
+}
+
+async function loadCatalog(args) {
+    let cv = args.cv || 'unknown'
+    let text
+    if (args.jsonl) {
+        if (/^https?:\/\//.test(args.jsonl)) {
+            text = await fetchText(args.jsonl)
+        } else {
+            text = await readFile(resolve(process.cwd(), args.jsonl), 'utf8')
+        }
+    } else {
+        const r = await resolveJsonlUrl(args.base)
+        cv = r.cv
+        console.error(`resolved catalog ${cv} -> ${r.url}`)
+        text = await fetchText(r.url)
+    }
+    const records = parseJsonl(text)
+    return { cv, records }
+}
+
+// ---- candidate model --------------------------------------------------------
+// A candidate carries exactly the fields the ranker reads. We also precompute
+// normalized per-column strings once (nname/nquestion/naliases/ndef/nsource) so
+// the full-scan retrieval doesn't re-normalize per query.
+function buildCandidates(records) {
+    const cands = []
+    for (const r of records) {
+        const pid = r.persistent_id
+        if (!pid) continue
+        const aliases = Array.isArray(r.aliases) ? r.aliases : []
+        const cand = {
+            id: r.id ?? pid,
+            persistent_id: pid,
+            cde_name: r.cde_name ?? null,
+            preferred_question_text: r.preferred_question_text ?? null,
+            cde_definition: r.cde_definition ?? null,
+            cde_source: r.cde_source ?? null,
+            cde_data_type: r.cde_data_type ?? null,
+            aliases,
+        }
+        const naliases = aliases.map(norm).join(' · ')
+        cand._n = {
+            cde_name: norm(cand.cde_name),
+            preferred_question_text: norm(cand.preferred_question_text),
+            aliases: naliases,
+            cde_definition: norm(cand.cde_definition),
+            cde_source: norm(cand.cde_source),
+        }
+        cand._nameLen = cand._n.cde_name.length || Infinity
+        cands.push(cand)
+    }
+    return cands
+}
+
+// ---- retrieval (full scan, substring-faithful to the app's SQL) -------------
+// cols = the search columns in play (cold mode drops the queried field).
+// A candidate qualifies (SQL WHERE) if any token is a substring of any allowed
+// column; its coarse score uses the shared COARSE weights.
+function retrieve(cands, phrase, terms, cols) {
+    const allow = new Set(cols)
+    const phraseCols = Object.keys(COARSE.phrase).filter((c) => allow.has(c))
+    const tokenCols = Object.keys(COARSE.token).filter((c) => allow.has(c))
+    const whereCols = SEARCH_COLS.filter((c) => allow.has(c))
+
+    const scored = []
+    for (const c of cands) {
+        const n = c._n
+        // WHERE: any token in any allowed column.
+        let qualifies = false
+        for (const col of whereCols) {
+            const text = n[col]
+            if (!text) continue
+            for (const tok of terms) if (text.includes(tok)) { qualifies = true; break }
+            if (qualifies) break
+        }
+        if (!qualifies) continue
+        // Coarse score.
+        let s = 0
+        for (const col of phraseCols) if (n[col].includes(phrase)) s += COARSE.phrase[col]
+        for (const tok of terms) {
+            for (const col of tokenCols) if (n[col].includes(tok)) s += COARSE.token[col]
+        }
+        scored.push([c, s, c._nameLen])
+    }
+    scored.sort((a, b) => b[1] - a[1] || a[2] - b[2])
+    return scored.slice(0, RETRIEVE).map((x) => x[0])
+}
+
+// ---- fixtures ---------------------------------------------------------------
+// A field-set maps a display field to labeled (query -> relevant pids). Multiple
+// CDEs can share a question/alias, so relevance is a set; a query "hits" at k if
+// ANY relevant pid is in the top-k (first-relevant rank drives MRR).
+function buildFixtures(cands, field, maxAliases) {
+    const byQuery = new Map() // normQuery -> { query, relevant:Set<pid> }
+    const add = (raw, pid) => {
+        const q = String(raw ?? '')
+        if (norm(q).length < 2) return
+        const k = norm(q)
+        let e = byQuery.get(k)
+        if (!e) { e = { query: q, relevant: new Set() }; byQuery.set(k, e) }
+        e.relevant.add(pid)
+    }
+    for (const c of cands) {
+        if (field === 'aliases') {
+            for (const al of c.aliases.slice(0, maxAliases)) add(al, c.persistent_id)
+        } else {
+            add(c[field], c.persistent_id)
+        }
+    }
+    return [...byQuery.values()]
+}
+
+// ---- eval one field-set × mode ----------------------------------------------
+function evalSet(cands, fixtures, field, mode, ks) {
+    const cold = mode === 'cold'
+    const cols = cold ? SEARCH_COLS.filter((c) => c !== field) : SEARCH_COLS
+    const exclude = cold ? new Set([field]) : new Set()
+    const maxK = Math.max(...ks)
+
+    let n = 0
+    let retrievalHits = 0 // relevant present in the retrieved set
+    let mrr = 0
+    const recallAtK = Object.fromEntries(ks.map((k) => [k, 0])) // overall
+    const rankRecallAtK = Object.fromEntries(ks.map((k) => [k, 0])) // among retrieved
+
+    for (const fx of fixtures) {
+        const tokens = tokenize(fx.query).slice(0, 6)
+        const terms = tokens.length ? tokens : [fx.query.toLowerCase()]
+        const phrase = norm(fx.query)
+
+        const retrieved = retrieve(cands, phrase, terms, cols)
+        const inRetrieved = retrieved.some((c) => fx.relevant.has(c.persistent_id))
+
+        // Stage-2: the shipped ranker over the retrieved candidates.
+        const ranked = rankCandidates(retrieved, fx.query, '', exclude)
+        let rank = Infinity
+        for (let i = 0; i < ranked.length; i++) {
+            if (fx.relevant.has(ranked[i].persistent_id)) { rank = i + 1; break }
+        }
+
+        n++
+        if (inRetrieved) retrievalHits++
+        if (rank !== Infinity) mrr += 1 / rank
+        for (const k of ks) {
+            if (rank <= k) recallAtK[k]++
+            if (inRetrieved && rank <= k) rankRecallAtK[k]++
+        }
+        void maxK
+    }
+
+    const div = (x) => (n ? x / n : 0)
+    const divR = (x) => (retrievalHits ? x / retrievalHits : 0)
+    return {
+        field,
+        mode,
+        n_queries: n,
+        recall: Object.fromEntries(ks.map((k) => [k, +div(recallAtK[k]).toFixed(4)])),
+        precision_at_1: +div(recallAtK[1] || 0).toFixed(4), // == hit@1 (single/first relevant)
+        mrr: +div(mrr).toFixed(4),
+        retrieval_recall_at_RETRIEVE: +div(retrievalHits).toFixed(4),
+        rank_recall_given_retrieved: Object.fromEntries(ks.map((k) => [k, +divR(rankRecallAtK[k]).toFixed(4)])),
+    }
+}
+
+// ---- field fill-rates (SUGGEST-5 overlap) -----------------------------------
+function fillRates(cands) {
+    const total = cands.length
+    const nonEmpty = (v) => (Array.isArray(v) ? v.length > 0 : !!(v && String(v).trim()))
+    const fields = ['cde_name', 'preferred_question_text', 'cde_definition', 'cde_source', 'aliases', 'cde_data_type']
+    const out = {}
+    for (const f of fields) {
+        const c = cands.reduce((acc, x) => acc + (nonEmpty(x[f]) ? 1 : 0), 0)
+        out[f] = { filled: c, total, pct: total ? +(100 * c / total).toFixed(1) : 0 }
+    }
+    return out
+}
+
+// ---- decision rubric --------------------------------------------------------
+// Drive the recommendation off the COLD numbers (the honest ones). Distinguish a
+// retrieval bottleneck (→ SUGGEST-2 embeddings) from a ranking bottleneck
+// (→ SUGGEST-4 LLM re-rank).
+function rubric(results) {
+    const cold = results.filter((r) => r.mode === 'cold')
+    if (!cold.length) return { verdict: 'no cold results', notes: [] }
+    const avg = (sel) => cold.reduce((a, r) => a + sel(r), 0) / cold.length
+    const r5 = avg((r) => r.recall[5] ?? 0)
+    const r20 = avg((r) => r.recall[20] ?? 0)
+    const mrr = avg((r) => r.mrr)
+
+    let verdict
+    if (r5 >= 0.85) {
+        verdict = 'LEXICAL SUFFICIENT — ship SUGGEST-1 as the default; SUGGEST-2/4 low priority.'
+    } else if (r5 >= 0.6) {
+        verdict = 'LEXICAL DECENT — worth investing in the tail (SUGGEST-2 embeddings and/or SUGGEST-4 re-rank).'
+    } else {
+        verdict = 'LEXICAL INSUFFICIENT — prioritize SUGGEST-2 (embeddings) for semantic recall.'
+    }
+
+    // Per-field bottleneck attribution — the two field-sets often fail for
+    // OPPOSITE reasons (retrieval vs ranking), so averaging would hide the
+    // actionable signal. A low retrieval-recall means the target never enters
+    // the candidate set (semantic gap → SUGGEST-2); a high retrieval-recall with
+    // weak top-k means candidates are present but mis-ordered (→ SUGGEST-4).
+    const bottlenecks = []
+    const notes = []
+    for (const r of cold) {
+        const retr = r.retrieval_recall_at_RETRIEVE
+        const rg5 = r.rank_recall_given_retrieved[5] ?? 0
+        const r1 = r.recall[1] ?? 0
+        const label = r.field.replace('preferred_question_text', 'question')
+        let kind, note
+        if (retr < 0.85) {
+            kind = 'retrieval'
+            note = `${label}: RETRIEVAL-limited — cold retrieval-recall@${RETRIEVE}=${pctv(retr)} (target absent from candidates ${pctv(1 - retr)} of the time). Substring lexical misses paraphrase/synonymy → SUGGEST-2 embeddings.`
+        } else if (rg5 < 0.9 || r1 < 0.75) {
+            kind = 'ranking'
+            note = `${label}: RANKING-limited — target retrieved ${pctv(retr)} of the time, but rank-recall@5|retrieved=${pctv(rg5)} and hit@1=${pctv(r1)}. Candidates present, mis-ordered → SUGGEST-4 LLM re-rank of the top-N.`
+        } else {
+            kind = 'none'
+            note = `${label}: lexical strong — retrieval-recall=${pctv(retr)}, recall@5=${pctv(r.recall[5] ?? 0)}.`
+        }
+        bottlenecks.push({ field: r.field, kind, retrieval_recall: retr, rank_recall_at_5_given_retrieved: rg5, hit_at_1: r1 })
+        notes.push(note)
+    }
+    notes.push(`overall (cold, avg of field-sets): recall@5=${pctv(r5)}  recall@20=${pctv(r20)}  MRR=${mrr.toFixed(3)}`)
+    return {
+        verdict,
+        cold_recall_at_5: +r5.toFixed(4),
+        cold_recall_at_20: +r20.toFixed(4),
+        cold_mrr: +mrr.toFixed(4),
+        bottlenecks,
+        notes,
+    }
+}
+function pctv(x) { return `${(100 * x).toFixed(1)}%` }
+
+// ---- reporting --------------------------------------------------------------
+function pct(x) { return `${(100 * x).toFixed(1)}%` }
+function printTable(results, ks) {
+    const head = ['field', 'mode', 'n', ...ks.map((k) => `R@${k}`), 'MRR', `retr@${RETRIEVE}`]
+    const rows = results.map((r) => [
+        r.field.replace('preferred_question_text', 'question'),
+        r.mode,
+        String(r.n_queries),
+        ...ks.map((k) => pct(r.recall[k] ?? 0)),
+        r.mrr.toFixed(3),
+        pct(r.retrieval_recall_at_RETRIEVE),
+    ])
+    const widths = head.map((h, i) => Math.max(h.length, ...rows.map((row) => row[i].length)))
+    const fmt = (cells) => cells.map((c, i) => c.padEnd(widths[i])).join('  ')
+    console.log('\n' + fmt(head))
+    console.log(widths.map((w) => '-'.repeat(w)).join('  '))
+    for (const row of rows) console.log(fmt(row))
+}
+
+// ---- main -------------------------------------------------------------------
+async function main() {
+    const args = parseArgs(process.argv)
+    if (args.help) { console.log(HELP); return }
+
+    console.error('loading catalog…')
+    const { cv, records } = await loadCatalog(args)
+    const cands = buildCandidates(records)
+    console.error(`catalog ${cv}: ${records.length} records, ${cands.length} with persistent_id`)
+    if (!cands.length) throw new Error('no candidates with persistent_id — wrong data source?')
+
+    const rnd = mulberry32(args.seed)
+    const fills = fillRates(cands)
+    const results = []
+    for (const field of ['preferred_question_text', 'aliases']) {
+        const all = buildFixtures(cands, field, args.maxAliases)
+        const fixtures = sampleN(all, args.sample, rnd)
+        console.error(
+            `field ${field}: ${all.length} labeled queries` +
+            (fixtures.length < all.length ? ` (sampling ${fixtures.length})` : ''),
+        )
+        if (!fixtures.length) continue
+        for (const mode of ['hot', 'cold']) {
+            const r = evalSet(cands, fixtures, field, mode, args.ks)
+            r.labeled_total = all.length
+            results.push(r)
+        }
+    }
+
+    const decision = rubric(results)
+    const report = {
+        generated_at: new Date().toISOString(),
+        catalog_version: cv,
+        catalog_records: records.length,
+        candidates_with_pid: cands.length,
+        retrieve_depth: RETRIEVE,
+        sample_per_field: args.sample,
+        ks: args.ks,
+        field_fill_rates: fills,
+        results,
+        decision,
+    }
+
+    printTable(results, args.ks)
+    console.log('\nField fill-rates (SUGGEST-5 signal):')
+    for (const [f, s] of Object.entries(fills)) console.log(`  ${f.padEnd(24)} ${String(s.filled).padStart(7)} / ${s.total}  (${s.pct}%)`)
+    console.log('\nDecision:')
+    console.log('  ' + decision.verdict)
+    for (const note of decision.notes) console.log('  • ' + note)
+
+    if (!existsSync(dirname(args.out))) await mkdir(dirname(args.out), { recursive: true })
+    await writeFile(args.out, JSON.stringify(report, null, 2))
+    console.log(`\nJSON report → ${args.out}`)
+}
+
+main().catch((e) => {
+    console.error('\nEVAL FAILED:', e?.message || e)
+    if (String(e?.message || e).includes('fetch') || String(e).includes('ENOTFOUND') || String(e).includes('403')) {
+        console.error('  (catalog CDN can be unreachable on VPN. Pass a local file with --jsonl,')
+        console.error('   or produce one from the published parquet — see eval/cde-suggest/README.md.)')
+    }
+    process.exit(1)
+})

--- a/src/stores/cdeCatalogStore.js
+++ b/src/stores/cdeCatalogStore.js
@@ -12,6 +12,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import * as site from '@/site-config/site.json'
 import { useDuckDBStore } from '@/stores/duckdbStore'
+import { SEARCH_COLS, RETRIEVE, COARSE, tokenize, rankCandidates } from '@/stores/cdeSuggestRanker'
 
 const VIEWER_ID = 'cde-catalog'
 const TABLE = 'cde_catalog' // slim list projection (browse/search/facets)
@@ -140,7 +141,8 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
     //      name/question/aliases/definition + exact/prefix bonuses (precision).
     // Matches only the slim columns (name, question text, definition, source,
     // aliases) — not text buried in the heavy blobs, which aren't in the list file.
-    const SEARCH_COLS = ['cde_name', 'preferred_question_text', 'cde_definition', 'cde_source', 'aliases']
+    // SEARCH_COLS / RETRIEVE / COARSE / rankCandidates come from cdeSuggestRanker
+    // so this SQL and the offline eval harness score identically.
     // opts.dataType (optional): the property's chosen type; boosts type-compatible CDEs.
     const search = async (term, limit = 25, opts = {}) => {
         await ensureLoaded()
@@ -160,21 +162,21 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
         const terms = tokens.length ? tokens : [t.toLowerCase()]
         const phrase = escapeLiteral(t)
 
-        // Coarse SQL score: phrase-in-name/question dominate; then per-token field hits.
-        const scoreParts = [
-            `(CASE WHEN cde_name ILIKE '%${phrase}%' THEN 200 ELSE 0 END)`,
-            `(CASE WHEN preferred_question_text ILIKE '%${phrase}%' THEN 80 ELSE 0 END)`,
-        ]
+        // Coarse SQL score: phrase-in-name/question dominate; then per-token field
+        // hits. Built from the shared COARSE weights (cdeSuggestRanker) so the SQL
+        // and the eval harness stay in lockstep.
+        const scoreParts = []
+        for (const [col, w] of Object.entries(COARSE.phrase)) {
+            scoreParts.push(`(CASE WHEN ${col} ILIKE '%${phrase}%' THEN ${w} ELSE 0 END)`)
+        }
         const ors = []
         for (const tok of terms) {
             const lt = escapeLiteral(tok)
             for (const c of SEARCH_COLS) ors.push(`${c} ILIKE '%${lt}%'`)
-            scoreParts.push(`(CASE WHEN cde_name ILIKE '%${lt}%' THEN 6 ELSE 0 END)`)
-            scoreParts.push(`(CASE WHEN preferred_question_text ILIKE '%${lt}%' THEN 4 ELSE 0 END)`)
-            scoreParts.push(`(CASE WHEN aliases ILIKE '%${lt}%' THEN 3 ELSE 0 END)`)
-            scoreParts.push(`(CASE WHEN cde_definition ILIKE '%${lt}%' THEN 1 ELSE 0 END)`)
+            for (const [col, w] of Object.entries(COARSE.token)) {
+                scoreParts.push(`(CASE WHEN ${col} ILIKE '%${lt}%' THEN ${w} ELSE 0 END)`)
+            }
         }
-        const RETRIEVE = 300
         const query =
             `SELECT * FROM ${TABLE} WHERE ${ors.join(' OR ')}` +
             ` ORDER BY (${scoreParts.join(' + ')}) DESC, length(cde_name) NULLS LAST LIMIT ${RETRIEVE}`
@@ -577,75 +579,5 @@ function sqlList(vals) {
     return vals.map((v) => `'${escapeLiteral(v)}'`).join(', ')
 }
 
-// --- Lexical suggest ranking (SUGGEST-1) --------------------------------------
-
-const SUGGEST_STOP = new Set([
-    'the', 'a', 'an', 'of', 'and', 'or', 'to', 'in', 'for', 'on', 'by', 'with',
-    'is', 'are', 'at', 'as', 'de', 'per',
-])
-
-function norm(s) {
-    return String(s ?? '').toLowerCase().replace(/\s+/g, ' ').trim()
-}
-
-// Split into meaningful lowercased tokens (drop 1-char + stopwords).
-function tokenize(s) {
-    return (norm(s).match(/[a-z0-9]+/g) || []).filter((t) => t.length > 1 && !SUGGEST_STOP.has(t))
-}
-
-// Map a property's chosen type to the CDE's cde_data_type vocabulary.
-function compatibleType(propType, cdeType) {
-    const p = norm(propType)
-    const c = norm(cdeType)
-    if (!p || !c) return false
-    if (p === 'number' || p === 'integer' || p === 'long' || p === 'double') return c === 'number'
-    if (p === 'date' || p === 'datetime') return c === 'date'
-    if (p === 'boolean' || p === 'enum') return c === 'value list'
-    if (p === 'string' || p === 'text') return c === 'text' || c === 'value list'
-    return false
-}
-
-// Score one candidate against the query. Higher = more relevant.
-function scoreCandidate(c, qNorm, qTokens, dataType) {
-    const name = norm(c.cde_name)
-    const question = norm(c.preferred_question_text)
-    const aliases = Array.isArray(c.aliases) ? c.aliases.map(norm).join(' · ') : ''
-    const def = norm(c.cde_definition)
-    const source = norm(c.cde_source)
-
-    let s = 0
-    // Exact / prefix / substring on the label fields.
-    if (name === qNorm || question === qNorm) s += 120
-    else if (name.startsWith(qNorm) || question.startsWith(qNorm)) s += 50
-    else if (name.includes(qNorm) || question.includes(qNorm)) s += 25
-
-    // Weighted token coverage: a token counts once, at its best-scoring field.
-    const fields = [[name, 6], [question, 4], [aliases, 3], [def, 1], [source, 0.5]]
-    let matched = 0
-    for (const t of qTokens) {
-        let best = 0
-        for (const [text, w] of fields) if (text.includes(t)) best = Math.max(best, w)
-        if (best > 0) {
-            s += best
-            matched++
-        }
-    }
-    // Reward covering more of the query (penalize 1-of-3-token matches).
-    const coverage = qTokens.length ? matched / qTokens.length : 0
-    s *= 0.4 + 0.6 * coverage
-
-    if (dataType && compatibleType(dataType, c.cde_data_type)) s += 5
-    // Prefer concise names on ties.
-    s -= Math.min(name.length, 80) * 0.03
-    return s
-}
-
-// Rank retrieved candidates by relevance to the query (stable, best first).
-function rankCandidates(cands, query, dataType) {
-    const qNorm = norm(query)
-    const qTokens = tokenize(query)
-    return cands
-        .map((c, i) => ({ c, i, s: scoreCandidate(c, qNorm, qTokens, dataType) }))
-        .sort((a, b) => b.s - a.s || a.i - b.i)
-        .map((x) => x.c)
-}
+// Lexical suggest ranking (SUGGEST-1) now lives in cdeSuggestRanker.js so the
+// picker and the offline eval harness score identically.

--- a/src/stores/cdeSuggestRanker.mjs
+++ b/src/stores/cdeSuggestRanker.mjs
@@ -1,0 +1,150 @@
+// @/stores/cdeSuggestRanker.js
+//
+// The CDE lexical-suggest ranker (SUGGEST-1), extracted so the shipped picker
+// (cdeCatalogStore) and the offline eval harness (eval/cde-suggest) run the
+// EXACT same scoring. Pure JS — no Vue, no DuckDB, no app imports — so it loads
+// unchanged under Vite (browser) and Node (the eval `.mjs`).
+//
+// Two stages, entirely client-side over the slim list (no infra, no LLM):
+//   1. Retrieval — a coarse score narrows the catalog to the best RETRIEVE
+//      candidates (recall). In the app this runs as DuckDB SQL; the SQL is built
+//      from the COARSE weights below so it can't drift from stage 2 / the eval.
+//   2. Rank — score each candidate by weighted token coverage across
+//      name/question/aliases/definition + exact/prefix bonuses (precision).
+//
+// The optional `exclude`/`cols` params default to the shipped behavior. The eval
+// uses them for its "cold" mode: when the query IS a candidate's own field
+// (e.g. the CDE's preferred_question_text), scoring that field is circular, so
+// cold mode excludes it to measure what the *other* fields can recover.
+
+// Slim-list columns the suggest matches against (name, question, definition,
+// source, aliases) — the heavy blobs aren't in the list projection.
+export const SEARCH_COLS = ['cde_name', 'preferred_question_text', 'cde_definition', 'cde_source', 'aliases']
+
+// How many candidates stage-1 retrieval keeps before ranking.
+export const RETRIEVE = 300
+
+// Coarse retrieval weights. The store builds its SQL CASE-score from these and
+// the eval scores in JS from these — one source of truth for both.
+//   phrase: the whole query as a substring of the field.
+//   token:  a single query token as a substring of the field.
+export const COARSE = {
+    phrase: { cde_name: 200, preferred_question_text: 80 },
+    token: { cde_name: 6, preferred_question_text: 4, aliases: 3, cde_definition: 1 },
+}
+
+const EMPTY = new Set()
+
+const SUGGEST_STOP = new Set([
+    'the', 'a', 'an', 'of', 'and', 'or', 'to', 'in', 'for', 'on', 'by', 'with',
+    'is', 'are', 'at', 'as', 'de', 'per',
+])
+
+export function norm(s) {
+    return String(s ?? '').toLowerCase().replace(/\s+/g, ' ').trim()
+}
+
+// Split into meaningful lowercased tokens (drop 1-char + stopwords).
+export function tokenize(s) {
+    return (norm(s).match(/[a-z0-9]+/g) || []).filter((t) => t.length > 1 && !SUGGEST_STOP.has(t))
+}
+
+// Map a property's chosen type to the CDE's cde_data_type vocabulary.
+export function compatibleType(propType, cdeType) {
+    const p = norm(propType)
+    const c = norm(cdeType)
+    if (!p || !c) return false
+    if (p === 'number' || p === 'integer' || p === 'long' || p === 'double') return c === 'number'
+    if (p === 'date' || p === 'datetime') return c === 'date'
+    if (p === 'boolean' || p === 'enum') return c === 'value list'
+    if (p === 'string' || p === 'text') return c === 'text' || c === 'value list'
+    return false
+}
+
+// The aliases field is stored as a JSON-array string in the slim parquet column,
+// so the ranker's alias text mirrors what SQL ILIKE sees. Accept either an array
+// (eval loads from records.jsonl) or an already-joined string.
+function aliasText(aliases) {
+    return Array.isArray(aliases) ? aliases.map(norm).join(' · ') : norm(aliases)
+}
+
+// Score one candidate against the query. Higher = more relevant.
+// `exclude` (a Set of column names) drops those fields from scoring — used by the
+// eval's cold mode; empty by default, so the app's ranking is unchanged.
+export function scoreCandidate(c, qNorm, qTokens, dataType, exclude = EMPTY) {
+    const name = exclude.has('cde_name') ? '' : norm(c.cde_name)
+    const question = exclude.has('preferred_question_text') ? '' : norm(c.preferred_question_text)
+    const aliases = exclude.has('aliases') ? '' : aliasText(c.aliases)
+    const def = exclude.has('cde_definition') ? '' : norm(c.cde_definition)
+    const source = exclude.has('cde_source') ? '' : norm(c.cde_source)
+
+    let s = 0
+    // Exact / prefix / substring on the label fields.
+    if (name === qNorm || question === qNorm) s += 120
+    else if (name.startsWith(qNorm) || question.startsWith(qNorm)) s += 50
+    else if (name.includes(qNorm) || question.includes(qNorm)) s += 25
+
+    // Weighted token coverage: a token counts once, at its best-scoring field.
+    const fields = [[name, 6], [question, 4], [aliases, 3], [def, 1], [source, 0.5]]
+    let matched = 0
+    for (const t of qTokens) {
+        let best = 0
+        for (const [text, w] of fields) if (text.includes(t)) best = Math.max(best, w)
+        if (best > 0) {
+            s += best
+            matched++
+        }
+    }
+    // Reward covering more of the query (penalize 1-of-3-token matches).
+    const coverage = qTokens.length ? matched / qTokens.length : 0
+    s *= 0.4 + 0.6 * coverage
+
+    if (dataType && compatibleType(dataType, c.cde_data_type)) s += 5
+    // Prefer concise names on ties.
+    s -= Math.min(name.length, 80) * 0.03
+    return s
+}
+
+// Rank retrieved candidates by relevance to the query (stable, best first).
+export function rankCandidates(cands, query, dataType, exclude = EMPTY) {
+    const qNorm = norm(query)
+    const qTokens = tokenize(query)
+    return cands
+        .map((c, i) => ({ c, i, s: scoreCandidate(c, qNorm, qTokens, dataType, exclude) }))
+        .sort((a, b) => b.s - a.s || a.i - b.i)
+        .map((x) => x.c)
+}
+
+// Coarse stage-1 retrieval score for one candidate (JS mirror of the store's SQL
+// CASE-score, from the shared COARSE weights). `cols` restricts the fields
+// considered (cold mode passes SEARCH_COLS minus the queried field).
+export function coarseScore(c, phraseNorm, terms, cols = SEARCH_COLS) {
+    const allow = new Set(cols)
+    const field = (col) => {
+        if (!allow.has(col)) return ''
+        if (col === 'aliases') return aliasText(c.aliases)
+        return norm(c[col])
+    }
+    let s = 0
+    for (const [col, w] of Object.entries(COARSE.phrase)) {
+        if (field(col).includes(phraseNorm)) s += w
+    }
+    for (const tok of terms) {
+        for (const [col, w] of Object.entries(COARSE.token)) {
+            if (field(col).includes(tok)) s += w
+        }
+    }
+    return s
+}
+
+// Does the candidate match the retrieval WHERE clause — any query token as a
+// substring of any allowed search column? (Stage-1 qualifier, before scoring.)
+export function coarseQualifies(c, terms, cols = SEARCH_COLS) {
+    const allow = cols.filter((col) => SEARCH_COLS.includes(col))
+    for (const col of allow) {
+        const text = col === 'aliases' ? aliasText(c.aliases) : norm(c[col])
+        if (!text) continue
+        for (const tok of terms) if (text.includes(tok)) return true
+    }
+    return false
+}

--- a/src/stores/cdeSuggestRanker.spec.js
+++ b/src/stores/cdeSuggestRanker.spec.js
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import {
+    tokenize,
+    scoreCandidate,
+    rankCandidates,
+    compatibleType,
+    coarseScore,
+    coarseQualifies,
+    norm,
+    SEARCH_COLS,
+    RETRIEVE,
+    COARSE,
+} from './cdeSuggestRanker.mjs'
+
+const cde = (over) => ({
+    persistent_id: 'p',
+    cde_name: '',
+    preferred_question_text: '',
+    cde_definition: '',
+    cde_source: '',
+    cde_data_type: '',
+    aliases: [],
+    ...over,
+})
+
+describe('tokenize', () => {
+    it('lowercases, drops 1-char tokens and stopwords', () => {
+        expect(tokenize('Age at Enrollment (years)')).toEqual(['age', 'enrollment', 'years'])
+    })
+    it('is empty for punctuation/stopword-only input', () => {
+        expect(tokenize('the of a')).toEqual([])
+    })
+})
+
+describe('compatibleType', () => {
+    it('maps property types onto the CDE data-type vocabulary', () => {
+        expect(compatibleType('integer', 'Number')).toBe(true)
+        expect(compatibleType('date', 'Date')).toBe(true)
+        expect(compatibleType('enum', 'Value List')).toBe(true)
+        expect(compatibleType('string', 'Number')).toBe(false)
+    })
+})
+
+describe('scoreCandidate', () => {
+    const q = 'age'
+    const score = (c, exclude) => scoreCandidate(c, norm(q), tokenize(q), '', exclude)
+
+    it('rewards an exact name match over a mere substring', () => {
+        const exact = score(cde({ cde_name: 'age' }))
+        const substr = score(cde({ cde_name: 'patient age at visit' }))
+        expect(exact).toBeGreaterThan(substr)
+    })
+
+    it('weights name above question above definition for the same token', () => {
+        const inName = score(cde({ cde_name: 'age' }))
+        const inQuestion = score(cde({ preferred_question_text: 'age' }))
+        const inDef = score(cde({ cde_definition: 'age' }))
+        expect(inName).toBeGreaterThan(inQuestion)
+        expect(inQuestion).toBeGreaterThan(inDef)
+    })
+
+    it('gives a data-type-compatible CDE a bonus', () => {
+        const base = cde({ cde_name: 'age', cde_data_type: 'Number' })
+        expect(scoreCandidate(base, 'age', ['age'], 'integer')).toBeGreaterThan(
+            scoreCandidate(base, 'age', ['age'], ''),
+        )
+    })
+
+    it('exclude drops a field from scoring (cold mode)', () => {
+        const c = cde({ preferred_question_text: 'age' })
+        expect(score(c)).toBeGreaterThan(0)
+        expect(score(c, new Set(['preferred_question_text']))).toBeLessThanOrEqual(0)
+    })
+})
+
+describe('rankCandidates', () => {
+    const cands = [
+        cde({ persistent_id: 'weight', cde_name: 'Body Weight', cde_definition: 'mass' }),
+        cde({ persistent_id: 'age', cde_name: 'Age Value', preferred_question_text: 'what is the age' }),
+        cde({ persistent_id: 'age-alias', cde_name: 'Years Lived', aliases: ['age'] }),
+    ]
+    it('ranks the strongest lexical match first and is stable', () => {
+        const ranked = rankCandidates(cands, 'age', '').map((c) => c.persistent_id)
+        expect(ranked[0]).toBe('age')
+        expect(ranked).toContain('age-alias')
+        expect(ranked).not.toContain(undefined)
+    })
+    it('cold exclude changes ordering without throwing', () => {
+        const ranked = rankCandidates(cands, 'age', '', new Set(['cde_name']))
+        expect(ranked.map((c) => c.persistent_id)).toContain('age-alias')
+    })
+})
+
+describe('coarse retrieval (stage 1)', () => {
+    it('scores from the shared COARSE weights (phrase-in-name dominates)', () => {
+        const nameHit = coarseScore(cde({ cde_name: 'blood pressure' }), 'blood pressure', ['blood', 'pressure'])
+        const defHit = coarseScore(cde({ cde_definition: 'blood pressure' }), 'blood pressure', ['blood', 'pressure'])
+        expect(nameHit).toBeGreaterThan(defHit)
+        expect(nameHit).toBe(COARSE.phrase.cde_name + COARSE.token.cde_name * 2)
+    })
+    it('qualifies a candidate when any token substring-hits an allowed column', () => {
+        expect(coarseQualifies(cde({ cde_definition: 'systolic value' }), ['systolic'])).toBe(true)
+        expect(coarseQualifies(cde({ cde_definition: 'systolic value' }), ['diastolic'])).toBe(false)
+    })
+    it('cols restricts which columns count (cold mode)', () => {
+        const c = cde({ preferred_question_text: 'age' })
+        const cold = SEARCH_COLS.filter((x) => x !== 'preferred_question_text')
+        expect(coarseQualifies(c, ['age'])).toBe(true)
+        expect(coarseQualifies(c, ['age'], cold)).toBe(false)
+    })
+    it('exposes a sane retrieval depth', () => {
+        expect(RETRIEVE).toBeGreaterThanOrEqual(100)
+    })
+})


### PR DESCRIPTION
## What

Scopes **SUGGEST-3** — an offline eval harness that answers *"is the CDE lexical suggest good enough, or is SUGGEST-2 (embeddings) / SUGGEST-4 (LLM re-rank) worth building?"* — and refactors the shipped ranker so the harness measures the **real** pipeline, not a re-implementation.

### 1. Extract the ranker (no behavior change)
- New `src/stores/cdeSuggestRanker.mjs` holds `tokenize` / `scoreCandidate` / `rankCandidates` + the coarse retrieval weights (`COARSE`, `SEARCH_COLS`, `RETRIEVE`), previously inline in `cdeCatalogStore`.
- `cdeCatalogStore` now imports them **and builds its DuckDB coarse-score SQL from the same `COARSE` constants** — stage-1 retrieval and the eval can't drift.
- `.mjs` so it loads unchanged under Vite (browser) and Node (the eval).
- 13-test unit spec (`cdeSuggestRanker.spec.js`) locks the shipped behavior — the SUGGEST-1 ranker previously had no coverage.

### 2. The harness (`eval/cde-suggest/`)
- **Self-labeling:** a CDE's own `preferred_question_text` and `aliases` are what a user would type to find it — no human annotation.
- **Circularity guard:** every field-set runs `hot` (all fields scored) and `cold` (the queried field excluded from retrieval + ranking). **Cold is the honest number.**
- **Two-stage split:** `retrieval-recall@300` (did coarse keep the target?) vs `rank-recall@k | retrieved` (once kept, is it ranked well?) — so the verdict points at *retrieval* (→ SUGGEST-2) vs *ranking* (→ SUGGEST-4).
- **Faithful:** ranking calls the shipped `rankCandidates`; retrieval is substring-faithful to the app's SQL (same weights, same `ILIKE`), just a full JS scan instead of DuckDB.
- Pure Node, no new deps. Reads the published `records.jsonl` (CDN or local file).

## Result — prod `20260715T161304Z` (23,350 CDEs)

| field | mode | R@1 | R@5 | R@20 | MRR | retr@300 |
|---|---|---|---|---|---|---|
| question | cold | 69.7% | 79.4% | 82.4% | 0.740 | 84.5% |
| aliases | cold | 62.3% | 82.0% | 89.5% | 0.711 | 95.3% |

**Verdict: LEXICAL DECENT** (cold recall@5 ≈ 80.7%) — ship SUGGEST-1 as the default, with a field-specific upgrade path:
- **question text → RETRIEVAL-limited** (retrieval-recall caps at 84.5%): paraphrase/synonymy that substring lexical can't reach → **SUGGEST-2 embeddings**.
- **aliases → RANKING-limited** (retrieved 95.3%, but hit@1 only 62.3%): present but mis-ordered → **SUGGEST-4 LLM re-rank**.
- **Coverage caveat (SUGGEST-5):** only 29.6% of CDEs have a question and 7.8% have aliases — field coverage moves the needle as much as a better model.

## Verify
```
npx vitest run src/stores/cdeSuggestRanker.spec.js
node eval/cde-suggest/run-eval.mjs --base https://cde-catalog.pennsieve.io
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)