### PR TITLE
deploy(dev): ontology-assisted dataset tags (ONT-2)

### DIFF
--- a/eval/cde-suggest/README.md
+++ b/eval/cde-suggest/README.md
@@ -1,0 +1,122 @@
+# CDE suggest eval (SUGGEST-3)
+
+An offline harness that measures the **shipped** CDE lexical-suggest pipeline and
+tells us whether lexical retrieval is good enough, or whether SUGGEST-2
+(embeddings) / SUGGEST-4 (LLM re-rank) are worth building.
+
+It reuses the production ranker directly — `src/stores/cdeSuggestRanker.mjs`, the
+same module `cdeCatalogStore` uses — so the numbers reflect what users actually
+get, not a re-implementation.
+
+## Why this design
+
+- **No human labels needed.** The catalog labels itself: a CDE's own
+  `preferred_question_text` and its `aliases` are exactly what a user would type
+  to find it. Fixtures are derived from the published records.
+- **Circularity guard (the crux).** If the query is a candidate's field and we
+  score that field, the target trivially wins. Every field-set is run in two
+  modes:
+  - `hot` — all fields scored. Upper bound; the field is present verbatim.
+  - `cold` — the queried field is **excluded** from both retrieval and ranking.
+    Measures whether the *other* fields recover the CDE. **Cold is the number
+    that matters.**
+- **Two-stage split.** Recall is decomposed so we know *what* to fix:
+  - `retrieval-recall@RETRIEVE` — did stage-1 (coarse) keep the target at all?
+    Low → the target never enters the candidate set → semantic recall gap →
+    **SUGGEST-2 embeddings**.
+  - `rank-recall@k | retrieved` — given it was retrieved, did stage-2 rank it
+    top-k? Low while retrieval is high → ordering problem → **SUGGEST-4 re-rank**.
+
+## Fidelity
+
+- **Ranking (stage 2)** calls the shipped `rankCandidates` — byte-for-byte the
+  production ranker.
+- **Retrieval (stage 1)** is substring-faithful to the app's DuckDB SQL: same
+  `COARSE` weights, same `ILIKE '%token%'` substring semantics, same
+  `ORDER BY score DESC, length(cde_name)` and `LIMIT RETRIEVE`. It runs as a full
+  JS scan instead of SQL — identical *selection*, just slower. (The app's SQL
+  coarse-score is built from the same `COARSE` constants, so the two cannot
+  drift.)
+
+## Run
+
+```bash
+# Production catalog (the shipped release):
+node eval/cde-suggest/run-eval.mjs --base https://cde-catalog.pennsieve.io
+
+# Dev catalog (default base):
+node eval/cde-suggest/run-eval.mjs
+
+# Full (no sampling) — slower, definitive:
+node eval/cde-suggest/run-eval.mjs --base https://cde-catalog.pennsieve.io --sample 0
+
+# From a local file (e.g. on VPN, where the CDN is unreachable):
+node eval/cde-suggest/run-eval.mjs --jsonl ./cde-records.jsonl
+```
+
+### Options
+
+| flag | default | meaning |
+|---|---|---|
+| `--base <url>` | `https://cde-catalog.pennsieve.net` | catalog CDN base |
+| `--jsonl <path\|url>` | — | explicit `cde` records.jsonl; skips latest/manifest resolution |
+| `--sample <n>` | `1000` | labeled queries per field-set; `0` = all |
+| `--max-aliases <n>` | `8` | aliases considered per CDE |
+| `--seed <n>` | `1337` | PRNG seed (sampling is deterministic) |
+| `--ks <a,b,c>` | `1,5,10,20` | recall@k cutoffs |
+| `--out <path>` | `eval/cde-suggest/last-report.json` | JSON report path |
+
+### Getting a local records.jsonl (VPN)
+
+The catalog CDN is blocked on the Pennsieve VPN. Off-VPN, download once:
+
+```bash
+BASE=https://cde-catalog.pennsieve.io
+CV=$(curl -s $BASE/cde/latest.json | python3 -c 'import sys,json;print(json.load(sys.stdin)["catalog_version"])')
+V=$(curl -s $BASE/cde/versions/$CV/manifest.json | python3 -c 'import sys,json;print(next(m["version"] for m in json.load(sys.stdin)["models"] if m["name"]=="cde"))')
+curl -s -o cde-records.jsonl $BASE/cde/versions/$CV/metadata/models/cde/versions/$V/records.jsonl
+```
+
+## Output
+
+A table (per field-set × mode), field fill-rates (SUGGEST-5 signal — how many
+CDEs even have a question / aliases to match on), and a decision verdict with
+bottleneck attribution. Full detail is written to the `--out` JSON.
+
+Interpreting the verdict (driven by **cold** recall@5):
+
+| cold recall@5 | verdict |
+|---|---|
+| ≥ 85% | lexical sufficient — ship SUGGEST-1; SUGGEST-2/4 low priority |
+| 60–85% | lexical decent — invest in the tail (SUGGEST-2 and/or SUGGEST-4) |
+| < 60% | lexical insufficient — prioritize SUGGEST-2 (embeddings) |
+
+`report-prod.json` in this directory is a checked-in snapshot from a
+representative run (see below).
+
+## Results — prod `20260715T161304Z` (23,350 CDEs, 1,500 sampled queries/set)
+
+| field-set | mode | recall@1 | recall@5 | recall@20 | MRR | retrieval-recall@300 |
+|---|---|---|---|---|---|---|
+| question | hot | 98.7% | 100.0% | 100.0% | 0.993 | 100.0% |
+| question | **cold** | 69.7% | 79.4% | 82.4% | 0.740 | 84.5% |
+| aliases | hot | 85.1% | 97.5% | 99.2% | 0.909 | 99.7% |
+| aliases | **cold** | 62.3% | 82.0% | 89.5% | 0.711 | 95.3% |
+
+**Verdict: LEXICAL DECENT** (cold recall@5 ≈ 80.7%) — good enough to ship as the
+default, with a clear, *field-specific* upgrade path:
+
+- **question text is RETRIEVAL-limited** — cold retrieval-recall caps at 84.5%, so
+  ~15% of the time the right CDE never enters the candidate set. Substring lexical
+  can't bridge paraphrase/synonymy (a user's phrasing vs. the curated question).
+  → **SUGGEST-2 (embeddings)** is where the return is.
+- **aliases are RANKING-limited** — the target is retrieved 95.3% of the time but
+  only ranked #1 for 62.3% of queries (rank-recall@5|retrieved ≈ 86%). Candidates
+  are present, just mis-ordered. → **SUGGEST-4 (LLM re-rank of the top-N)** would
+  lift precision@1 without new recall infrastructure.
+
+**Fill-rate caveat (SUGGEST-5).** Only **29.6%** of CDEs have a
+`preferred_question_text` and **7.8%** have `aliases`; every CDE has a name +
+definition. So the suggest quality above is measured on the minority of CDEs that
+carry rich matchable text — improving field coverage (SUGGEST-5) likely moves the
+needle as much as a better model.

--- a/eval/cde-suggest/report-prod.json
+++ b/eval/cde-suggest/report-prod.json
@@ -1,0 +1,159 @@
+{
+  "generated_at": "2026-07-15T22:04:08.770Z",
+  "catalog_version": "20260715T161304Z",
+  "catalog_records": 23350,
+  "candidates_with_pid": 23350,
+  "retrieve_depth": 300,
+  "sample_per_field": 1500,
+  "ks": [
+    1,
+    5,
+    10,
+    20
+  ],
+  "field_fill_rates": {
+    "cde_name": {
+      "filled": 23350,
+      "total": 23350,
+      "pct": 100
+    },
+    "preferred_question_text": {
+      "filled": 6909,
+      "total": 23350,
+      "pct": 29.6
+    },
+    "cde_definition": {
+      "filled": 23350,
+      "total": 23350,
+      "pct": 100
+    },
+    "cde_source": {
+      "filled": 23350,
+      "total": 23350,
+      "pct": 100
+    },
+    "aliases": {
+      "filled": 1811,
+      "total": 23350,
+      "pct": 7.8
+    },
+    "cde_data_type": {
+      "filled": 23350,
+      "total": 23350,
+      "pct": 100
+    }
+  },
+  "results": [
+    {
+      "field": "preferred_question_text",
+      "mode": "hot",
+      "n_queries": 1500,
+      "recall": {
+        "1": 0.9867,
+        "5": 1,
+        "10": 1,
+        "20": 1
+      },
+      "precision_at_1": 0.9867,
+      "mrr": 0.9927,
+      "retrieval_recall_at_RETRIEVE": 1,
+      "rank_recall_given_retrieved": {
+        "1": 0.9867,
+        "5": 1,
+        "10": 1,
+        "20": 1
+      },
+      "labeled_total": 6556
+    },
+    {
+      "field": "preferred_question_text",
+      "mode": "cold",
+      "n_queries": 1500,
+      "recall": {
+        "1": 0.6967,
+        "5": 0.794,
+        "10": 0.8113,
+        "20": 0.824
+      },
+      "precision_at_1": 0.6967,
+      "mrr": 0.74,
+      "retrieval_recall_at_RETRIEVE": 0.8453,
+      "rank_recall_given_retrieved": {
+        "1": 0.8241,
+        "5": 0.9393,
+        "10": 0.9598,
+        "20": 0.9748
+      },
+      "labeled_total": 6556
+    },
+    {
+      "field": "aliases",
+      "mode": "hot",
+      "n_queries": 1500,
+      "recall": {
+        "1": 0.8507,
+        "5": 0.9753,
+        "10": 0.9867,
+        "20": 0.992
+      },
+      "precision_at_1": 0.8507,
+      "mrr": 0.9094,
+      "retrieval_recall_at_RETRIEVE": 0.9973,
+      "rank_recall_given_retrieved": {
+        "1": 0.8529,
+        "5": 0.9779,
+        "10": 0.9893,
+        "20": 0.9947
+      },
+      "labeled_total": 1901
+    },
+    {
+      "field": "aliases",
+      "mode": "cold",
+      "n_queries": 1500,
+      "recall": {
+        "1": 0.6227,
+        "5": 0.82,
+        "10": 0.8587,
+        "20": 0.8947
+      },
+      "precision_at_1": 0.6227,
+      "mrr": 0.7114,
+      "retrieval_recall_at_RETRIEVE": 0.9533,
+      "rank_recall_given_retrieved": {
+        "1": 0.6531,
+        "5": 0.8601,
+        "10": 0.9007,
+        "20": 0.9385
+      },
+      "labeled_total": 1901
+    }
+  ],
+  "decision": {
+    "verdict": "LEXICAL DECENT — worth investing in the tail (SUGGEST-2 embeddings and/or SUGGEST-4 re-rank).",
+    "cold_recall_at_5": 0.807,
+    "cold_recall_at_20": 0.8594,
+    "cold_mrr": 0.7257,
+    "bottlenecks": [
+      {
+        "field": "preferred_question_text",
+        "kind": "retrieval",
+        "retrieval_recall": 0.8453,
+        "rank_recall_at_5_given_retrieved": 0.9393,
+        "hit_at_1": 0.6967
+      },
+      {
+        "field": "aliases",
+        "kind": "ranking",
+        "retrieval_recall": 0.9533,
+        "rank_recall_at_5_given_retrieved": 0.8601,
+        "hit_at_1": 0.6227
+      }
+    ],
+    "notes": [
+      "question: RETRIEVAL-limited — cold retrieval-recall@300=84.5% (target absent from candidates 15.5% of the time). Substring lexical misses paraphrase/synonymy → SUGGEST-2 embeddings.",
+      "aliases: RANKING-limited — target retrieved 95.3% of the time, but rank-recall@5|retrieved=86.0% and hit@1=62.3%. Candidates present, mis-ordered → SUGGEST-4 LLM re-rank of the top-N.",
+      "overall (cold, avg of field-sets): recall@5=80.7%  recall@20=85.9%  MRR=0.726"
+    ]
+  }
+}

--- a/eval/cde-suggest/run-eval.mjs
+++ b/eval/cde-suggest/run-eval.mjs
@@ -1,0 +1,478 @@
+#!/usr/bin/env node
+// SUGGEST-3 — offline eval harness for the CDE lexical suggest.
+//
+// Measures the SHIPPED retrieve-then-rank pipeline (src/stores/cdeSuggestRanker.mjs,
+// the same module the picker uses) against labeled fixtures derived from the
+// published catalog itself, and prints a decision rubric: is lexical good enough,
+// or is the return on SUGGEST-2 (embeddings) / SUGGEST-4 (LLM re-rank) worth it?
+//
+// Labels (no human annotation needed — the catalog supplies them):
+//   • preferred_question_text → CDE : typing a CDE's own question text should
+//     surface that CDE. This is what the picker's "suggest as you type" does.
+//   • aliases → CDE                 : typing a known alias should surface the CDE.
+//
+// Circularity guard (the crux). If the query IS a candidate's field and we score
+// that field, the target trivially wins — a meaningless 100%. So we run two modes:
+//   • hot  : all fields scored (upper bound; the field is present verbatim).
+//   • cold : the queried field is EXCLUDED from retrieval + ranking, measuring
+//            whether the OTHER fields (name/definition/source/[aliases]) recover
+//            the CDE. Cold is the number that should drive the decision.
+//
+// Two-stage split. recall is decomposed into:
+//   • retrieval-recall@RETRIEVE : did stage-1 (coarse) keep the target at all?
+//   • rank-recall@k | retrieved : given it was retrieved, did stage-2 rank it top-k?
+// If retrieval is the bottleneck → better recall wanted (embeddings, SUGGEST-2).
+// If ranking is the bottleneck → better ordering wanted (LLM re-rank, SUGGEST-4).
+//
+// Pure Node, no new deps. Data source: the published records.jsonl (fetched from
+// the catalog CDN or a local file). See eval/cde-suggest/README.md.
+//
+// NOTE: retrieval here is substring-faithful to the app's SQL WHERE/coarse-score
+// (same COARSE weights, same ILIKE-substring semantics) but runs a full JS scan
+// instead of DuckDB — identical selection, just slower. Ranking calls the shipped
+// rankCandidates directly, so stage-2 is byte-for-byte the production ranker.
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+    SEARCH_COLS,
+    RETRIEVE,
+    COARSE,
+    norm,
+    tokenize,
+    rankCandidates,
+} from '../../src/stores/cdeSuggestRanker.mjs'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+
+// ---- args -------------------------------------------------------------------
+function parseArgs(argv) {
+    const a = {
+        base: 'https://cde-catalog.pennsieve.net', // dev catalog CDN
+        jsonl: '', // explicit records.jsonl path/url (overrides base resolution)
+        cv: '', // catalog_version label when using --jsonl (else resolved from base)
+        sample: 1000, // labeled queries per field-set (0 = all)
+        maxAliases: 8, // aliases considered per CDE (bounds alias fixtures)
+        seed: 1337,
+        ks: [1, 5, 10, 20],
+        out: resolve(HERE, 'last-report.json'),
+    }
+    for (let i = 2; i < argv.length; i++) {
+        const [k, vRaw] = argv[i].includes('=') ? argv[i].split(/=(.*)/s) : [argv[i], argv[i + 1]]
+        const takeNext = () => (argv[i].includes('=') ? vRaw : argv[++i])
+        switch (k) {
+            case '--base': a.base = takeNext(); break
+            case '--jsonl': a.jsonl = takeNext(); break
+            case '--cv': a.cv = takeNext(); break
+            case '--sample': a.sample = Number(takeNext()); break
+            case '--max-aliases': a.maxAliases = Number(takeNext()); break
+            case '--seed': a.seed = Number(takeNext()); break
+            case '--ks': a.ks = takeNext().split(',').map(Number).filter((n) => n > 0); break
+            case '--out': a.out = resolve(process.cwd(), takeNext()); break
+            case '--help': case '-h': a.help = true; break
+            default: if (k.startsWith('--')) console.error(`(ignoring unknown arg ${k})`)
+        }
+    }
+    return a
+}
+
+const HELP = `SUGGEST-3 CDE suggest eval
+
+Usage: node eval/cde-suggest/run-eval.mjs [options]
+
+  --base <url>        catalog CDN base (default https://cde-catalog.pennsieve.net)
+  --jsonl <path|url>  explicit cde records.jsonl (skips latest/manifest resolution)
+  --cv <version>      catalog_version label for the report when using --jsonl
+  --sample <n>        labeled queries per field-set; 0 = all (default 1000)
+  --max-aliases <n>   aliases considered per CDE (default 8)
+  --seed <n>          PRNG seed for sampling (default 1337)
+  --ks <a,b,c>        recall@k cutoffs (default 1,5,10,20)
+  --out <path>        JSON report output (default eval/cde-suggest/last-report.json)
+
+Data: fetches {base}/cde/latest.json -> manifest.json -> the cde model's
+records.jsonl, or reads --jsonl directly. A local file may be plain .jsonl.`
+
+// ---- deterministic sampling -------------------------------------------------
+function mulberry32(seed) {
+    let s = seed >>> 0
+    return () => {
+        s |= 0; s = (s + 0x6d2b79f5) | 0
+        let t = Math.imul(s ^ (s >>> 15), 1 | s)
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    }
+}
+function sampleN(arr, n, rnd) {
+    if (!n || n >= arr.length) return arr
+    // Partial Fisher-Yates on a copy — first n are a uniform sample.
+    const a = arr.slice()
+    for (let i = 0; i < n; i++) {
+        const j = i + Math.floor(rnd() * (a.length - i))
+        ;[a[i], a[j]] = [a[j], a[i]]
+    }
+    return a.slice(0, n)
+}
+
+// ---- load catalog -----------------------------------------------------------
+async function fetchText(url) {
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(`GET ${url} -> ${res.status} ${res.statusText}`)
+    return res.text()
+}
+async function fetchJson(url) {
+    return JSON.parse(await fetchText(url))
+}
+
+async function resolveJsonlUrl(base) {
+    const b = base.replace(/\/+$/, '')
+    const latest = await fetchJson(`${b}/cde/latest.json`)
+    const cv = latest.catalog_version
+    if (!cv) throw new Error('latest.json has no catalog_version')
+    const manifest = await fetchJson(`${b}/cde/versions/${cv}/manifest.json`)
+    const models = Object.fromEntries((manifest.models || []).map((m) => [m.name, m.version]))
+    if (!models.cde) throw new Error('manifest has no cde model')
+    return {
+        cv,
+        url: `${b}/cde/versions/${cv}/metadata/models/cde/versions/${models.cde}/records.jsonl`,
+    }
+}
+
+// Parse one records.jsonl body → array of the `data` payloads (the CDE records).
+// Publish format is one {"id":..,"data":<record>} object per line; tolerate a
+// bare record object per line too.
+function parseJsonl(text) {
+    const out = []
+    for (const line of text.split('\n')) {
+        const s = line.trim()
+        if (!s) continue
+        let obj
+        try {
+            obj = JSON.parse(s)
+        } catch {
+            continue
+        }
+        const rec = obj && typeof obj === 'object' && 'data' in obj ? obj.data : obj
+        if (rec && typeof rec === 'object') out.push(rec)
+    }
+    return out
+}
+
+async function loadCatalog(args) {
+    let cv = args.cv || 'unknown'
+    let text
+    if (args.jsonl) {
+        if (/^https?:\/\//.test(args.jsonl)) {
+            text = await fetchText(args.jsonl)
+        } else {
+            text = await readFile(resolve(process.cwd(), args.jsonl), 'utf8')
+        }
+    } else {
+        const r = await resolveJsonlUrl(args.base)
+        cv = r.cv
+        console.error(`resolved catalog ${cv} -> ${r.url}`)
+        text = await fetchText(r.url)
+    }
+    const records = parseJsonl(text)
+    return { cv, records }
+}
+
+// ---- candidate model --------------------------------------------------------
+// A candidate carries exactly the fields the ranker reads. We also precompute
+// normalized per-column strings once (nname/nquestion/naliases/ndef/nsource) so
+// the full-scan retrieval doesn't re-normalize per query.
+function buildCandidates(records) {
+    const cands = []
+    for (const r of records) {
+        const pid = r.persistent_id
+        if (!pid) continue
+        const aliases = Array.isArray(r.aliases) ? r.aliases : []
+        const cand = {
+            id: r.id ?? pid,
+            persistent_id: pid,
+            cde_name: r.cde_name ?? null,
+            preferred_question_text: r.preferred_question_text ?? null,
+            cde_definition: r.cde_definition ?? null,
+            cde_source: r.cde_source ?? null,
+            cde_data_type: r.cde_data_type ?? null,
+            aliases,
+        }
+        const naliases = aliases.map(norm).join(' · ')
+        cand._n = {
+            cde_name: norm(cand.cde_name),
+            preferred_question_text: norm(cand.preferred_question_text),
+            aliases: naliases,
+            cde_definition: norm(cand.cde_definition),
+            cde_source: norm(cand.cde_source),
+        }
+        cand._nameLen = cand._n.cde_name.length || Infinity
+        cands.push(cand)
+    }
+    return cands
+}
+
+// ---- retrieval (full scan, substring-faithful to the app's SQL) -------------
+// cols = the search columns in play (cold mode drops the queried field).
+// A candidate qualifies (SQL WHERE) if any token is a substring of any allowed
+// column; its coarse score uses the shared COARSE weights.
+function retrieve(cands, phrase, terms, cols) {
+    const allow = new Set(cols)
+    const phraseCols = Object.keys(COARSE.phrase).filter((c) => allow.has(c))
+    const tokenCols = Object.keys(COARSE.token).filter((c) => allow.has(c))
+    const whereCols = SEARCH_COLS.filter((c) => allow.has(c))
+
+    const scored = []
+    for (const c of cands) {
+        const n = c._n
+        // WHERE: any token in any allowed column.
+        let qualifies = false
+        for (const col of whereCols) {
+            const text = n[col]
+            if (!text) continue
+            for (const tok of terms) if (text.includes(tok)) { qualifies = true; break }
+            if (qualifies) break
+        }
+        if (!qualifies) continue
+        // Coarse score.
+        let s = 0
+        for (const col of phraseCols) if (n[col].includes(phrase)) s += COARSE.phrase[col]
+        for (const tok of terms) {
+            for (const col of tokenCols) if (n[col].includes(tok)) s += COARSE.token[col]
+        }
+        scored.push([c, s, c._nameLen])
+    }
+    scored.sort((a, b) => b[1] - a[1] || a[2] - b[2])
+    return scored.slice(0, RETRIEVE).map((x) => x[0])
+}
+
+// ---- fixtures ---------------------------------------------------------------
+// A field-set maps a display field to labeled (query -> relevant pids). Multiple
+// CDEs can share a question/alias, so relevance is a set; a query "hits" at k if
+// ANY relevant pid is in the top-k (first-relevant rank drives MRR).
+function buildFixtures(cands, field, maxAliases) {
+    const byQuery = new Map() // normQuery -> { query, relevant:Set<pid> }
+    const add = (raw, pid) => {
+        const q = String(raw ?? '')
+        if (norm(q).length < 2) return
+        const k = norm(q)
+        let e = byQuery.get(k)
+        if (!e) { e = { query: q, relevant: new Set() }; byQuery.set(k, e) }
+        e.relevant.add(pid)
+    }
+    for (const c of cands) {
+        if (field === 'aliases') {
+            for (const al of c.aliases.slice(0, maxAliases)) add(al, c.persistent_id)
+        } else {
+            add(c[field], c.persistent_id)
+        }
+    }
+    return [...byQuery.values()]
+}
+
+// ---- eval one field-set × mode ----------------------------------------------
+function evalSet(cands, fixtures, field, mode, ks) {
+    const cold = mode === 'cold'
+    const cols = cold ? SEARCH_COLS.filter((c) => c !== field) : SEARCH_COLS
+    const exclude = cold ? new Set([field]) : new Set()
+    const maxK = Math.max(...ks)
+
+    let n = 0
+    let retrievalHits = 0 // relevant present in the retrieved set
+    let mrr = 0
+    const recallAtK = Object.fromEntries(ks.map((k) => [k, 0])) // overall
+    const rankRecallAtK = Object.fromEntries(ks.map((k) => [k, 0])) // among retrieved
+
+    for (const fx of fixtures) {
+        const tokens = tokenize(fx.query).slice(0, 6)
+        const terms = tokens.length ? tokens : [fx.query.toLowerCase()]
+        const phrase = norm(fx.query)
+
+        const retrieved = retrieve(cands, phrase, terms, cols)
+        const inRetrieved = retrieved.some((c) => fx.relevant.has(c.persistent_id))
+
+        // Stage-2: the shipped ranker over the retrieved candidates.
+        const ranked = rankCandidates(retrieved, fx.query, '', exclude)
+        let rank = Infinity
+        for (let i = 0; i < ranked.length; i++) {
+            if (fx.relevant.has(ranked[i].persistent_id)) { rank = i + 1; break }
+        }
+
+        n++
+        if (inRetrieved) retrievalHits++
+        if (rank !== Infinity) mrr += 1 / rank
+        for (const k of ks) {
+            if (rank <= k) recallAtK[k]++
+            if (inRetrieved && rank <= k) rankRecallAtK[k]++
+        }
+        void maxK
+    }
+
+    const div = (x) => (n ? x / n : 0)
+    const divR = (x) => (retrievalHits ? x / retrievalHits : 0)
+    return {
+        field,
+        mode,
+        n_queries: n,
+        recall: Object.fromEntries(ks.map((k) => [k, +div(recallAtK[k]).toFixed(4)])),
+        precision_at_1: +div(recallAtK[1] || 0).toFixed(4), // == hit@1 (single/first relevant)
+        mrr: +div(mrr).toFixed(4),
+        retrieval_recall_at_RETRIEVE: +div(retrievalHits).toFixed(4),
+        rank_recall_given_retrieved: Object.fromEntries(ks.map((k) => [k, +divR(rankRecallAtK[k]).toFixed(4)])),
+    }
+}
+
+// ---- field fill-rates (SUGGEST-5 overlap) -----------------------------------
+function fillRates(cands) {
+    const total = cands.length
+    const nonEmpty = (v) => (Array.isArray(v) ? v.length > 0 : !!(v && String(v).trim()))
+    const fields = ['cde_name', 'preferred_question_text', 'cde_definition', 'cde_source', 'aliases', 'cde_data_type']
+    const out = {}
+    for (const f of fields) {
+        const c = cands.reduce((acc, x) => acc + (nonEmpty(x[f]) ? 1 : 0), 0)
+        out[f] = { filled: c, total, pct: total ? +(100 * c / total).toFixed(1) : 0 }
+    }
+    return out
+}
+
+// ---- decision rubric --------------------------------------------------------
+// Drive the recommendation off the COLD numbers (the honest ones). Distinguish a
+// retrieval bottleneck (→ SUGGEST-2 embeddings) from a ranking bottleneck
+// (→ SUGGEST-4 LLM re-rank).
+function rubric(results) {
+    const cold = results.filter((r) => r.mode === 'cold')
+    if (!cold.length) return { verdict: 'no cold results', notes: [] }
+    const avg = (sel) => cold.reduce((a, r) => a + sel(r), 0) / cold.length
+    const r5 = avg((r) => r.recall[5] ?? 0)
+    const r20 = avg((r) => r.recall[20] ?? 0)
+    const mrr = avg((r) => r.mrr)
+
+    let verdict
+    if (r5 >= 0.85) {
+        verdict = 'LEXICAL SUFFICIENT — ship SUGGEST-1 as the default; SUGGEST-2/4 low priority.'
+    } else if (r5 >= 0.6) {
+        verdict = 'LEXICAL DECENT — worth investing in the tail (SUGGEST-2 embeddings and/or SUGGEST-4 re-rank).'
+    } else {
+        verdict = 'LEXICAL INSUFFICIENT — prioritize SUGGEST-2 (embeddings) for semantic recall.'
+    }
+
+    // Per-field bottleneck attribution — the two field-sets often fail for
+    // OPPOSITE reasons (retrieval vs ranking), so averaging would hide the
+    // actionable signal. A low retrieval-recall means the target never enters
+    // the candidate set (semantic gap → SUGGEST-2); a high retrieval-recall with
+    // weak top-k means candidates are present but mis-ordered (→ SUGGEST-4).
+    const bottlenecks = []
+    const notes = []
+    for (const r of cold) {
+        const retr = r.retrieval_recall_at_RETRIEVE
+        const rg5 = r.rank_recall_given_retrieved[5] ?? 0
+        const r1 = r.recall[1] ?? 0
+        const label = r.field.replace('preferred_question_text', 'question')
+        let kind, note
+        if (retr < 0.85) {
+            kind = 'retrieval'
+            note = `${label}: RETRIEVAL-limited — cold retrieval-recall@${RETRIEVE}=${pctv(retr)} (target absent from candidates ${pctv(1 - retr)} of the time). Substring lexical misses paraphrase/synonymy → SUGGEST-2 embeddings.`
+        } else if (rg5 < 0.9 || r1 < 0.75) {
+            kind = 'ranking'
+            note = `${label}: RANKING-limited — target retrieved ${pctv(retr)} of the time, but rank-recall@5|retrieved=${pctv(rg5)} and hit@1=${pctv(r1)}. Candidates present, mis-ordered → SUGGEST-4 LLM re-rank of the top-N.`
+        } else {
+            kind = 'none'
+            note = `${label}: lexical strong — retrieval-recall=${pctv(retr)}, recall@5=${pctv(r.recall[5] ?? 0)}.`
+        }
+        bottlenecks.push({ field: r.field, kind, retrieval_recall: retr, rank_recall_at_5_given_retrieved: rg5, hit_at_1: r1 })
+        notes.push(note)
+    }
+    notes.push(`overall (cold, avg of field-sets): recall@5=${pctv(r5)}  recall@20=${pctv(r20)}  MRR=${mrr.toFixed(3)}`)
+    return {
+        verdict,
+        cold_recall_at_5: +r5.toFixed(4),
+        cold_recall_at_20: +r20.toFixed(4),
+        cold_mrr: +mrr.toFixed(4),
+        bottlenecks,
+        notes,
+    }
+}
+function pctv(x) { return `${(100 * x).toFixed(1)}%` }
+
+// ---- reporting --------------------------------------------------------------
+function pct(x) { return `${(100 * x).toFixed(1)}%` }
+function printTable(results, ks) {
+    const head = ['field', 'mode', 'n', ...ks.map((k) => `R@${k}`), 'MRR', `retr@${RETRIEVE}`]
+    const rows = results.map((r) => [
+        r.field.replace('preferred_question_text', 'question'),
+        r.mode,
+        String(r.n_queries),
+        ...ks.map((k) => pct(r.recall[k] ?? 0)),
+        r.mrr.toFixed(3),
+        pct(r.retrieval_recall_at_RETRIEVE),
+    ])
+    const widths = head.map((h, i) => Math.max(h.length, ...rows.map((row) => row[i].length)))
+    const fmt = (cells) => cells.map((c, i) => c.padEnd(widths[i])).join('  ')
+    console.log('\n' + fmt(head))
+    console.log(widths.map((w) => '-'.repeat(w)).join('  '))
+    for (const row of rows) console.log(fmt(row))
+}
+
+// ---- main -------------------------------------------------------------------
+async function main() {
+    const args = parseArgs(process.argv)
+    if (args.help) { console.log(HELP); return }
+
+    console.error('loading catalog…')
+    const { cv, records } = await loadCatalog(args)
+    const cands = buildCandidates(records)
+    console.error(`catalog ${cv}: ${records.length} records, ${cands.length} with persistent_id`)
+    if (!cands.length) throw new Error('no candidates with persistent_id — wrong data source?')
+
+    const rnd = mulberry32(args.seed)
+    const fills = fillRates(cands)
+    const results = []
+    for (const field of ['preferred_question_text', 'aliases']) {
+        const all = buildFixtures(cands, field, args.maxAliases)
+        const fixtures = sampleN(all, args.sample, rnd)
+        console.error(
+            `field ${field}: ${all.length} labeled queries` +
+            (fixtures.length < all.length ? ` (sampling ${fixtures.length})` : ''),
+        )
+        if (!fixtures.length) continue
+        for (const mode of ['hot', 'cold']) {
+            const r = evalSet(cands, fixtures, field, mode, args.ks)
+            r.labeled_total = all.length
+            results.push(r)
+        }
+    }
+
+    const decision = rubric(results)
+    const report = {
+        generated_at: new Date().toISOString(),
+        catalog_version: cv,
+        catalog_records: records.length,
+        candidates_with_pid: cands.length,
+        retrieve_depth: RETRIEVE,
+        sample_per_field: args.sample,
+        ks: args.ks,
+        field_fill_rates: fills,
+        results,
+        decision,
+    }
+
+    printTable(results, args.ks)
+    console.log('\nField fill-rates (SUGGEST-5 signal):')
+    for (const [f, s] of Object.entries(fills)) console.log(`  ${f.padEnd(24)} ${String(s.filled).padStart(7)} / ${s.total}  (${s.pct}%)`)
+    console.log('\nDecision:')
+    console.log('  ' + decision.verdict)
+    for (const note of decision.notes) console.log('  • ' + note)
+
+    if (!existsSync(dirname(args.out))) await mkdir(dirname(args.out), { recursive: true })
+    await writeFile(args.out, JSON.stringify(report, null, 2))
+    console.log(`\nJSON report → ${args.out}`)
+}
+
+main().catch((e) => {
+    console.error('\nEVAL FAILED:', e?.message || e)
+    if (String(e?.message || e).includes('fetch') || String(e).includes('ENOTFOUND') || String(e).includes('403')) {
+        console.error('  (catalog CDN can be unreachable on VPN. Pass a local file with --jsonl,')
+        console.error('   or produce one from the published parquet — see eval/cde-suggest/README.md.)')
+    }
+    process.exit(1)
+})

--- a/src/components/datasets/metadata/models/CdeGallery.vue
+++ b/src/components/datasets/metadata/models/CdeGallery.vue
@@ -64,10 +64,11 @@
             <div v-if="!allBundles.length" class="cg-status">No matching bundles.</div>
             <div v-else class="cg-grid">
               <button v-for="b in pagedBundles" :key="b.bundle_name" class="cg-bundle" @click="openBundle(b)">
-                <div class="cg-bundle-name">{{ b.bundle_name }}</div>
+                <div class="cg-bundle-name">{{ b.display_name || b.bundle_name }}</div>
                 <div class="cg-bundle-meta">
                   {{ b.member_count }} element{{ b.member_count === 1 ? '' : 's' }}
-                  <template v-if="b.domain"> · {{ b.domain }}</template>
+                  <template v-if="b.steward_org"> · {{ b.steward_org }}</template>
+                  <template v-else-if="b.domain"> · {{ b.domain }}</template>
                 </div>
               </button>
             </div>
@@ -167,13 +168,65 @@
         </div>
 
         <div v-else-if="detail.kind === 'bundle'" class="cg-detail">
-          <div v-if="detail.loading" class="cg-status">Loading members…</div>
-          <ul v-else class="cg-member-list">
-            <li v-for="(m, i) in detail.members" :key="i" class="cg-member">
-              <span class="cg-member-name">{{ cdeLabel(m) }}</span>
-              <span class="cg-member-meta">{{ m.cde_data_type }}</span>
-            </li>
-          </ul>
+          <p v-if="detail.bundle && detail.bundle.definition && detail.bundle.definition !== detailTitle" class="cg-def">
+            {{ detail.bundle.definition }}
+          </p>
+
+          <div v-if="detail.bundle" class="cg-field">
+            <div class="cg-field-label">Steward</div>
+            <div>
+              {{ detail.bundle.steward_org || detail.bundle.working_group || '—' }}
+              <template v-if="detail.bundle.registration_status"> · {{ detail.bundle.registration_status }}</template>
+              <template v-if="detail.bundle.nih_endorsed"> · NIH-endorsed</template>
+            </div>
+          </div>
+
+          <div v-if="detail.bundle && detail.bundle.contexts && detail.bundle.contexts.length" class="cg-field">
+            <div class="cg-field-label">Context{{ detail.bundle.contexts.length === 1 ? '' : 's' }}</div>
+            <div class="cg-chips">
+              <span v-for="(c, i) in detail.bundle.contexts" :key="i" class="cg-chip">{{ c }}</span>
+            </div>
+          </div>
+
+          <div v-for="(vals, axis) in bundleFacets(detail.bundle)" :key="axis" class="cg-field">
+            <div class="cg-field-label">{{ axis }}</div>
+            <div class="cg-chips">
+              <span v-for="(v, i) in vals" :key="i" class="cg-chip">{{ v }}</span>
+            </div>
+          </div>
+
+          <div v-if="detail.bundle && detail.bundle.copyright_status" class="cg-field">
+            <div class="cg-field-label">Copyright</div>
+            <div>{{ detail.bundle.copyright_status }}</div>
+          </div>
+
+          <a
+            v-if="detail.bundle && detail.bundle.nlm_view_url"
+            :href="detail.bundle.nlm_view_url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="cg-nlm-link"
+          >
+            View this form on the NLM CDE Repository →
+          </a>
+
+          <div v-if="detail.bundle && detail.bundle.persistent_id" class="cg-field">
+            <div class="cg-field-label">Persistent ID</div>
+            <code class="cg-code">{{ detail.bundle.persistent_id }}</code>
+          </div>
+
+          <div class="cg-field">
+            <div class="cg-field-label">
+              Member CDEs<template v-if="!detail.loading"> ({{ detail.members.length }})</template>
+            </div>
+            <div v-if="detail.loading" class="cg-status">Loading members…</div>
+            <ul v-else class="cg-member-list">
+              <li v-for="(m, i) in detail.members" :key="i" class="cg-member">
+                <span class="cg-member-name">{{ cdeLabel(m) }}</span>
+                <span class="cg-member-meta">{{ m.cde_data_type }}</span>
+              </li>
+            </ul>
+          </div>
         </div>
       </el-drawer>
     </div>
@@ -213,7 +266,7 @@ const loading = ref(true)
 
 const membership = ref(new Map()) // persistent_id -> [bundle_name, ...]
 const detailVisible = ref(false)
-const detail = reactive({ kind: '', cde: null, bundles: [], members: [], loading: false, bundleName: '' })
+const detail = reactive({ kind: '', cde: null, bundle: null, bundles: [], members: [], loading: false, bundleName: '' })
 
 // Display label: the readable question text when present, else the (sometimes
 // cryptic) canonical name. NLM's cde_name can be a short code (e.g. PhenX
@@ -221,8 +274,19 @@ const detail = reactive({ kind: '', cde: null, bundles: [], members: [], loading
 const cdeLabel = (c) => (c && (c.preferred_question_text || c.cde_name)) || 'Element'
 
 const detailTitle = computed(() =>
-  detail.kind === 'cde' ? cdeLabel(detail.cde) : detail.bundleName || 'Bundle'
+  detail.kind === 'cde'
+    ? cdeLabel(detail.cde)
+    : (detail.bundle && detail.bundle.display_name) || detail.bundleName || 'Bundle'
 )
+
+// Bundle facets ({axis: [[node,node],...]}) -> {axis: ["node › node", ...]} for display.
+const bundleFacets = (b) => {
+  const out = {}
+  for (const [axis, paths] of Object.entries((b && b.facets) || {})) {
+    out[axis] = (paths || []).map((p) => (Array.isArray(p) ? p.join(' › ') : String(p)))
+  }
+  return out
+}
 
 const cdeValues = (c) =>
   ((c && c.permissible_values) || []).map((pv) => pv.label || pv.code || '').filter(Boolean)
@@ -242,7 +306,13 @@ const loadCdes = async () => {
 const loadBundles = async () => {
   const t = term.value.trim().toLowerCase()
   const all = await store.listBundles()
-  allBundles.value = t ? all.filter((b) => b.bundle_name.toLowerCase().includes(t)) : all
+  allBundles.value = t
+    ? all.filter(
+        (b) =>
+          (b.display_name || '').toLowerCase().includes(t) ||
+          b.bundle_name.toLowerCase().includes(t)
+      )
+    : all
   bundlePage.value = 1
 }
 const runSearch = async () => {
@@ -293,11 +363,19 @@ const openCde = async (c) => {
 const showBundle = async (name) => {
   detail.kind = 'bundle'
   detail.bundleName = name
+  detail.bundle = null
   detail.members = []
   detail.loading = true
   detailVisible.value = true
   try {
-    detail.members = await store.getBundleMembers(name)
+    const [full, members] = await Promise.all([store.getBundle(name), store.getBundleMembers(name)])
+    detail.bundle = full
+    // Show members in the form's question order (member_keys) when available.
+    if (full && Array.isArray(full.member_keys) && full.member_keys.length) {
+      const order = new Map(full.member_keys.map((k, i) => [k, i]))
+      members.sort((a, b) => (order.get(a.canonical_key) ?? 1e9) - (order.get(b.canonical_key) ?? 1e9))
+    }
+    detail.members = members
   } catch (e) {
     detail.members = []
   } finally {

--- a/src/components/datasets/metadata/models/OntologyBrowser.vue
+++ b/src/components/datasets/metadata/models/OntologyBrowser.vue
@@ -210,6 +210,26 @@
             <div v-else class="ob-muted">No narrower terms (leaf).</div>
           </div>
 
+          <div v-if="sel.partOf.length" class="ob-field">
+            <div class="ob-field-label">Part of</div>
+            <div class="ob-chips">
+              <button
+                v-for="p in sel.partOf"
+                :key="p.curie"
+                class="ob-chip ob-chip-link"
+                :title="p.curie"
+                @click="openTerm({ curie: p.curie, label: p.label })"
+              >{{ p.label }}</button>
+            </div>
+          </div>
+
+          <div v-if="sel.xrefs.length" class="ob-field">
+            <div class="ob-field-label">Cross-references</div>
+            <div class="ob-chips">
+              <span v-for="(x, i) in sel.xrefs" :key="i" class="ob-chip ob-chip-ref">{{ x }}</span>
+            </div>
+          </div>
+
           <a
             v-if="sel.iri"
             :href="sel.iri"
@@ -255,8 +275,14 @@ const showResults = computed(() => resultsOpen.value && term.value.trim() !== ''
 const detailVisible = ref(false)
 const sel = reactive({
   curie: '', label: '', ontology: '', ontology_version: '', definition: '', synonyms: '', iri: '',
-  lineage: [], children: [], childrenTruncated: false, loading: false,
+  lineage: [], children: [], childrenTruncated: false, xrefs: [], partOf: [], loading: false,
 })
+
+const splitPipe = (s) =>
+  String(s || '')
+    .split('|')
+    .map((x) => x.trim())
+    .filter(Boolean)
 
 const treeProps = {
   label: 'label',
@@ -335,6 +361,8 @@ const openTerm = async (node) => {
   sel.lineage = []
   sel.children = []
   sel.childrenTruncated = false
+  sel.xrefs = []
+  sel.partOf = []
   sel.loading = true
   detailVisible.value = true
   try {
@@ -345,11 +373,20 @@ const openTerm = async (node) => {
     ])
     if (sel.curie !== curie) return // a newer selection won the race
     if (full) {
+      if (full.label) sel.label = full.label // corrects the title when navigated by curie
       sel.ontology = full.ontology || sel.ontology
       sel.ontology_version = full.ontology_version || ''
       sel.definition = full.definition || ''
       sel.synonyms = full.synonyms || ''
       sel.iri = full.iri || ''
+      sel.xrefs = splitPipe(full.xrefs)
+      // Resolve part_of target labels (curies -> readable names) in one query.
+      const partCuries = splitPipe(full.part_of)
+      if (partCuries.length) {
+        const labels = await store.labelsFor(partCuries)
+        if (sel.curie !== curie) return
+        sel.partOf = partCuries.map((c) => ({ curie: c, label: labels.get(c) || c }))
+      }
     }
     sel.lineage = lineage
     sel.childrenTruncated = kids.length > CHILD_DISPLAY_CAP

--- a/src/components/datasets/metadata/models/OntologyBrowser.vue
+++ b/src/components/datasets/metadata/models/OntologyBrowser.vue
@@ -1,0 +1,556 @@
+<template>
+  <bf-stage>
+    <div class="ontology-browser">
+      <div class="ob-head">
+        <h2>Ontology Browser</h2>
+        <p class="ob-sub">
+          Explore the standard biomedical ontologies published to the catalog (MONDO diseases, HPO
+          phenotypes, UBERON anatomy, NCIt, and more). Browse the <code>is_a</code> hierarchy as a
+          tree, or search for a term — the detail panel shows where a concept sits in the ontology.
+        </p>
+      </div>
+
+      <div class="ob-controls">
+        <el-select
+          v-model="selectedOntology"
+          class="ob-onto"
+          placeholder="Ontology"
+          @change="onOntologyChange"
+        >
+          <el-option
+            v-for="s in store.sources"
+            :key="s.ontology"
+            :label="ontologyOptionLabel(s)"
+            :value="s.ontology"
+          />
+        </el-select>
+
+        <div class="ob-search-wrap">
+          <el-input
+            v-model="term"
+            placeholder="Search terms in this ontology"
+            clearable
+            class="ob-search"
+            @input="onSearch"
+            @focus="resultsOpen = true"
+            @blur="onSearchBlur"
+          >
+            <template #prefix><el-icon><Search /></el-icon></template>
+          </el-input>
+          <div v-if="showResults" class="ob-results">
+            <div v-if="searching" class="ob-status">Searching…</div>
+            <div v-else-if="!results.length" class="ob-status">No matching terms.</div>
+            <ul v-else class="ob-result-list">
+              <li
+                v-for="r in results"
+                :key="r.curie"
+                class="ob-result"
+                @mousedown.prevent="selectResult(r)"
+              >
+                <span class="ob-result-label">{{ r.label }}</span>
+                <span class="ob-result-curie">{{ r.curie }}</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="store.error" class="ob-status ob-error">{{ store.error }}</div>
+
+      <template v-else>
+        <!-- Breadcrumb: ontology root → ancestors → focus -->
+        <nav class="ob-crumbs" aria-label="Ontology lineage">
+          <button class="ob-crumb ob-crumb-link" @click="clearFocus">{{ selectedOntology || 'Ontology' }}</button>
+          <template v-for="(a, i) in focusLineage" :key="a.curie">
+            <span class="ob-crumb-sep">›</span>
+            <button class="ob-crumb ob-crumb-link" :title="a.curie" @click="focusTerm(a)">{{ a.label }}</button>
+          </template>
+          <template v-if="focus">
+            <span class="ob-crumb-sep">›</span>
+            <span class="ob-crumb ob-crumb-current" :title="focus.curie">{{ focus.label }}</span>
+          </template>
+        </nav>
+
+        <div v-if="treeLoading" class="ob-status">Loading ontology…</div>
+        <el-tree
+          v-else
+          :key="treeKey"
+          ref="treeRef"
+          class="ob-tree"
+          node-key="curie"
+          :props="treeProps"
+          :load="loadNode"
+          lazy
+          :default-expanded-keys="defaultExpandedKeys"
+          :expand-on-click-node="false"
+          highlight-current
+          @node-click="onNodeClick"
+        >
+          <template #default="{ data }">
+            <span class="ob-node" :class="{ 'ob-node-active': sel.curie === data.curie }">
+              <span class="ob-node-label">{{ data.label }}</span>
+              <span class="ob-node-curie">{{ data.curie }}</span>
+            </span>
+          </template>
+        </el-tree>
+      </template>
+
+      <!-- Detail drawer -->
+      <el-drawer v-model="detailVisible" :title="sel.label || 'Term'" size="480px" direction="rtl">
+        <div class="ob-detail">
+          <p v-if="sel.definition" class="ob-def">{{ sel.definition }}</p>
+          <p v-else-if="sel.loading" class="ob-def ob-muted">Loading…</p>
+
+          <div class="ob-field">
+            <div class="ob-field-label">Identifier</div>
+            <code class="ob-code">{{ sel.curie }}</code>
+          </div>
+
+          <div class="ob-field">
+            <div class="ob-field-label">Ontology</div>
+            <div>
+              {{ sel.ontology || selectedOntology }}
+              <template v-if="sel.ontology_version"> · {{ sel.ontology_version }}</template>
+            </div>
+          </div>
+
+          <div v-if="synonymList.length" class="ob-field">
+            <div class="ob-field-label">Synonyms</div>
+            <div class="ob-chips">
+              <span v-for="(s, i) in synonymList" :key="i" class="ob-chip">{{ s }}</span>
+            </div>
+          </div>
+
+          <div v-if="focusableSel" class="ob-field">
+            <button class="ob-focus-btn" @click="focusSelected">Focus this term in the tree</button>
+          </div>
+
+          <div class="ob-field">
+            <div class="ob-field-label">
+              Broader terms<template v-if="!sel.loading"> ({{ sel.lineage.length }})</template>
+            </div>
+            <div v-if="sel.loading" class="ob-status">Loading…</div>
+            <div v-else-if="sel.lineage.length" class="ob-chips">
+              <button
+                v-for="a in sel.lineage"
+                :key="a.curie"
+                class="ob-chip ob-chip-link"
+                :title="a.curie"
+                @click="focusTerm(a)"
+              >{{ a.label }}</button>
+            </div>
+            <div v-else class="ob-muted">Top-level term.</div>
+          </div>
+
+          <div class="ob-field">
+            <div class="ob-field-label">
+              Narrower terms<template v-if="!sel.loading"> ({{ sel.children.length }}<template v-if="sel.childrenTruncated">+</template>)</template>
+            </div>
+            <div v-if="sel.loading" class="ob-status">Loading…</div>
+            <div v-else-if="sel.children.length" class="ob-chips">
+              <button
+                v-for="k in sel.children"
+                :key="k.curie"
+                class="ob-chip ob-chip-link"
+                :title="k.curie"
+                @click="focusTerm(k)"
+              >{{ k.label }}</button>
+            </div>
+            <div v-else class="ob-muted">No narrower terms (leaf).</div>
+          </div>
+
+          <a
+            v-if="sel.iri"
+            :href="sel.iri"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="ob-ext-link"
+          >
+            View source ontology entry →
+          </a>
+        </div>
+      </el-drawer>
+    </div>
+  </bf-stage>
+</template>
+
+<script setup>
+import { ref, reactive, computed, onMounted } from 'vue'
+import { Search } from '@element-plus/icons-vue'
+import debounce from 'lodash.debounce'
+import { useOntologyStore } from '@/stores/ontologyStore'
+
+const store = useOntologyStore()
+
+const CHILD_DISPLAY_CAP = 60 // chips in the drawer "narrower terms" list
+
+const selectedOntology = ref('')
+const treeLoading = ref(true)
+
+// Tree is rooted at `focus` (its direct children are the top level); when focus is
+// null the top level is the ontology's roots. Remounting on treeKey re-runs the
+// lazy root load — the simplest reliable way to re-seed a lazy el-tree.
+const focus = ref(null) // { curie, label } | null
+const focusLineage = ref([]) // breadcrumb ancestors of focus, root-first
+const treeRef = ref(null)
+
+const term = ref('')
+const results = ref([])
+const searching = ref(false)
+const resultsOpen = ref(false)
+const showResults = computed(() => resultsOpen.value && term.value.trim() !== '')
+
+const detailVisible = ref(false)
+const sel = reactive({
+  curie: '', label: '', ontology: '', ontology_version: '', definition: '', synonyms: '', iri: '',
+  lineage: [], children: [], childrenTruncated: false, loading: false,
+})
+
+const treeProps = {
+  label: 'label',
+  children: 'children',
+  isLeaf: (data) => !data.has_children,
+}
+const treeKey = computed(() => `${selectedOntology.value}::${focus.value ? focus.value.curie : 'roots'}`)
+const defaultExpandedKeys = computed(() => []) // top level is loaded directly; nothing to pre-expand
+
+const ontologyOptionLabel = (s) =>
+  s.ontology_version ? `${s.ontology} · ${s.ontology_version}` : s.ontology
+const focusableSel = computed(() => sel.curie && (!focus.value || focus.value.curie !== sel.curie))
+const synonymList = computed(() =>
+  String(sel.synonyms || '')
+    .split(/[|;]/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+)
+
+// el-tree lazy loader. Level 0 = the tree's top level (focus's children, or the
+// ontology roots); deeper levels = a node's direct children.
+const loadNode = async (node, resolve) => {
+  try {
+    if (node.level === 0) {
+      const rows = focus.value
+        ? await store.children(focus.value.curie)
+        : await store.roots(selectedOntology.value)
+      resolve(rows)
+      return
+    }
+    resolve(await store.children(node.data.curie))
+  } catch (e) {
+    console.error('Ontology tree load failed:', e)
+    resolve([])
+  }
+}
+
+const onNodeClick = (data) => openTerm(data)
+
+// Populate the detail drawer: the node gives curie/label instantly, then hydrate
+// the full record + lineage + children.
+const openTerm = async (node) => {
+  const curie = node.curie
+  sel.curie = curie
+  sel.label = node.label
+  sel.ontology = node.ontology || ''
+  sel.ontology_version = ''
+  sel.definition = ''
+  sel.synonyms = ''
+  sel.iri = ''
+  sel.lineage = []
+  sel.children = []
+  sel.childrenTruncated = false
+  sel.loading = true
+  detailVisible.value = true
+  try {
+    const [full, lineage, kids] = await Promise.all([
+      store.getByCurie(curie),
+      store.lineage(curie),
+      store.children(curie, { limit: CHILD_DISPLAY_CAP + 1 }),
+    ])
+    if (sel.curie !== curie) return // a newer selection won the race
+    if (full) {
+      sel.ontology = full.ontology || sel.ontology
+      sel.ontology_version = full.ontology_version || ''
+      sel.definition = full.definition || ''
+      sel.synonyms = full.synonyms || ''
+      sel.iri = full.iri || ''
+    }
+    sel.lineage = lineage
+    sel.childrenTruncated = kids.length > CHILD_DISPLAY_CAP
+    sel.children = sel.childrenTruncated ? kids.slice(0, CHILD_DISPLAY_CAP) : kids
+  } catch (e) {
+    console.error('Ontology term detail load failed:', e)
+  } finally {
+    if (sel.curie === curie) sel.loading = false
+  }
+}
+
+// Re-root the tree at a term and refresh the breadcrumb.
+const focusTerm = async (node) => {
+  focus.value = { curie: node.curie, label: node.label }
+  term.value = ''
+  results.value = []
+  resultsOpen.value = false
+  try {
+    focusLineage.value = await store.lineage(node.curie)
+  } catch {
+    focusLineage.value = []
+  }
+}
+const focusSelected = () => focusTerm({ curie: sel.curie, label: sel.label })
+const clearFocus = () => {
+  focus.value = null
+  focusLineage.value = []
+}
+
+const runSearch = async () => {
+  const t = term.value.trim()
+  if (!t) {
+    results.value = []
+    return
+  }
+  searching.value = true
+  try {
+    results.value = await store.search(t, {
+      limit: 25,
+      ontologies: selectedOntology.value ? [selectedOntology.value] : null,
+    })
+  } catch (e) {
+    console.error('Ontology search failed:', e)
+    results.value = []
+  } finally {
+    searching.value = false
+  }
+}
+const onSearch = debounce(runSearch, 300)
+const onSearchBlur = () => setTimeout(() => { resultsOpen.value = false }, 150)
+
+const selectResult = async (r) => {
+  await focusTerm(r) // re-root the tree at the found term
+  openTerm(r) // and open its detail
+}
+
+const onOntologyChange = () => {
+  clearFocus()
+  term.value = ''
+  results.value = []
+}
+
+onMounted(async () => {
+  try {
+    await store.ensureLoaded()
+    if (store.sources.length) selectedOntology.value = store.sources[0].ontology
+  } catch (e) {
+    console.error('Ontology browser load failed:', e)
+  } finally {
+    treeLoading.value = false
+  }
+})
+</script>
+
+<style scoped lang="scss">
+@use '../../../../styles/theme' as theme;
+
+.ontology-browser {
+  min-height: 500px;
+}
+.ob-head h2 {
+  font-size: 20px;
+  line-height: 24px;
+  margin: 0;
+}
+.ob-sub {
+  color: theme.$gray_5;
+  max-width: 680px;
+  margin: 8px 0 20px;
+  line-height: 1.5;
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 12px;
+  }
+}
+.ob-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+.ob-onto {
+  width: 200px;
+}
+.ob-search-wrap {
+  position: relative;
+  flex: 1;
+  min-width: 260px;
+  max-width: 420px;
+}
+.ob-search {
+  width: 100%;
+}
+.ob-results {
+  position: absolute;
+  z-index: 10;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: theme.$white;
+  border: 1px solid theme.$gray_2;
+  border-radius: 3px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  max-height: 360px;
+  overflow-y: auto;
+}
+.ob-result-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.ob-result {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 12px;
+  cursor: pointer;
+  border-bottom: 1px solid theme.$gray_1;
+  &:last-child {
+    border-bottom: none;
+  }
+  &:hover {
+    background: theme.$gray_1;
+  }
+}
+.ob-result-label {
+  color: theme.$gray_6;
+}
+.ob-result-curie {
+  font-size: 12px;
+  color: theme.$gray_4;
+  white-space: nowrap;
+}
+.ob-status {
+  color: theme.$gray_4;
+  font-size: 14px;
+  padding: 8px 0;
+}
+.ob-error {
+  color: theme.$status_red;
+}
+.ob-muted {
+  color: theme.$gray_4;
+}
+.ob-crumbs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 12px;
+  font-size: 13px;
+}
+.ob-crumb {
+  padding: 2px 4px;
+}
+.ob-crumb-link {
+  color: theme.$purple_2;
+  cursor: pointer;
+  background: none;
+  border: none;
+  &:hover {
+    text-decoration: underline;
+  }
+}
+.ob-crumb-current {
+  color: theme.$gray_6;
+  font-weight: 500;
+}
+.ob-crumb-sep {
+  color: theme.$gray_3;
+}
+.ob-tree {
+  border: 1px solid theme.$gray_2;
+  border-radius: 3px;
+  padding: 8px;
+  min-height: 240px;
+}
+.ob-node {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+.ob-node-active .ob-node-label {
+  color: theme.$purple_2;
+}
+.ob-node-label {
+  color: theme.$gray_6;
+}
+.ob-node-curie {
+  font-size: 11px;
+  color: theme.$gray_4;
+}
+.ob-detail {
+  padding: 0 4px;
+}
+.ob-def {
+  color: theme.$gray_6;
+  line-height: 1.5;
+  margin: 0 0 16px;
+}
+.ob-field {
+  margin-bottom: 16px;
+}
+.ob-field-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: theme.$gray_5;
+  margin-bottom: 6px;
+}
+.ob-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.ob-chip {
+  font-size: 12px;
+  background: theme.$white;
+  border: 1px solid theme.$gray_2;
+  border-radius: 3px;
+  padding: 2px 8px;
+  color: theme.$gray_5;
+}
+.ob-chip-link {
+  cursor: pointer;
+  color: theme.$purple_2;
+  border-color: theme.$purple_0_7;
+  &:hover {
+    background: theme.$purple_tint;
+  }
+}
+.ob-focus-btn {
+  font-size: 13px;
+  color: theme.$purple_2;
+  background: none;
+  border: 1px solid theme.$purple_0_7;
+  border-radius: 3px;
+  padding: 6px 12px;
+  cursor: pointer;
+  &:hover {
+    background: theme.$purple_tint;
+  }
+}
+.ob-code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  color: theme.$purple_2;
+}
+.ob-ext-link {
+  display: inline-block;
+  margin-top: 8px;
+  font-size: 13px;
+  color: theme.$purple_2;
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
+}
+</style>

--- a/src/components/datasets/metadata/models/OntologyBrowser.vue
+++ b/src/components/datasets/metadata/models/OntologyBrowser.vue
@@ -84,6 +84,7 @@
           :default-expanded-keys="defaultExpandedKeys"
           :expand-on-click-node="false"
           highlight-current
+          empty-text="No terms"
           @node-click="onNodeClick"
         >
           <template #default="{ data }">

--- a/src/components/datasets/metadata/models/OntologyBrowser.vue
+++ b/src/components/datasets/metadata/models/OntologyBrowser.vue
@@ -2,15 +2,39 @@
   <bf-stage>
     <div class="ontology-browser">
       <div class="ob-head">
-        <h2>Ontology Browser</h2>
-        <p class="ob-sub">
-          Standard biomedical vocabularies you can reuse across your workspace. Pick a vocabulary,
-          then search or browse its hierarchy to find the right term.
-        </p>
-        <div class="ob-uses">
-          <span class="ob-use"><el-icon><PriceTag /></el-icon> Tag datasets with standard terms</span>
-          <span class="ob-use"><el-icon><Collection /></el-icon> Use a term’s subtree as a value set in metadata models</span>
+        <div class="ob-title-row">
+          <h2>Ontology Browser</h2>
+          <el-popover placement="bottom-start" :width="380" trigger="click" popper-class="ob-help-popper">
+            <template #reference>
+              <button type="button" class="ob-help-link">
+                <el-icon><QuestionFilled /></el-icon> How it works
+              </button>
+            </template>
+            <div class="ob-help">
+              <p class="ob-help-lead">
+                An <strong>ontology</strong> is a standard, shared vocabulary — biomedical terms with
+                agreed meanings, stable IDs, and <code>is_a</code> relationships that place each term
+                in a hierarchy (e.g. <em>type 2 diabetes</em> is a kind of <em>diabetes</em>).
+              </p>
+              <div class="ob-help-item">
+                <div class="ob-help-h"><el-icon><PriceTag /></el-icon> Tag datasets</div>
+                <p>Attach a term to a dataset so it's described in a standard way — making it easier
+                  to find and compare datasets across the platform.</p>
+              </div>
+              <div class="ob-help-item">
+                <div class="ob-help-h"><el-icon><Collection /></el-icon> Value sets in metadata</div>
+                <p>Pick a term and use its subtree (all narrower terms) as the allowed values for a
+                  property in a metadata model — so records are filled in with consistent, standardized
+                  codes.</p>
+              </div>
+            </div>
+          </el-popover>
         </div>
+        <p class="ob-sub">
+          Standard biomedical vocabularies you can reuse across your workspace — <strong>tag
+          datasets</strong> with standard terms and define <strong>value sets</strong> for metadata
+          properties. Pick a vocabulary, then search or browse its hierarchy to find the right term.
+        </p>
       </div>
 
       <!-- Vocabulary chooser -->
@@ -32,6 +56,22 @@
           <span class="ob-onto-desc">{{ ontologyMeta(o.ontology).desc }}</span>
           <span class="ob-onto-count">{{ formatCount(o.count) }} terms</span>
         </button>
+      </div>
+
+      <div v-if="!booting && browsableOntologies.length" class="ob-request-row">
+        <el-popover placement="top-start" :width="240" trigger="hover" popper-class="ob-help-popper">
+          <template #reference>
+            <span class="ob-request-icon" tabindex="0" role="button" aria-label="Request a different vocabulary">
+              <el-icon><InfoFilled /></el-icon> Missing a vocabulary?
+            </span>
+          </template>
+          <div class="ob-help ob-help-sm">
+            Don't see the vocabulary you need?
+            <a href="https://discover.pennsieve.io/support" target="_blank" rel="noopener noreferrer">
+              Contact our team →
+            </a>
+          </div>
+        </el-popover>
       </div>
 
       <div class="ob-controls">
@@ -187,7 +227,7 @@
 
 <script setup>
 import { ref, reactive, computed, onMounted } from 'vue'
-import { Search, Check, PriceTag, Collection } from '@element-plus/icons-vue'
+import { Search, Check, PriceTag, Collection, QuestionFilled, InfoFilled } from '@element-plus/icons-vue'
 import debounce from 'lodash.debounce'
 import { useOntologyStore } from '@/stores/ontologyStore'
 
@@ -400,10 +440,32 @@ onMounted(async () => {
 .ontology-browser {
   min-height: 500px;
 }
+.ob-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
 .ob-head h2 {
   font-size: 20px;
   line-height: 24px;
   margin: 0;
+}
+.ob-help-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: 13px;
+  color: theme.$purple_2;
+  &:hover {
+    text-decoration: underline;
+  }
+  .el-icon {
+    font-size: 15px;
+  }
 }
 .ob-sub {
   color: theme.$gray_5;
@@ -415,24 +477,6 @@ onMounted(async () => {
     font-size: 12px;
   }
 }
-.ob-uses {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 20px;
-  margin-bottom: 24px;
-}
-.ob-use {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 13px;
-  color: theme.$gray_5;
-  .el-icon {
-    color: theme.$purple_2;
-    font-size: 15px;
-  }
-}
-
 /* Vocabulary chooser — a row of selectable cards */
 .ob-onto-cards {
   display: grid;
@@ -493,6 +537,23 @@ onMounted(async () => {
   margin-top: 2px;
   font-size: 11px;
   color: theme.$gray_4;
+}
+.ob-request-row {
+  margin: 0 0 24px;
+}
+.ob-request-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  color: theme.$gray_4;
+  cursor: default;
+  .el-icon {
+    font-size: 14px;
+  }
+  &:hover {
+    color: theme.$purple_2;
+  }
 }
 .ob-controls {
   display: flex;
@@ -674,6 +735,58 @@ onMounted(async () => {
   text-decoration: none;
   &:hover {
     text-decoration: underline;
+  }
+}
+</style>
+
+<!-- Popover content is teleported to <body>, so it can't be styled by the scoped
+     block above; namespace it via popper-class instead. -->
+<style lang="scss">
+@use '../../../../styles/theme' as theme;
+
+.ob-help-popper.el-popover {
+  .ob-help-lead {
+    margin: 0 0 12px;
+    font-size: 13px;
+    line-height: 1.5;
+    color: theme.$gray_6;
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 12px;
+    }
+  }
+  .ob-help-item {
+    margin-top: 12px;
+    p {
+      margin: 4px 0 0;
+      font-size: 12px;
+      line-height: 1.5;
+      color: theme.$gray_5;
+    }
+  }
+  .ob-help-h {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    color: theme.$gray_6;
+    .el-icon {
+      color: theme.$purple_2;
+      font-size: 15px;
+    }
+  }
+  .ob-help-sm {
+    font-size: 13px;
+    line-height: 1.5;
+    color: theme.$gray_6;
+    a {
+      color: theme.$purple_2;
+      text-decoration: none;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
 }
 </style>

--- a/src/components/datasets/metadata/models/OntologyBrowser.vue
+++ b/src/components/datasets/metadata/models/OntologyBrowser.vue
@@ -18,7 +18,7 @@
           @change="onOntologyChange"
         >
           <el-option
-            v-for="s in store.sources"
+            v-for="s in browsableOntologies"
             :key="s.ontology"
             :label="ontologyOptionLabel(s)"
             :value="s.ontology"
@@ -71,7 +71,7 @@
           </template>
         </nav>
 
-        <div v-if="treeLoading" class="ob-status">Loading ontology…</div>
+        <div v-if="booting || ontologyLoading" class="ob-status">Loading ontology…</div>
         <el-tree
           v-else
           :key="treeKey"
@@ -185,7 +185,8 @@ const store = useOntologyStore()
 const CHILD_DISPLAY_CAP = 60 // chips in the drawer "narrower terms" list
 
 const selectedOntology = ref('')
-const treeLoading = ref(true)
+const booting = ref(true) // fetching the registry
+const ontologyLoading = ref(false) // loading the selected ontology's slice
 
 // Tree is rooted at `focus` (its direct children are the top level); when focus is
 // null the top level is the ontology's roots. Remounting on treeKey re-runs the
@@ -214,6 +215,8 @@ const treeProps = {
 const treeKey = computed(() => `${selectedOntology.value}::${focus.value ? focus.value.curie : 'roots'}`)
 const defaultExpandedKeys = computed(() => []) // top level is loaded directly; nothing to pre-expand
 
+// UCUM is a flat unit list (no is_a hierarchy) — not a browsable tree.
+const browsableOntologies = computed(() => store.available.filter((o) => o.ontology !== 'UCUM'))
 const ontologyOptionLabel = (s) =>
   s.ontology_version ? `${s.ontology} · ${s.ontology_version}` : s.ontology
 const focusableSel = computed(() => sel.curie && (!focus.value || focus.value.curie !== sel.curie))
@@ -329,20 +332,38 @@ const selectResult = async (r) => {
   openTerm(r) // and open its detail
 }
 
-const onOntologyChange = () => {
+// Load only the selected ontology's slice (+edges) — not every ontology.
+const loadSelected = async () => {
+  if (!selectedOntology.value) return
+  ontologyLoading.value = true
+  try {
+    await store.ensureOntology(selectedOntology.value)
+  } catch (e) {
+    console.error('Ontology load failed:', e)
+  } finally {
+    ontologyLoading.value = false
+  }
+}
+
+const onOntologyChange = async () => {
   clearFocus()
   term.value = ''
   results.value = []
+  await loadSelected()
 }
 
 onMounted(async () => {
   try {
-    await store.ensureLoaded()
-    if (store.sources.length) selectedOntology.value = store.sources[0].ontology
+    await store.ensureRegistry()
+    const first = browsableOntologies.value[0] || store.available[0]
+    if (first) {
+      selectedOntology.value = first.ontology
+      await loadSelected()
+    }
   } catch (e) {
     console.error('Ontology browser load failed:', e)
   } finally {
-    treeLoading.value = false
+    booting.value = false
   }
 })
 </script>

--- a/src/components/datasets/metadata/models/OntologyBrowser.vue
+++ b/src/components/datasets/metadata/models/OntologyBrowser.vue
@@ -271,14 +271,28 @@ const ONTOLOGY_META = {
   MONDO: { title: 'Diseases & disorders', desc: 'Harmonized disease definitions merged from many disease resources.' },
   HPO: { title: 'Phenotypes & signs', desc: 'Human phenotypic abnormalities — symptoms and clinical findings.' },
   UBERON: { title: 'Anatomy', desc: 'Anatomical structures across species — organs, tissues, body parts.' },
+  CL: { title: 'Cell types', desc: 'Types of cells across organisms — neurons, glia, immune cells, and more.' },
+  NCBITaxon: { title: 'Organisms & species', desc: 'Taxonomy of species and higher groups — tag the organism a dataset studies.' },
+  CHEBI: { title: 'Chemicals & drugs', desc: 'Chemical entities of biological interest — compounds, drugs, metabolites.' },
   NCIT: { title: 'Cancer & biomedical', desc: 'NCI Thesaurus — broad cancer and biomedical reference concepts.' },
   UCUM: { title: 'Units of measure', desc: 'Standard units for measurements.' },
 }
 const ontologyMeta = (name) => ONTOLOGY_META[name] || { title: name, desc: '' }
 const formatCount = (n) => Number(n || 0).toLocaleString()
 
-// UCUM is a flat unit list (no is_a hierarchy) — not a browsable tree.
-const browsableOntologies = computed(() => store.available.filter((o) => o.ontology !== 'UCUM'))
+// Preferred card order (and default landing = first). Anything not listed sorts
+// after, alphabetically. UCUM is a flat unit list — not a browsable tree.
+const ONTOLOGY_ORDER = ['MONDO', 'HPO', 'UBERON', 'CL', 'NCBITaxon', 'CHEBI', 'NCIT']
+const browsableOntologies = computed(() => {
+  const rank = (o) => {
+    const i = ONTOLOGY_ORDER.indexOf(o.ontology)
+    return i === -1 ? ONTOLOGY_ORDER.length : i
+  }
+  return store.available
+    .filter((o) => o.ontology !== 'UCUM')
+    .slice()
+    .sort((a, b) => rank(a) - rank(b) || a.ontology.localeCompare(b.ontology))
+})
 const focusableSel = computed(() => sel.curie && (!focus.value || focus.value.curie !== sel.curie))
 const synonymList = computed(() =>
   String(sel.synonyms || '')

--- a/src/components/datasets/metadata/models/OntologyBrowser.vue
+++ b/src/components/datasets/metadata/models/OntologyBrowser.vue
@@ -4,27 +4,37 @@
       <div class="ob-head">
         <h2>Ontology Browser</h2>
         <p class="ob-sub">
-          Explore the standard biomedical ontologies published to the catalog (MONDO diseases, HPO
-          phenotypes, UBERON anatomy, NCIt, and more). Browse the <code>is_a</code> hierarchy as a
-          tree, or search for a term — the detail panel shows where a concept sits in the ontology.
+          Standard biomedical vocabularies you can reuse across your workspace. Pick a vocabulary,
+          then search or browse its hierarchy to find the right term.
         </p>
+        <div class="ob-uses">
+          <span class="ob-use"><el-icon><PriceTag /></el-icon> Tag datasets with standard terms</span>
+          <span class="ob-use"><el-icon><Collection /></el-icon> Use a term’s subtree as a value set in metadata models</span>
+        </div>
+      </div>
+
+      <!-- Vocabulary chooser -->
+      <div v-if="booting" class="ob-status">Loading vocabularies…</div>
+      <div v-else class="ob-onto-cards">
+        <button
+          v-for="o in browsableOntologies"
+          :key="o.ontology"
+          type="button"
+          class="ob-onto-card"
+          :class="{ 'is-active': o.ontology === selectedOntology }"
+          @click="selectOntology(o.ontology)"
+        >
+          <span class="ob-onto-card-top">
+            <span class="ob-onto-code">{{ o.ontology }}</span>
+            <el-icon v-if="o.ontology === selectedOntology" class="ob-onto-check"><Check /></el-icon>
+          </span>
+          <span class="ob-onto-title">{{ ontologyMeta(o.ontology).title }}</span>
+          <span class="ob-onto-desc">{{ ontologyMeta(o.ontology).desc }}</span>
+          <span class="ob-onto-count">{{ formatCount(o.count) }} terms</span>
+        </button>
       </div>
 
       <div class="ob-controls">
-        <el-select
-          v-model="selectedOntology"
-          class="ob-onto"
-          placeholder="Ontology"
-          @change="onOntologyChange"
-        >
-          <el-option
-            v-for="s in browsableOntologies"
-            :key="s.ontology"
-            :label="ontologyOptionLabel(s)"
-            :value="s.ontology"
-          />
-        </el-select>
-
         <div class="ob-search-wrap">
           <el-input
             v-model="term"
@@ -177,7 +187,7 @@
 
 <script setup>
 import { ref, reactive, computed, onMounted } from 'vue'
-import { Search } from '@element-plus/icons-vue'
+import { Search, Check, PriceTag, Collection } from '@element-plus/icons-vue'
 import debounce from 'lodash.debounce'
 import { useOntologyStore } from '@/stores/ontologyStore'
 
@@ -216,10 +226,19 @@ const treeProps = {
 const treeKey = computed(() => `${selectedOntology.value}::${focus.value ? focus.value.curie : 'roots'}`)
 const defaultExpandedKeys = computed(() => []) // top level is loaded directly; nothing to pre-expand
 
+// Plain-language descriptions so users don't need to know the acronyms.
+const ONTOLOGY_META = {
+  MONDO: { title: 'Diseases & disorders', desc: 'Harmonized disease definitions merged from many disease resources.' },
+  HPO: { title: 'Phenotypes & signs', desc: 'Human phenotypic abnormalities — symptoms and clinical findings.' },
+  UBERON: { title: 'Anatomy', desc: 'Anatomical structures across species — organs, tissues, body parts.' },
+  NCIT: { title: 'Cancer & biomedical', desc: 'NCI Thesaurus — broad cancer and biomedical reference concepts.' },
+  UCUM: { title: 'Units of measure', desc: 'Standard units for measurements.' },
+}
+const ontologyMeta = (name) => ONTOLOGY_META[name] || { title: name, desc: '' }
+const formatCount = (n) => Number(n || 0).toLocaleString()
+
 // UCUM is a flat unit list (no is_a hierarchy) — not a browsable tree.
 const browsableOntologies = computed(() => store.available.filter((o) => o.ontology !== 'UCUM'))
-const ontologyOptionLabel = (s) =>
-  s.ontology_version ? `${s.ontology} · ${s.ontology_version}` : s.ontology
 const focusableSel = computed(() => sel.curie && (!focus.value || focus.value.curie !== sel.curie))
 const synonymList = computed(() =>
   String(sel.synonyms || '')
@@ -353,6 +372,12 @@ const onOntologyChange = async () => {
   await loadSelected()
 }
 
+const selectOntology = async (name) => {
+  if (name === selectedOntology.value) return
+  selectedOntology.value = name
+  await onOntologyChange()
+}
+
 onMounted(async () => {
   try {
     await store.ensureRegistry()
@@ -383,12 +408,91 @@ onMounted(async () => {
 .ob-sub {
   color: theme.$gray_5;
   max-width: 680px;
-  margin: 8px 0 20px;
+  margin: 8px 0 12px;
   line-height: 1.5;
   code {
     font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     font-size: 12px;
   }
+}
+.ob-uses {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+  margin-bottom: 24px;
+}
+.ob-use {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: theme.$gray_5;
+  .el-icon {
+    color: theme.$purple_2;
+    font-size: 15px;
+  }
+}
+
+/* Vocabulary chooser — a row of selectable cards */
+.ob-onto-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px;
+  margin-bottom: 24px;
+  max-width: 940px;
+}
+.ob-onto-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: left;
+  padding: 14px 16px;
+  background: theme.$white;
+  border: 1px solid theme.$gray_2;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease, background 0.15s ease;
+  &:hover {
+    border-color: theme.$purple_0_7;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+    transform: translateY(-1px);
+  }
+  &.is-active {
+    border-color: theme.$purple_2;
+    background: theme.$purple_tint;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07);
+  }
+}
+.ob-onto-card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 18px;
+}
+.ob-onto-code {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: theme.$purple_2;
+}
+.ob-onto-check {
+  color: theme.$purple_2;
+  font-size: 16px;
+}
+.ob-onto-title {
+  font-size: 15px;
+  font-weight: 500;
+  color: theme.$gray_6;
+}
+.ob-onto-desc {
+  font-size: 12px;
+  color: theme.$gray_5;
+  line-height: 1.4;
+}
+.ob-onto-count {
+  margin-top: 2px;
+  font-size: 11px;
+  color: theme.$gray_4;
 }
 .ob-controls {
   display: flex;
@@ -396,9 +500,6 @@ onMounted(async () => {
   align-items: flex-start;
   gap: 12px;
   margin-bottom: 16px;
-}
-.ob-onto {
-  width: 200px;
 }
 .ob-search-wrap {
   position: relative;

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -403,9 +403,13 @@ const pickSubtree = async (term) => {
   ontoTerm.value = ''
   subtreeNote.value = 'Loading subtypes…'
   try {
-    const descs = await ontology.descendants(term.curie, { limit: 2000 })
-    manual.enumInput = [term.label, ...descs.map((d) => d.label)].join(', ')
-    subtreeNote.value = `Loaded ${descs.length} subtypes of “${term.label}” (${term.curie}) as allowed values.`
+    const descs = await ontology.descendants(term.curie, { limit: 5000 })
+    // A value set's members are the ontology CODES (curies) — comma-free and
+    // stable — not the labels (which contain commas and aren't identifiers). The
+    // labels are display only; a full value_domain materialization carries them.
+    const curies = [term.curie, ...descs.map((d) => d.curie)]
+    manual.enumInput = curies.join(', ')
+    subtreeNote.value = `Loaded ${curies.length} coded values from the “${term.label}” (${term.curie}) subtree — the codes are the value set; display labels come with a full value-domain materialization.`
   } catch (e) {
     subtreeNote.value = 'Could not load subtree: ' + (e?.message || e)
   }

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -403,9 +403,10 @@ const ontology = useOntologyStore()
 const ontoTerm = ref('')
 const ontoResults = ref([])
 const subtreeNote = ref('')
-const subtreeRoot = ref(null) // { curie, label }
+const subtreeRoot = ref(null) // { curie, label, ontology, ontology_version }
 const subtreeDepth = ref('all') // 'all' | '1' | '2' | '3'
 const subtreeLeaves = ref(false)
+const valueDomain = ref(null) // the materialized ontology-subtree value domain (or null)
 const SUBTREE_INLINE_CAP = 512
 
 const runOntoSearch = debounce(async () => {
@@ -420,20 +421,27 @@ const runOntoSearch = debounce(async () => {
 const ontoMeta = (c) => (c.curie.startsWith(c.ontology + ':') ? c.curie : `${c.ontology} · ${c.curie}`)
 
 const selectSubtreeRoot = (term) => {
-  subtreeRoot.value = { curie: term.curie, label: term.label }
+  subtreeRoot.value = {
+    curie: term.curie,
+    label: term.label,
+    ontology: term.ontology,
+    ontology_version: term.ontology_version,
+  }
   ontoResults.value = []
   ontoTerm.value = ''
   applySubtree()
 }
 const clearSubtree = () => {
   subtreeRoot.value = null
+  valueDomain.value = null
   subtreeNote.value = ''
 }
 
-// Build the value set from the chosen root + granularity (depth / leaves-only).
-// Value-set members are the ontology CODES (curies) — comma-free + stable; labels
-// are display only. Over the inline cap, don't bloat the schema — that's the
-// subtree-reference + membership-check case (a real value_domain).
+// Resolve the value set from the chosen root + granularity (depth / leaves-only)
+// and hold it as a materialized value_domain. Under the inline cap it carries the
+// {code,label} members (materialized to an enum + labels at build); over the cap
+// it's a subtree REFERENCE (root + version + granularity) enforced by a membership
+// check — never an inline dump. Value-set members are the ontology CODES (curies).
 const applySubtree = async () => {
   const root = subtreeRoot.value
   if (!root) return
@@ -441,22 +449,67 @@ const applySubtree = async () => {
   try {
     const maxDepth = subtreeDepth.value === 'all' ? null : Number(subtreeDepth.value)
     const descs = await ontology.descendants(root.curie, { maxDepth, leavesOnly: subtreeLeaves.value, limit: 10000 })
-    const members = subtreeLeaves.value ? descs : [{ curie: root.curie, label: root.label }, ...descs]
+    const memberTerms = subtreeLeaves.value ? descs : [{ curie: root.curie, label: root.label }, ...descs]
     const scope =
       (subtreeDepth.value === 'all' ? 'all descendants' : `depth ≤ ${subtreeDepth.value}`) +
       (subtreeLeaves.value ? ', most-specific only' : '')
 
-    if (members.length > SUBTREE_INLINE_CAP) {
+    const overCap = memberTerms.length > SUBTREE_INLINE_CAP
+    valueDomain.value = {
+      kind: 'subtree',
+      ontology: root.ontology,
+      root_curie: root.curie,
+      root_label: root.label,
+      ontology_version: root.ontology_version,
+      max_depth: maxDepth,
+      leaves_only: subtreeLeaves.value,
+      count: memberTerms.length,
+      over_cap: overCap,
+      members: overCap ? null : memberTerms.map((m) => ({ code: m.curie, label: m.label })),
+    }
+
+    if (overCap) {
+      manual.enumInput = '' // don't inline; stored as a subtree reference at build
       subtreeNote.value =
-        `${members.length} values from “${root.label}” (${scope}) — over the ${SUBTREE_INLINE_CAP} inline cap. ` +
-        `A full value_domain would store this as a subtree reference (root + version) enforced by a membership check, not an inline list. ` +
+        `${memberTerms.length} values from “${root.label}” (${scope}) — over the ${SUBTREE_INLINE_CAP} inline cap, ` +
+        `so this is stored as a subtree reference (root + version + granularity) enforced by a membership check, not an inline list. ` +
         `Narrow the root or lower the depth to inline it.`
     } else {
-      manual.enumInput = members.map((m) => m.curie).join(', ')
-      subtreeNote.value = `Filled ${members.length} coded values from “${root.label}” (${scope}). Codes are the value set; labels are display.`
+      manual.enumInput = memberTerms.map((m) => m.curie).join(', ') // codes; labels attached at build
+      subtreeNote.value = `${memberTerms.length} values from “${root.label}” (${scope}) — inlined as an enum with display labels.`
     }
   } catch (e) {
+    valueDomain.value = null
     subtreeNote.value = 'Could not load subtree: ' + (e?.message || e)
+  }
+}
+
+// Materialize the chosen ontology value domain onto a property schema: the concept
+// anchor always; under the cap an enum (codes) + display labels; over the cap the
+// subtree reference (membership-enforced at record write, VALSET-style).
+const applyValueDomain = (schema, vd) => {
+  schema['x-pennsieve-concept'] = {
+    curie: vd.root_curie,
+    label: vd.root_label,
+    ontology: vd.ontology,
+    ontology_version: vd.ontology_version,
+  }
+  if (vd.over_cap) {
+    delete schema.enum
+    const ref = {
+      tier: 'subtree',
+      ontology: vd.ontology,
+      root: vd.root_curie,
+      ontology_version: vd.ontology_version,
+      count: vd.count,
+    }
+    if (vd.max_depth != null) ref.max_depth = vd.max_depth
+    if (vd.leaves_only) ref.leaves_only = true
+    schema['x-pennsieve-concept-valueset'] = ref
+  } else {
+    schema.type = schema.type || 'string'
+    schema.enum = vd.members.map((m) => m.code)
+    schema['x-pennsieve-concept-values'] = vd.members
   }
 }
 
@@ -692,6 +745,7 @@ const buildSingleDef = () => {
   if (basics.description) schema.description = basics.description
   if (isManual.value) {
     Object.assign(schema, manualValueSchema())
+    if (valueDomain.value) applyValueDomain(schema, valueDomain.value)
   } else if (selectedCde.value) {
     Object.assign(schema, dataTypeSchema(selectedCde.value.cde_data_type))
     schema['x-pennsieve-cde'] = { persistent_id: selectedCde.value.persistent_id, strength: strength.value }

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -313,12 +313,27 @@
                   v-for="c in ontoResults"
                   :key="c.curie"
                   style="display: flex; justify-content: space-between; gap: 8px; padding: 8px 16px; cursor: pointer"
-                  @click="pickSubtree(c)"
+                  @click="selectSubtreeRoot(c)"
                 >
                   <span>{{ c.label }}</span>
                   <span style="flex-shrink: 0; font-size: 12px; opacity: 0.6">{{ ontoMeta(c) }}</span>
                 </li>
               </ul>
+              <!-- Granularity controls once a root is chosen -->
+              <div
+                v-if="subtreeRoot"
+                style="margin-top: 8px; display: flex; gap: 12px; align-items: center; flex-wrap: wrap"
+              >
+                <span style="font-size: 12px">From <strong>{{ subtreeRoot.label }}</strong>:</span>
+                <el-select v-model="subtreeDepth" size="small" style="width: 160px" @change="applySubtree">
+                  <el-option label="All descendants" value="all" />
+                  <el-option label="Direct children" value="1" />
+                  <el-option label="2 levels" value="2" />
+                  <el-option label="3 levels" value="3" />
+                </el-select>
+                <el-checkbox v-model="subtreeLeaves" size="small" @change="applySubtree">Most specific only</el-checkbox>
+                <el-button text size="small" @click="clearSubtree">clear</el-button>
+              </div>
               <div v-if="subtreeNote" class="wiz-hint" style="margin-top: 6px">{{ subtreeNote }}</div>
             </div>
           </el-form-item>
@@ -388,6 +403,11 @@ const ontology = useOntologyStore()
 const ontoTerm = ref('')
 const ontoResults = ref([])
 const subtreeNote = ref('')
+const subtreeRoot = ref(null) // { curie, label }
+const subtreeDepth = ref('all') // 'all' | '1' | '2' | '3'
+const subtreeLeaves = ref(false)
+const SUBTREE_INLINE_CAP = 512
+
 const runOntoSearch = debounce(async () => {
   const q = ontoTerm.value.trim()
   if (!q) { ontoResults.value = []; return }
@@ -398,18 +418,43 @@ const runOntoSearch = debounce(async () => {
   }
 }, 200)
 const ontoMeta = (c) => (c.curie.startsWith(c.ontology + ':') ? c.curie : `${c.ontology} · ${c.curie}`)
-const pickSubtree = async (term) => {
+
+const selectSubtreeRoot = (term) => {
+  subtreeRoot.value = { curie: term.curie, label: term.label }
   ontoResults.value = []
   ontoTerm.value = ''
-  subtreeNote.value = 'Loading subtypes…'
+  applySubtree()
+}
+const clearSubtree = () => {
+  subtreeRoot.value = null
+  subtreeNote.value = ''
+}
+
+// Build the value set from the chosen root + granularity (depth / leaves-only).
+// Value-set members are the ontology CODES (curies) — comma-free + stable; labels
+// are display only. Over the inline cap, don't bloat the schema — that's the
+// subtree-reference + membership-check case (a real value_domain).
+const applySubtree = async () => {
+  const root = subtreeRoot.value
+  if (!root) return
+  subtreeNote.value = 'Loading…'
   try {
-    const descs = await ontology.descendants(term.curie, { limit: 5000 })
-    // A value set's members are the ontology CODES (curies) — comma-free and
-    // stable — not the labels (which contain commas and aren't identifiers). The
-    // labels are display only; a full value_domain materialization carries them.
-    const curies = [term.curie, ...descs.map((d) => d.curie)]
-    manual.enumInput = curies.join(', ')
-    subtreeNote.value = `Loaded ${curies.length} coded values from the “${term.label}” (${term.curie}) subtree — the codes are the value set; display labels come with a full value-domain materialization.`
+    const maxDepth = subtreeDepth.value === 'all' ? null : Number(subtreeDepth.value)
+    const descs = await ontology.descendants(root.curie, { maxDepth, leavesOnly: subtreeLeaves.value, limit: 10000 })
+    const members = subtreeLeaves.value ? descs : [{ curie: root.curie, label: root.label }, ...descs]
+    const scope =
+      (subtreeDepth.value === 'all' ? 'all descendants' : `depth ≤ ${subtreeDepth.value}`) +
+      (subtreeLeaves.value ? ', most-specific only' : '')
+
+    if (members.length > SUBTREE_INLINE_CAP) {
+      subtreeNote.value =
+        `${members.length} values from “${root.label}” (${scope}) — over the ${SUBTREE_INLINE_CAP} inline cap. ` +
+        `A full value_domain would store this as a subtree reference (root + version) enforced by a membership check, not an inline list. ` +
+        `Narrow the root or lower the depth to inline it.`
+    } else {
+      manual.enumInput = members.map((m) => m.curie).join(', ')
+      subtreeNote.value = `Filled ${members.length} coded values from “${root.label}” (${scope}). Codes are the value set; labels are display.`
+    }
   } catch (e) {
     subtreeNote.value = 'Could not load subtree: ' + (e?.message || e)
   }

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -295,6 +295,32 @@
         <el-form label-position="top">
           <el-form-item label="Allowed values">
             <el-input v-model="manual.enumInput" placeholder="Comma-separated, e.g. Low, Medium, High" />
+            <!-- Prototype: fill allowed values from an ontology subtree -->
+            <div style="margin-top: 8px; width: 100%">
+              <el-input
+                v-model="ontoTerm"
+                size="small"
+                placeholder="…or fill from an ontology term's subtree — e.g. diabetes, seizure"
+                @input="runOntoSearch"
+              >
+                <template #prefix><el-icon><Search /></el-icon></template>
+              </el-input>
+              <ul
+                v-if="ontoResults.length"
+                style="list-style: none; margin: 8px 0 0; padding: 0; border: 1px solid var(--el-border-color); border-radius: 4px; max-height: 200px; overflow: auto"
+              >
+                <li
+                  v-for="c in ontoResults"
+                  :key="c.curie"
+                  style="display: flex; justify-content: space-between; gap: 8px; padding: 8px 16px; cursor: pointer"
+                  @click="pickSubtree(c)"
+                >
+                  <span>{{ c.label }}</span>
+                  <span style="flex-shrink: 0; font-size: 12px; opacity: 0.6">{{ ontoMeta(c) }}</span>
+                </li>
+              </ul>
+              <div v-if="subtreeNote" class="wiz-hint" style="margin-top: 6px">{{ subtreeNote }}</div>
+            </div>
           </el-form-item>
           <template v-if="manual.type === 'string'">
             <div class="wiz-two">
@@ -345,6 +371,7 @@ import { ElMessage } from 'element-plus'
 import { Link, EditPen, Search, Close } from '@element-plus/icons-vue'
 import debounce from 'lodash.debounce'
 import { useCdeCatalogStore } from '@/stores/cdeCatalogStore'
+import { useOntologyStore } from '@/stores/ontologyStore'
 import CdeFacets from './CdeFacets.vue'
 
 const props = defineProps({
@@ -354,6 +381,35 @@ const props = defineProps({
 const emit = defineEmits(['save', 'cancel'])
 
 const store = useCdeCatalogStore()
+const ontology = useOntologyStore()
+
+// Prototype: fill a custom property's allowed values from an open-ontology
+// subtree (all is_a descendants of a term) — the ontology → value-set bridge.
+const ontoTerm = ref('')
+const ontoResults = ref([])
+const subtreeNote = ref('')
+const runOntoSearch = debounce(async () => {
+  const q = ontoTerm.value.trim()
+  if (!q) { ontoResults.value = []; return }
+  try {
+    ontoResults.value = (await ontology.search(q, { limit: 6 })).filter((r) => r.ontology !== 'UCUM')
+  } catch (e) {
+    ontoResults.value = []
+  }
+}, 200)
+const ontoMeta = (c) => (c.curie.startsWith(c.ontology + ':') ? c.curie : `${c.ontology} · ${c.curie}`)
+const pickSubtree = async (term) => {
+  ontoResults.value = []
+  ontoTerm.value = ''
+  subtreeNote.value = 'Loading subtypes…'
+  try {
+    const descs = await ontology.descendants(term.curie, { limit: 2000 })
+    manual.enumInput = [term.label, ...descs.map((d) => d.label)].join(', ')
+    subtreeNote.value = `Loaded ${descs.length} subtypes of “${term.label}” (${term.curie}) as allowed values.`
+  } catch (e) {
+    subtreeNote.value = 'Could not load subtree: ' + (e?.message || e)
+  }
+}
 
 const sourceMode = ref('') // '' | 'catalog' | 'manual'
 

--- a/src/components/datasets/metadata/records/RecordSpecGenerator.vue
+++ b/src/components/datasets/metadata/records/RecordSpecGenerator.vue
@@ -466,6 +466,21 @@ const updateRecord = async () => {
   }
 }
 
+// A required CDE binding whose value set was too large to inline (or has no
+// published values) carries `x-pennsieve-cde-valueset` instead of an `enum`.
+// Surface it so the field reads as controlled-by-a-CDE rather than free-form.
+const cdeValueSet = (property) => property?.property?.['x-pennsieve-cde-valueset'] || null
+const cdeValueSetHint = (property) => {
+  const vs = cdeValueSet(property)
+  if (!vs) return ''
+  if (vs.reason === 'values_unpublished') {
+    return 'Allowed values are defined by a linked CDE but not published (they may be license-restricted). Enter a value that conforms to the CDE.'
+  }
+  const count = typeof vs.count === 'number' ? vs.count.toLocaleString() : ''
+  const system = vs.code_system ? ` from ${vs.code_system}` : ''
+  return `Bound to a CDE value set (${count ? count + ' ' : ''}allowed values${system}) too large to list here — refer to the CDE for the allowed codes.`
+}
+
 // Helper function for rendering just the form input
 const renderFormFieldInput = (property) => {
   const { key, type, format, enum: enumValues } = property
@@ -1120,13 +1135,21 @@ onMounted(async () => {
                   >
                     Required
                   </el-tag>
-                  <el-tag 
+                  <el-tag
                     v-if="property.property && property.property['x-pennsieve-key']"
                     size="small"
                     effect="plain"
                     class="tag-key"
                   >
                     Key
+                  </el-tag>
+                  <el-tag
+                    v-if="cdeValueSet(property)"
+                    size="small"
+                    effect="plain"
+                    class="tag-valueset"
+                  >
+                    Value set
                   </el-tag>
                   <el-tag 
                     size="small"
@@ -1149,7 +1172,12 @@ onMounted(async () => {
               <!-- Form Input -->
               <div class="property-input">
                 <component :is="renderFormField(property)" />
-                
+
+                <!-- CDE value-set reference (too large to inline / unpublished) -->
+                <div v-if="cdeValueSet(property)" class="cde-valueset-hint">
+                  {{ cdeValueSetHint(property) }}
+                </div>
+
                 <!-- Validation Error Display -->
                 <div 
                   v-for="error in validationErrors.filter(err => err.instancePath && err.instancePath.includes(property.key))" 
@@ -1497,7 +1525,13 @@ onMounted(async () => {
                     border-color: theme.$gray_3;
                     color: theme.$gray_5;
                   }
-                  
+
+                  :deep(.tag-valueset) {
+                    background-color: theme.$purple_tint;
+                    border-color: theme.$purple_0_7;
+                    color: theme.$purple_2;
+                  }
+
                   :deep(.tag-array) {
                     background-color: theme.$purple_tint;
                     border-color: theme.$purple_0_7;
@@ -1580,6 +1614,16 @@ onMounted(async () => {
                   padding: 4px 8px;
                   background: theme.$red_tint;
                   border: 1px solid theme.$red_1;
+                }
+
+                .cde-valueset-hint {
+                  color: theme.$gray_5;
+                  font-size: 12px;
+                  margin-top: 6px;
+                  padding: 4px 8px;
+                  background: theme.$purple_tint;
+                  border: 1px solid theme.$purple_0_7;
+                  border-radius: 4px;
                 }
               }
             }

--- a/src/components/datasets/metadata/records/RecordSpecGenerator.vue
+++ b/src/components/datasets/metadata/records/RecordSpecGenerator.vue
@@ -470,6 +470,22 @@ const updateRecord = async () => {
 // published values) carries `x-pennsieve-cde-valueset` instead of an `enum`.
 // Surface it so the field reads as controlled-by-a-CDE rather than free-form.
 const cdeValueSet = (property) => property?.property?.['x-pennsieve-cde-valueset'] || null
+
+// code -> display label for an enum, from a materialized value-list annotation
+// (ontology `x-pennsieve-concept-values` or CDE `x-pennsieve-cde-values`). Empty
+// map when none — the enum then shows the raw codes.
+const enumOptionLabels = (property) => {
+  const vals =
+    property?.property?.['x-pennsieve-concept-values'] ||
+    property?.property?.['x-pennsieve-cde-values'] ||
+    []
+  const map = {}
+  for (const v of vals) {
+    const code = v?.code ?? v?.value
+    if (code != null) map[code] = v.label || String(code)
+  }
+  return map
+}
 const cdeValueSetHint = (property) => {
   const vs = cdeValueSet(property)
   if (!vs) return ''
@@ -486,6 +502,10 @@ const renderFormFieldInput = (property) => {
   const { key, type, format, enum: enumValues } = property
   
   if (enumValues && enumValues.length > 0) {
+    // Enum stores codes; show human labels when a values annotation carries them
+    // (CDE-materialized or ontology value domains), so the dropdown reads
+    // "type 2 diabetes mellitus" while the record stores "MONDO:0005148".
+    const labels = enumOptionLabels(property)
     return h(ElSelect, {
       modelValue: formData.value[key],
       'onUpdate:modelValue': (value) => {
@@ -497,9 +517,10 @@ const renderFormFieldInput = (property) => {
       },
       placeholder: `Select ${property.label}`,
       clearable: true,
+      filterable: true,
       size: 'default'
-    }, () => enumValues.map(option => 
-      h(ElOption, { key: option, label: option, value: option })
+    }, () => enumValues.map(option =>
+      h(ElOption, { key: option, label: labels[option] || option, value: option })
     ))
   }
   

--- a/src/components/datasets/settings/BfDatasetSettings.vue
+++ b/src/components/datasets/settings/BfDatasetSettings.vue
@@ -50,14 +50,31 @@
               <el-input
                 ref="inputTags"
                 v-model="inputTag"
-                placeholder="Add tags and press Enter"
+                placeholder="Add a tag and press Enter, or search standard ontology terms"
                 :disabled="datasetLocked"
                 @keyup.enter.native.stop="addTag"
+                @input="onTagInput"
               >
                 <template #prefix>
                   <IconTag :height="16" :width="16" />
                 </template>
               </el-input>
+              <!-- Ontology term suggestions (MONDO/HPO/UBERON/NCIt): pick one to add a
+                   standardized tag. Silently empty until slices are published / when
+                   offline, so free-text tagging always works. -->
+              <ul
+                v-if="conceptResults.length && inputTag.trim()"
+                class="concept-suggestions"
+              >
+                <li
+                  v-for="c in conceptResults"
+                  :key="c.curie"
+                  @click="addConceptTag(c)"
+                >
+                  <span class="concept-label">{{ c.label }}</span>
+                  <span class="concept-meta">{{ c.ontology }} · {{ c.curie }}</span>
+                </li>
+              </ul>
               <div v-if="form.tags.length > 0" class="tag-wrap">
                 <bf-tag
                   v-for="tag in form.tags"
@@ -119,6 +136,7 @@
   import SanitizeName from '../../../mixins/sanitize-name'
   import BfEmptyPageState from '../../shared/bf-empty-page-state/BfEmptyPageState.vue'
   import BfTag from '../../shared/BfTag/BfTag.vue'
+  import { useOntologyStore } from '@/stores/ontologyStore'
 
 
   import licenses from './dataset-licenses'
@@ -173,6 +191,7 @@ export default {
         tags: []
       },
       inputTag: '',
+      conceptResults: [],
       rules: {
         name: [
           {
@@ -487,6 +506,7 @@ export default {
 
       if (tag) {
         this.inputTag = ''
+        this.conceptResults = []
 
         const tagExists = this.checkIfTagExists(tag)
         if (tagExists === false) {
@@ -504,6 +524,47 @@ export default {
       const idx = this.form.tags.indexOf(tag)
       this.form.tags.splice(idx, 1)
       this.submitUpdateDatasetRequest()
+    },
+
+    /**
+     * As the user types a tag, search the published ontology slices for standard
+     * terms to suggest (debounced). Degrades silently to free-text tagging when
+     * the slices aren't published or the browser is offline.
+     */
+    onTagInput: function() {
+      if (!this.inputTag.trim()) {
+        this.conceptResults = []
+        return
+      }
+      if (!this.debouncedConceptSearch) {
+        this.debouncedConceptSearch = debounce(this.doConceptSearch, 200)
+      }
+      this.debouncedConceptSearch()
+    },
+
+    doConceptSearch: async function() {
+      const q = this.inputTag.trim()
+      if (!q) {
+        this.conceptResults = []
+        return
+      }
+      try {
+        const rows = await useOntologyStore().search(q, { limit: 8 })
+        // Dataset tags: drop UCUM units (irrelevant for describing a dataset).
+        this.conceptResults = (rows || []).filter((r) => r.ontology !== 'UCUM')
+      } catch (e) {
+        this.conceptResults = [] // slices unpublished / offline — free-text still works
+      }
+    },
+
+    /**
+     * Add a standardized tag from a picked ontology term (reuses addTag's
+     * normalization + dedup + save; Level 1 stores the label string).
+     */
+    addConceptTag: function(term) {
+      this.inputTag = term.label
+      this.conceptResults = []
+      this.addTag()
     }
   }
 }
@@ -515,6 +576,44 @@ export default {
 
 .details-container {
   max-width: 640px;
+}
+
+// Ontology term suggestions under the tags input (ONT-2).
+.concept-suggestions {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  border: 1px solid theme.$gray_2;
+  border-radius: 4px;
+  max-height: 240px;
+  overflow-y: auto;
+
+  li {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 8px 16px;
+    cursor: pointer;
+
+    &:hover {
+      background: theme.$gray_1;
+    }
+
+    & + li {
+      border-top: 1px solid theme.$gray_1;
+    }
+  }
+
+  .concept-label {
+    font-size: 14px;
+  }
+
+  .concept-meta {
+    flex-shrink: 0;
+    font-size: 12px;
+    color: theme.$gray_5;
+  }
 }
 
 .settings-section {

--- a/src/components/datasets/settings/BfDatasetSettings.vue
+++ b/src/components/datasets/settings/BfDatasetSettings.vue
@@ -72,7 +72,7 @@
                   @click="addConceptTag(c)"
                 >
                   <span class="concept-label">{{ c.label }}</span>
-                  <span class="concept-meta">{{ c.ontology }} · {{ c.curie }}</span>
+                  <span class="concept-meta">{{ conceptMeta(c) }}</span>
                 </li>
               </ul>
               <div v-if="form.tags.length > 0" class="tag-wrap">
@@ -565,6 +565,17 @@ export default {
       this.inputTag = term.label
       this.conceptResults = []
       this.addTag()
+    },
+
+    /**
+     * The meta line for a suggestion. The curie already carries the ontology as
+     * its prefix (UBERON:…), so only prepend the friendly ontology name when it
+     * differs from that prefix (e.g. "HPO" for HP:… terms) — avoids "UBERON · UBERON:…".
+     */
+    conceptMeta: function(term) {
+      return term.curie.startsWith(term.ontology + ':')
+        ? term.curie
+        : `${term.ontology} · ${term.curie}`
     }
   }
 }

--- a/src/components/user/dashboard/UserDashboardCard.vue
+++ b/src/components/user/dashboard/UserDashboardCard.vue
@@ -40,6 +40,7 @@ import IconProposals from '../../icons/IconProposals.vue'
 import IconIntegrations from '../../icons/IconIntegrations.vue'
 import IconCollection from '../../icons/IconCollection.vue'
 import IconOverview from '../../icons/IconOverview.vue'
+import IconGraph from '../../icons/IconGraph.vue'
 
 export default {
   name: 'UserDashboardCard',
@@ -61,6 +62,7 @@ export default {
     IconIntegrations,
     IconCollection,
     IconOverview,
+    IconGraph,
   },
 
   props: {
@@ -103,7 +105,8 @@ export default {
         'proposals': 'IconProposals',
         'integrations': 'IconIntegrations',
         'cde-catalog': 'IconCollection',
-        'model-templates': 'IconOverview'
+        'model-templates': 'IconOverview',
+        'ontology-browser': 'IconGraph'
       }
       return iconMap[this.icon] || 'IconUser'
     }

--- a/src/router/MyWorkSpace/ResourcesList.vue
+++ b/src/router/MyWorkSpace/ResourcesList.vue
@@ -16,6 +16,13 @@
       />
 
       <user-dashboard-card
+        title="Ontology Browser"
+        description="Explore standard biomedical ontologies (MONDO, HPO, UBERON, NCIt) and their hierarchy"
+        :route="{ name: 'ontology-browser' }"
+        icon="ontology-browser"
+      />
+
+      <user-dashboard-card
         title="Model Templates"
         description="Browse reusable model templates"
         :route="{ name: 'resources' }"

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -9,6 +9,7 @@ import ModelSpecViewer from "@/components/datasets/metadata/models/ModelSpecView
 import ModelSpecGenerator from "@/components/datasets/metadata/models/ModelSpecGenerator.vue";
 import TemplateGallery from "@/components/datasets/metadata/models/TemplateGallery.vue";
 import CdeGallery from "@/components/datasets/metadata/models/CdeGallery.vue";
+import OntologyBrowser from "@/components/datasets/metadata/models/OntologyBrowser.vue";
 import ListRecords from "@/components/datasets/metadata/records/ListRecords.vue";
 import RecordSpecViewer from "@/components/datasets/metadata/records/RecordSpecViewer.vue";
 import RecordSpecGenerator from "@/components/datasets/metadata/records/RecordSpecGenerator.vue";
@@ -412,6 +413,21 @@ const router = createRouter({
             backLink: { name: 'resources' },
             title: 'CDE Catalog',
             description: 'Browse common data elements and bundles.'
+          }
+        },
+        {
+          name: 'ontology-browser',
+          path: 'resources/ontology-browser',
+          components: {
+            stage: OntologyBrowser,
+            navigation: UserNavigation,
+          },
+          props: true,
+          meta: {
+            hideSecondaryNav: true,
+            backLink: { name: 'resources' },
+            title: 'Ontology Browser',
+            description: 'Explore standard biomedical ontologies and their hierarchy.'
           }
         },
         {

--- a/src/site-config/prod.json
+++ b/src/site-config/prod.json
@@ -2,6 +2,7 @@
   "app_domain": "pennsieve.io",
   "apiUrl": "https://api.pennsieve.io",
   "api2Url": "https://api2.pennsieve.io",
+  "cdeCatalogUrl": "https://cde-catalog.pennsieve.io",
   "zipitUrl": "https://api.pennsieve.io/zipit",
   "discoverUrl": "https://api.pennsieve.io/discover",
   "discoverAppUrl": "https://discover.pennsieve.io",

--- a/src/stores/cdeCatalogStore.js
+++ b/src/stores/cdeCatalogStore.js
@@ -273,17 +273,18 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
     const getFacetMap = async () => {
         if (facetMap) return facetMap
         await ensureClassificationsLoaded()
-        // cls.context/domain/tier are promoted parquet columns. `context` is a real
-        // disease only when the classification is rooted under "Disease" (NINDS);
-        // other stewards root their trees under collection/domain names that aren't
-        // diseases. Take path[0] from the record blob and only treat Disease-rooted
-        // contexts as diseases (domain/tier are unaffected).
+        // cls.context/domain/tier/path_root are all promoted parquet columns, so
+        // this reads small columns via pushdown — never the ~13MB data blob.
+        // `context` is a real disease only when the classification is rooted under
+        // "Disease" (NINDS); other stewards root their trees under collection/domain
+        // names that aren't diseases, so only treat Disease-rooted contexts as
+        // diseases (domain/tier are unaffected).
         const query = `
             SELECT cde.persistent_id AS pid,
                    cls.context AS disease,
                    cls.domain AS domain,
                    cls.tier AS tier,
-                   ((cls.data::JSON) -> 'path' ->> 0) AS path_root
+                   cls.path_root AS path_root
             FROM ${TABLE} cde
             JOIN cde_rel cl ON cl.target_record_id = CAST(cde.id AS VARCHAR) AND cl.relationship_type = 'CLASSIFIES'
             JOIN cde_cls cls ON CAST(cls.id AS VARCHAR) = cl.source_record_id`
@@ -315,7 +316,10 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
         return i === -1 ? 99 : i
     }
 
-    // Distinct facet values for the filter UI: { diseases, domains, tiers }.
+    // Distinct facet values for the filter UI: { diseases, domains, tiers, stewards }.
+    // stewards comes from the cde slim list's own steward_org column (promoted, and
+    // present on EVERY cde incl. unclassified ones) — the universal browse axis —
+    // so it needs neither the classification load nor the data blob.
     const getFacetValues = async () => {
         if (facetValuesCache) return facetValuesCache
         const map = await getFacetMap()
@@ -327,10 +331,16 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
             e.domains.forEach((d) => domains.add(d))
             e.tiers.forEach((t) => tiers.add(t))
         }
+        const stewardRows = await duck.executeQuery(
+            `SELECT DISTINCT steward_org FROM ${TABLE}` +
+                ` WHERE steward_org IS NOT NULL AND steward_org <> '' ORDER BY steward_org`,
+            connectionId
+        )
         facetValuesCache = {
             diseases: [...diseases].sort(),
             domains: [...domains].sort(),
             tiers: [...tiers].sort((a, b) => tierRank(a) - tierRank(b)),
+            stewards: stewardRows.map((r) => r.steward_org).filter(Boolean),
         }
         return facetValuesCache
     }
@@ -409,9 +419,13 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
         const diseases = asList(opts.disease)
         const domains = asList(opts.domain)
         const tiers = asList(opts.tier)
+        const stewards = asList(opts.steward)
         await ensureBundlesLoaded()
         const t = (term || '').trim()
-        const hasFacet = diseases.length > 0 || domains.length > 0 || tiers.length > 0
+        // steward filters on the cde's own column (no classification needed); the
+        // disease/domain/tier facets need the classification map.
+        const hasClassFacet = diseases.length > 0 || domains.length > 0 || tiers.length > 0
+        const hasFacet = hasClassFacet || stewards.length > 0
 
         const [allBundles, membership] = await Promise.all([listBundles(), getBundleMembership()])
         // Facets are CDE-level; when one is active we're doing targeted element
@@ -424,11 +438,12 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
 
         // Always list CDEs — a sample when browsing (no term/facet), narrowed as
         // the user types or applies facets.
-        const facets = hasFacet ? await getFacetMap() : null
+        const facets = hasClassFacet ? await getFacetMap() : null
         const raw = await search(t, hasFacet ? 500 : limit)
         const cdes = raw
             .filter((c) => {
-                if (!hasFacet) return true
+                if (stewards.length && !stewards.includes(c.steward_org)) return false
+                if (!hasClassFacet) return true
                 const f = facets.get(c.persistent_id)
                 if (!f) return false
                 if (diseases.length && !diseases.some((d) => f.diseases.has(d))) return false
@@ -457,12 +472,16 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
         const diseases = asList(opts.disease)
         const domains = asList(opts.domain)
         const tiers = asList(opts.tier)
+        const stewards = asList(opts.steward)
         await ensureLoaded()
         if (diseases.length || domains.length || tiers.length) await ensureClassificationsLoaded()
 
         const clauses = []
         const t = (term || '').trim()
         if (t) clauses.push(searchPredicate(t))
+        // steward_org is a promoted column on the slim list itself — filter directly
+        // (covers unclassified cdes too; no classification join, no data blob).
+        if (stewards.length) clauses.push(`${TABLE}.steward_org IN (${sqlList(stewards)})`)
 
         // Correlated EXISTS against the classification edges for this CDE.
         const classExists = (cond) =>

--- a/src/stores/cdeCatalogStore.js
+++ b/src/stores/cdeCatalogStore.js
@@ -12,6 +12,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import * as site from '@/site-config/site.json'
 import { useDuckDBStore } from '@/stores/duckdbStore'
+import { SEARCH_COLS, RETRIEVE, COARSE, tokenize, rankCandidates } from '@/stores/cdeSuggestRanker'
 
 const VIEWER_ID = 'cde-catalog'
 const TABLE = 'cde_catalog' // slim list projection (browse/search/facets)
@@ -140,7 +141,8 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
     //      name/question/aliases/definition + exact/prefix bonuses (precision).
     // Matches only the slim columns (name, question text, definition, source,
     // aliases) — not text buried in the heavy blobs, which aren't in the list file.
-    const SEARCH_COLS = ['cde_name', 'preferred_question_text', 'cde_definition', 'cde_source', 'aliases']
+    // SEARCH_COLS / RETRIEVE / COARSE / rankCandidates come from cdeSuggestRanker
+    // so this SQL and the offline eval harness score identically.
     // opts.dataType (optional): the property's chosen type; boosts type-compatible CDEs.
     const search = async (term, limit = 25, opts = {}) => {
         await ensureLoaded()
@@ -160,21 +162,21 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
         const terms = tokens.length ? tokens : [t.toLowerCase()]
         const phrase = escapeLiteral(t)
 
-        // Coarse SQL score: phrase-in-name/question dominate; then per-token field hits.
-        const scoreParts = [
-            `(CASE WHEN cde_name ILIKE '%${phrase}%' THEN 200 ELSE 0 END)`,
-            `(CASE WHEN preferred_question_text ILIKE '%${phrase}%' THEN 80 ELSE 0 END)`,
-        ]
+        // Coarse SQL score: phrase-in-name/question dominate; then per-token field
+        // hits. Built from the shared COARSE weights (cdeSuggestRanker) so the SQL
+        // and the eval harness stay in lockstep.
+        const scoreParts = []
+        for (const [col, w] of Object.entries(COARSE.phrase)) {
+            scoreParts.push(`(CASE WHEN ${col} ILIKE '%${phrase}%' THEN ${w} ELSE 0 END)`)
+        }
         const ors = []
         for (const tok of terms) {
             const lt = escapeLiteral(tok)
             for (const c of SEARCH_COLS) ors.push(`${c} ILIKE '%${lt}%'`)
-            scoreParts.push(`(CASE WHEN cde_name ILIKE '%${lt}%' THEN 6 ELSE 0 END)`)
-            scoreParts.push(`(CASE WHEN preferred_question_text ILIKE '%${lt}%' THEN 4 ELSE 0 END)`)
-            scoreParts.push(`(CASE WHEN aliases ILIKE '%${lt}%' THEN 3 ELSE 0 END)`)
-            scoreParts.push(`(CASE WHEN cde_definition ILIKE '%${lt}%' THEN 1 ELSE 0 END)`)
+            for (const [col, w] of Object.entries(COARSE.token)) {
+                scoreParts.push(`(CASE WHEN ${col} ILIKE '%${lt}%' THEN ${w} ELSE 0 END)`)
+            }
         }
-        const RETRIEVE = 300
         const query =
             `SELECT * FROM ${TABLE} WHERE ${ors.join(' OR ')}` +
             ` ORDER BY (${scoreParts.join(' + ')}) DESC, length(cde_name) NULLS LAST LIMIT ${RETRIEVE}`
@@ -577,75 +579,5 @@ function sqlList(vals) {
     return vals.map((v) => `'${escapeLiteral(v)}'`).join(', ')
 }
 
-// --- Lexical suggest ranking (SUGGEST-1) --------------------------------------
-
-const SUGGEST_STOP = new Set([
-    'the', 'a', 'an', 'of', 'and', 'or', 'to', 'in', 'for', 'on', 'by', 'with',
-    'is', 'are', 'at', 'as', 'de', 'per',
-])
-
-function norm(s) {
-    return String(s ?? '').toLowerCase().replace(/\s+/g, ' ').trim()
-}
-
-// Split into meaningful lowercased tokens (drop 1-char + stopwords).
-function tokenize(s) {
-    return (norm(s).match(/[a-z0-9]+/g) || []).filter((t) => t.length > 1 && !SUGGEST_STOP.has(t))
-}
-
-// Map a property's chosen type to the CDE's cde_data_type vocabulary.
-function compatibleType(propType, cdeType) {
-    const p = norm(propType)
-    const c = norm(cdeType)
-    if (!p || !c) return false
-    if (p === 'number' || p === 'integer' || p === 'long' || p === 'double') return c === 'number'
-    if (p === 'date' || p === 'datetime') return c === 'date'
-    if (p === 'boolean' || p === 'enum') return c === 'value list'
-    if (p === 'string' || p === 'text') return c === 'text' || c === 'value list'
-    return false
-}
-
-// Score one candidate against the query. Higher = more relevant.
-function scoreCandidate(c, qNorm, qTokens, dataType) {
-    const name = norm(c.cde_name)
-    const question = norm(c.preferred_question_text)
-    const aliases = Array.isArray(c.aliases) ? c.aliases.map(norm).join(' · ') : ''
-    const def = norm(c.cde_definition)
-    const source = norm(c.cde_source)
-
-    let s = 0
-    // Exact / prefix / substring on the label fields.
-    if (name === qNorm || question === qNorm) s += 120
-    else if (name.startsWith(qNorm) || question.startsWith(qNorm)) s += 50
-    else if (name.includes(qNorm) || question.includes(qNorm)) s += 25
-
-    // Weighted token coverage: a token counts once, at its best-scoring field.
-    const fields = [[name, 6], [question, 4], [aliases, 3], [def, 1], [source, 0.5]]
-    let matched = 0
-    for (const t of qTokens) {
-        let best = 0
-        for (const [text, w] of fields) if (text.includes(t)) best = Math.max(best, w)
-        if (best > 0) {
-            s += best
-            matched++
-        }
-    }
-    // Reward covering more of the query (penalize 1-of-3-token matches).
-    const coverage = qTokens.length ? matched / qTokens.length : 0
-    s *= 0.4 + 0.6 * coverage
-
-    if (dataType && compatibleType(dataType, c.cde_data_type)) s += 5
-    // Prefer concise names on ties.
-    s -= Math.min(name.length, 80) * 0.03
-    return s
-}
-
-// Rank retrieved candidates by relevance to the query (stable, best first).
-function rankCandidates(cands, query, dataType) {
-    const qNorm = norm(query)
-    const qTokens = tokenize(query)
-    return cands
-        .map((c, i) => ({ c, i, s: scoreCandidate(c, qNorm, qTokens, dataType) }))
-        .sort((a, b) => b.s - a.s || a.i - b.i)
-        .map((x) => x.c)
-}
+// Lexical suggest ranking (SUGGEST-1) now lives in cdeSuggestRanker.js so the
+// picker and the offline eval harness score identically.

--- a/src/stores/cdeCatalogStore.js
+++ b/src/stores/cdeCatalogStore.js
@@ -341,17 +341,21 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
         await ensureBundlesLoaded()
         const query = `
             SELECT to_json(b.data) ->> 'bundle_name' AS bundle_name,
+                   to_json(b.data) ->> 'display_name' AS display_name,
                    to_json(b.data) ->> 'domain' AS domain,
+                   to_json(b.data) ->> 'steward_org' AS steward_org,
                    COUNT(DISTINCT po.source_record_id) AS member_count
             FROM cde_bundle b
             LEFT JOIN cde_rel po ON po.target_record_id = CAST(b.id AS VARCHAR) AND po.relationship_type = 'PART_OF'
-            GROUP BY 1, 2
+            GROUP BY 1, 2, 3, 4
             HAVING member_count > 0
-            ORDER BY bundle_name`
+            ORDER BY lower(to_json(b.data) ->> 'display_name'), bundle_name`
         const rows = await duck.executeQuery(query, connectionId)
         return rows.map((r) => ({
             bundle_name: r.bundle_name,
+            display_name: r.display_name || r.bundle_name,
             domain: r.domain,
+            steward_org: r.steward_org,
             member_count: Number(r.member_count),
         }))
     }
@@ -372,6 +376,19 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
             ORDER BY length(cde_name) NULLS LAST`
         const rows = await duck.executeQuery(query, connectionId)
         return rows.map(mapListRow).filter(Boolean)
+    }
+
+    // Full bundle record by name (definition, facets, contexts, num_questions,
+    // steward, nlm_view_url, …) — from the already-loaded cde_bundle table, for
+    // the detail panel. Members come separately from getBundleMembers.
+    const getBundle = async (bundleName) => {
+        if (!bundleName) return null
+        await ensureBundlesLoaded()
+        const query =
+            `SELECT to_json(data) AS data FROM cde_bundle` +
+            ` WHERE (to_json(data) ->> 'bundle_name') = '${escapeLiteral(bundleName)}' LIMIT 1`
+        const rows = await duck.executeQuery(query, connectionId)
+        return rows.length ? parseRow(rows[0]) : null
     }
 
     // persistent_id -> [bundle_name, ...] for every CDE that belongs to a bundle.
@@ -503,6 +520,7 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
         search,
         getByPersistentId,
         listBundles,
+        getBundle,
         getBundleMembers,
         getBundleMembership,
         getFacetValues,

--- a/src/stores/cdeCatalogStore.js
+++ b/src/stores/cdeCatalogStore.js
@@ -131,22 +131,56 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
         return loadPromise
     }
 
-    // Free-text search over the slim list columns (name, question text, definition,
-    // source, aliases). This intentionally does NOT match text buried in the heavy
-    // blobs (permissible-value labels, references) — those aren't in the list file.
-    // Returns list records, shortest name first (more-exact matches surface first).
+    // Lexical suggest (SUGGEST-1): rank the loaded catalog against what the user
+    // typed rather than just substring-filtering. Two stages, entirely client-side
+    // over the slim list (no infra, no LLM):
+    //   1. Retrieval — DuckDB pulls candidates matching any query token, biased by a
+    //      coarse SQL score so the LIMIT keeps the best ones (recall).
+    //   2. Rank — score each candidate in JS by weighted token coverage across
+    //      name/question/aliases/definition + exact/prefix bonuses (precision).
+    // Matches only the slim columns (name, question text, definition, source,
+    // aliases) — not text buried in the heavy blobs, which aren't in the list file.
     const SEARCH_COLS = ['cde_name', 'preferred_question_text', 'cde_definition', 'cde_source', 'aliases']
-    const search = async (term, limit = 25) => {
+    // opts.dataType (optional): the property's chosen type; boosts type-compatible CDEs.
+    const search = async (term, limit = 25, opts = {}) => {
         await ensureLoaded()
         const t = (term || '').trim()
-        const n = Number.isFinite(limit) ? Math.max(1, Math.min(200, limit)) : 25
+        const n = Number.isFinite(limit) ? Math.max(1, Math.min(500, limit)) : 25
 
-        const where = t ? `WHERE ${searchPredicate(t)}` : ''
+        // No term → browse sample (shortest names first).
+        if (!t) {
+            const rows = await duck.executeQuery(
+                `SELECT * FROM ${TABLE} ORDER BY length(cde_name) NULLS LAST LIMIT ${n}`,
+                connectionId
+            )
+            return rows.map(mapListRow).filter(Boolean)
+        }
+
+        const tokens = tokenize(t).slice(0, 6)
+        const terms = tokens.length ? tokens : [t.toLowerCase()]
+        const phrase = escapeLiteral(t)
+
+        // Coarse SQL score: phrase-in-name/question dominate; then per-token field hits.
+        const scoreParts = [
+            `(CASE WHEN cde_name ILIKE '%${phrase}%' THEN 200 ELSE 0 END)`,
+            `(CASE WHEN preferred_question_text ILIKE '%${phrase}%' THEN 80 ELSE 0 END)`,
+        ]
+        const ors = []
+        for (const tok of terms) {
+            const lt = escapeLiteral(tok)
+            for (const c of SEARCH_COLS) ors.push(`${c} ILIKE '%${lt}%'`)
+            scoreParts.push(`(CASE WHEN cde_name ILIKE '%${lt}%' THEN 6 ELSE 0 END)`)
+            scoreParts.push(`(CASE WHEN preferred_question_text ILIKE '%${lt}%' THEN 4 ELSE 0 END)`)
+            scoreParts.push(`(CASE WHEN aliases ILIKE '%${lt}%' THEN 3 ELSE 0 END)`)
+            scoreParts.push(`(CASE WHEN cde_definition ILIKE '%${lt}%' THEN 1 ELSE 0 END)`)
+        }
+        const RETRIEVE = 300
         const query =
-            `SELECT * FROM ${TABLE} ${where}` +
-            ` ORDER BY length(cde_name) NULLS LAST LIMIT ${n}`
+            `SELECT * FROM ${TABLE} WHERE ${ors.join(' OR ')}` +
+            ` ORDER BY (${scoreParts.join(' + ')}) DESC, length(cde_name) NULLS LAST LIMIT ${RETRIEVE}`
         const rows = await duck.executeQuery(query, connectionId)
-        return rows.map(mapListRow).filter(Boolean)
+        const cands = rows.map(mapListRow).filter(Boolean)
+        return rankCandidates(cands, t, opts.dataType || '').slice(0, n)
     }
 
     const searchPredicate = (t) => {
@@ -541,4 +575,77 @@ function asList(v) {
 // Render a list of values as a SQL IN-list of quoted literals.
 function sqlList(vals) {
     return vals.map((v) => `'${escapeLiteral(v)}'`).join(', ')
+}
+
+// --- Lexical suggest ranking (SUGGEST-1) --------------------------------------
+
+const SUGGEST_STOP = new Set([
+    'the', 'a', 'an', 'of', 'and', 'or', 'to', 'in', 'for', 'on', 'by', 'with',
+    'is', 'are', 'at', 'as', 'de', 'per',
+])
+
+function norm(s) {
+    return String(s ?? '').toLowerCase().replace(/\s+/g, ' ').trim()
+}
+
+// Split into meaningful lowercased tokens (drop 1-char + stopwords).
+function tokenize(s) {
+    return (norm(s).match(/[a-z0-9]+/g) || []).filter((t) => t.length > 1 && !SUGGEST_STOP.has(t))
+}
+
+// Map a property's chosen type to the CDE's cde_data_type vocabulary.
+function compatibleType(propType, cdeType) {
+    const p = norm(propType)
+    const c = norm(cdeType)
+    if (!p || !c) return false
+    if (p === 'number' || p === 'integer' || p === 'long' || p === 'double') return c === 'number'
+    if (p === 'date' || p === 'datetime') return c === 'date'
+    if (p === 'boolean' || p === 'enum') return c === 'value list'
+    if (p === 'string' || p === 'text') return c === 'text' || c === 'value list'
+    return false
+}
+
+// Score one candidate against the query. Higher = more relevant.
+function scoreCandidate(c, qNorm, qTokens, dataType) {
+    const name = norm(c.cde_name)
+    const question = norm(c.preferred_question_text)
+    const aliases = Array.isArray(c.aliases) ? c.aliases.map(norm).join(' · ') : ''
+    const def = norm(c.cde_definition)
+    const source = norm(c.cde_source)
+
+    let s = 0
+    // Exact / prefix / substring on the label fields.
+    if (name === qNorm || question === qNorm) s += 120
+    else if (name.startsWith(qNorm) || question.startsWith(qNorm)) s += 50
+    else if (name.includes(qNorm) || question.includes(qNorm)) s += 25
+
+    // Weighted token coverage: a token counts once, at its best-scoring field.
+    const fields = [[name, 6], [question, 4], [aliases, 3], [def, 1], [source, 0.5]]
+    let matched = 0
+    for (const t of qTokens) {
+        let best = 0
+        for (const [text, w] of fields) if (text.includes(t)) best = Math.max(best, w)
+        if (best > 0) {
+            s += best
+            matched++
+        }
+    }
+    // Reward covering more of the query (penalize 1-of-3-token matches).
+    const coverage = qTokens.length ? matched / qTokens.length : 0
+    s *= 0.4 + 0.6 * coverage
+
+    if (dataType && compatibleType(dataType, c.cde_data_type)) s += 5
+    // Prefer concise names on ties.
+    s -= Math.min(name.length, 80) * 0.03
+    return s
+}
+
+// Rank retrieved candidates by relevance to the query (stable, best first).
+function rankCandidates(cands, query, dataType) {
+    const qNorm = norm(query)
+    const qTokens = tokenize(query)
+    return cands
+        .map((c, i) => ({ c, i, s: scoreCandidate(c, qNorm, qTokens, dataType) }))
+        .sort((a, b) => b.s - a.s || a.i - b.i)
+        .map((x) => x.c)
 }

--- a/src/stores/cdeCatalogStore.js
+++ b/src/stores/cdeCatalogStore.js
@@ -336,15 +336,15 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
     }
 
     // List bundles that have at least one member CDE, with member counts.
+    // Membership is a DIRECT cde -> bundle PART_OF edge (source = cde, target = bundle).
     const listBundles = async () => {
         await ensureBundlesLoaded()
         const query = `
             SELECT to_json(b.data) ->> 'bundle_name' AS bundle_name,
                    to_json(b.data) ->> 'domain' AS domain,
-                   COUNT(DISTINCT cl.target_record_id) AS member_count
+                   COUNT(DISTINCT po.source_record_id) AS member_count
             FROM cde_bundle b
             LEFT JOIN cde_rel po ON po.target_record_id = CAST(b.id AS VARCHAR) AND po.relationship_type = 'PART_OF'
-            LEFT JOIN cde_rel cl ON cl.source_record_id = po.source_record_id AND cl.relationship_type = 'CLASSIFIES'
             GROUP BY 1, 2
             HAVING member_count > 0
             ORDER BY bundle_name`
@@ -356,18 +356,17 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
         }))
     }
 
-    // Resolve the member CDE records of a bundle (deduped; a CDE classified into
-    // the bundle under multiple contexts appears once).
+    // Resolve the member CDE records of a bundle (the cdes with a direct
+    // PART_OF edge to it).
     const getBundleMembers = async (bundleName) => {
         if (!bundleName) return []
         await ensureBundlesLoaded()
         const query = `
             SELECT * FROM ${TABLE}
             WHERE CAST(id AS VARCHAR) IN (
-                SELECT cl.target_record_id
+                SELECT po.source_record_id
                 FROM cde_bundle b
                 JOIN cde_rel po ON po.target_record_id = CAST(b.id AS VARCHAR) AND po.relationship_type = 'PART_OF'
-                JOIN cde_rel cl ON cl.source_record_id = po.source_record_id AND cl.relationship_type = 'CLASSIFIES'
                 WHERE (to_json(b.data) ->> 'bundle_name') = '${escapeLiteral(bundleName)}'
             )
             ORDER BY length(cde_name) NULLS LAST`
@@ -384,8 +383,7 @@ export const useCdeCatalogStore = defineStore('cdeCatalog', () => {
         const query = `
             SELECT cde.persistent_id AS pid, to_json(b.data) ->> 'bundle_name' AS bundle_name
             FROM ${TABLE} cde
-            JOIN cde_rel cl ON cl.target_record_id = CAST(cde.id AS VARCHAR) AND cl.relationship_type = 'CLASSIFIES'
-            JOIN cde_rel po ON po.source_record_id = cl.source_record_id AND po.relationship_type = 'PART_OF'
+            JOIN cde_rel po ON po.source_record_id = CAST(cde.id AS VARCHAR) AND po.relationship_type = 'PART_OF'
             JOIN cde_bundle b ON CAST(b.id AS VARCHAR) = po.target_record_id`
         const rows = await duck.executeQuery(query, connectionId)
         const map = new Map()

--- a/src/stores/cdeSuggestRanker.mjs
+++ b/src/stores/cdeSuggestRanker.mjs
@@ -1,0 +1,150 @@
+// @/stores/cdeSuggestRanker.js
+//
+// The CDE lexical-suggest ranker (SUGGEST-1), extracted so the shipped picker
+// (cdeCatalogStore) and the offline eval harness (eval/cde-suggest) run the
+// EXACT same scoring. Pure JS — no Vue, no DuckDB, no app imports — so it loads
+// unchanged under Vite (browser) and Node (the eval `.mjs`).
+//
+// Two stages, entirely client-side over the slim list (no infra, no LLM):
+//   1. Retrieval — a coarse score narrows the catalog to the best RETRIEVE
+//      candidates (recall). In the app this runs as DuckDB SQL; the SQL is built
+//      from the COARSE weights below so it can't drift from stage 2 / the eval.
+//   2. Rank — score each candidate by weighted token coverage across
+//      name/question/aliases/definition + exact/prefix bonuses (precision).
+//
+// The optional `exclude`/`cols` params default to the shipped behavior. The eval
+// uses them for its "cold" mode: when the query IS a candidate's own field
+// (e.g. the CDE's preferred_question_text), scoring that field is circular, so
+// cold mode excludes it to measure what the *other* fields can recover.
+
+// Slim-list columns the suggest matches against (name, question, definition,
+// source, aliases) — the heavy blobs aren't in the list projection.
+export const SEARCH_COLS = ['cde_name', 'preferred_question_text', 'cde_definition', 'cde_source', 'aliases']
+
+// How many candidates stage-1 retrieval keeps before ranking.
+export const RETRIEVE = 300
+
+// Coarse retrieval weights. The store builds its SQL CASE-score from these and
+// the eval scores in JS from these — one source of truth for both.
+//   phrase: the whole query as a substring of the field.
+//   token:  a single query token as a substring of the field.
+export const COARSE = {
+    phrase: { cde_name: 200, preferred_question_text: 80 },
+    token: { cde_name: 6, preferred_question_text: 4, aliases: 3, cde_definition: 1 },
+}
+
+const EMPTY = new Set()
+
+const SUGGEST_STOP = new Set([
+    'the', 'a', 'an', 'of', 'and', 'or', 'to', 'in', 'for', 'on', 'by', 'with',
+    'is', 'are', 'at', 'as', 'de', 'per',
+])
+
+export function norm(s) {
+    return String(s ?? '').toLowerCase().replace(/\s+/g, ' ').trim()
+}
+
+// Split into meaningful lowercased tokens (drop 1-char + stopwords).
+export function tokenize(s) {
+    return (norm(s).match(/[a-z0-9]+/g) || []).filter((t) => t.length > 1 && !SUGGEST_STOP.has(t))
+}
+
+// Map a property's chosen type to the CDE's cde_data_type vocabulary.
+export function compatibleType(propType, cdeType) {
+    const p = norm(propType)
+    const c = norm(cdeType)
+    if (!p || !c) return false
+    if (p === 'number' || p === 'integer' || p === 'long' || p === 'double') return c === 'number'
+    if (p === 'date' || p === 'datetime') return c === 'date'
+    if (p === 'boolean' || p === 'enum') return c === 'value list'
+    if (p === 'string' || p === 'text') return c === 'text' || c === 'value list'
+    return false
+}
+
+// The aliases field is stored as a JSON-array string in the slim parquet column,
+// so the ranker's alias text mirrors what SQL ILIKE sees. Accept either an array
+// (eval loads from records.jsonl) or an already-joined string.
+function aliasText(aliases) {
+    return Array.isArray(aliases) ? aliases.map(norm).join(' · ') : norm(aliases)
+}
+
+// Score one candidate against the query. Higher = more relevant.
+// `exclude` (a Set of column names) drops those fields from scoring — used by the
+// eval's cold mode; empty by default, so the app's ranking is unchanged.
+export function scoreCandidate(c, qNorm, qTokens, dataType, exclude = EMPTY) {
+    const name = exclude.has('cde_name') ? '' : norm(c.cde_name)
+    const question = exclude.has('preferred_question_text') ? '' : norm(c.preferred_question_text)
+    const aliases = exclude.has('aliases') ? '' : aliasText(c.aliases)
+    const def = exclude.has('cde_definition') ? '' : norm(c.cde_definition)
+    const source = exclude.has('cde_source') ? '' : norm(c.cde_source)
+
+    let s = 0
+    // Exact / prefix / substring on the label fields.
+    if (name === qNorm || question === qNorm) s += 120
+    else if (name.startsWith(qNorm) || question.startsWith(qNorm)) s += 50
+    else if (name.includes(qNorm) || question.includes(qNorm)) s += 25
+
+    // Weighted token coverage: a token counts once, at its best-scoring field.
+    const fields = [[name, 6], [question, 4], [aliases, 3], [def, 1], [source, 0.5]]
+    let matched = 0
+    for (const t of qTokens) {
+        let best = 0
+        for (const [text, w] of fields) if (text.includes(t)) best = Math.max(best, w)
+        if (best > 0) {
+            s += best
+            matched++
+        }
+    }
+    // Reward covering more of the query (penalize 1-of-3-token matches).
+    const coverage = qTokens.length ? matched / qTokens.length : 0
+    s *= 0.4 + 0.6 * coverage
+
+    if (dataType && compatibleType(dataType, c.cde_data_type)) s += 5
+    // Prefer concise names on ties.
+    s -= Math.min(name.length, 80) * 0.03
+    return s
+}
+
+// Rank retrieved candidates by relevance to the query (stable, best first).
+export function rankCandidates(cands, query, dataType, exclude = EMPTY) {
+    const qNorm = norm(query)
+    const qTokens = tokenize(query)
+    return cands
+        .map((c, i) => ({ c, i, s: scoreCandidate(c, qNorm, qTokens, dataType, exclude) }))
+        .sort((a, b) => b.s - a.s || a.i - b.i)
+        .map((x) => x.c)
+}
+
+// Coarse stage-1 retrieval score for one candidate (JS mirror of the store's SQL
+// CASE-score, from the shared COARSE weights). `cols` restricts the fields
+// considered (cold mode passes SEARCH_COLS minus the queried field).
+export function coarseScore(c, phraseNorm, terms, cols = SEARCH_COLS) {
+    const allow = new Set(cols)
+    const field = (col) => {
+        if (!allow.has(col)) return ''
+        if (col === 'aliases') return aliasText(c.aliases)
+        return norm(c[col])
+    }
+    let s = 0
+    for (const [col, w] of Object.entries(COARSE.phrase)) {
+        if (field(col).includes(phraseNorm)) s += w
+    }
+    for (const tok of terms) {
+        for (const [col, w] of Object.entries(COARSE.token)) {
+            if (field(col).includes(tok)) s += w
+        }
+    }
+    return s
+}
+
+// Does the candidate match the retrieval WHERE clause — any query token as a
+// substring of any allowed search column? (Stage-1 qualifier, before scoring.)
+export function coarseQualifies(c, terms, cols = SEARCH_COLS) {
+    const allow = cols.filter((col) => SEARCH_COLS.includes(col))
+    for (const col of allow) {
+        const text = col === 'aliases' ? aliasText(c.aliases) : norm(c[col])
+        if (!text) continue
+        for (const tok of terms) if (text.includes(tok)) return true
+    }
+    return false
+}

--- a/src/stores/cdeSuggestRanker.spec.js
+++ b/src/stores/cdeSuggestRanker.spec.js
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import {
+    tokenize,
+    scoreCandidate,
+    rankCandidates,
+    compatibleType,
+    coarseScore,
+    coarseQualifies,
+    norm,
+    SEARCH_COLS,
+    RETRIEVE,
+    COARSE,
+} from './cdeSuggestRanker.mjs'
+
+const cde = (over) => ({
+    persistent_id: 'p',
+    cde_name: '',
+    preferred_question_text: '',
+    cde_definition: '',
+    cde_source: '',
+    cde_data_type: '',
+    aliases: [],
+    ...over,
+})
+
+describe('tokenize', () => {
+    it('lowercases, drops 1-char tokens and stopwords', () => {
+        expect(tokenize('Age at Enrollment (years)')).toEqual(['age', 'enrollment', 'years'])
+    })
+    it('is empty for punctuation/stopword-only input', () => {
+        expect(tokenize('the of a')).toEqual([])
+    })
+})
+
+describe('compatibleType', () => {
+    it('maps property types onto the CDE data-type vocabulary', () => {
+        expect(compatibleType('integer', 'Number')).toBe(true)
+        expect(compatibleType('date', 'Date')).toBe(true)
+        expect(compatibleType('enum', 'Value List')).toBe(true)
+        expect(compatibleType('string', 'Number')).toBe(false)
+    })
+})
+
+describe('scoreCandidate', () => {
+    const q = 'age'
+    const score = (c, exclude) => scoreCandidate(c, norm(q), tokenize(q), '', exclude)
+
+    it('rewards an exact name match over a mere substring', () => {
+        const exact = score(cde({ cde_name: 'age' }))
+        const substr = score(cde({ cde_name: 'patient age at visit' }))
+        expect(exact).toBeGreaterThan(substr)
+    })
+
+    it('weights name above question above definition for the same token', () => {
+        const inName = score(cde({ cde_name: 'age' }))
+        const inQuestion = score(cde({ preferred_question_text: 'age' }))
+        const inDef = score(cde({ cde_definition: 'age' }))
+        expect(inName).toBeGreaterThan(inQuestion)
+        expect(inQuestion).toBeGreaterThan(inDef)
+    })
+
+    it('gives a data-type-compatible CDE a bonus', () => {
+        const base = cde({ cde_name: 'age', cde_data_type: 'Number' })
+        expect(scoreCandidate(base, 'age', ['age'], 'integer')).toBeGreaterThan(
+            scoreCandidate(base, 'age', ['age'], ''),
+        )
+    })
+
+    it('exclude drops a field from scoring (cold mode)', () => {
+        const c = cde({ preferred_question_text: 'age' })
+        expect(score(c)).toBeGreaterThan(0)
+        expect(score(c, new Set(['preferred_question_text']))).toBeLessThanOrEqual(0)
+    })
+})
+
+describe('rankCandidates', () => {
+    const cands = [
+        cde({ persistent_id: 'weight', cde_name: 'Body Weight', cde_definition: 'mass' }),
+        cde({ persistent_id: 'age', cde_name: 'Age Value', preferred_question_text: 'what is the age' }),
+        cde({ persistent_id: 'age-alias', cde_name: 'Years Lived', aliases: ['age'] }),
+    ]
+    it('ranks the strongest lexical match first and is stable', () => {
+        const ranked = rankCandidates(cands, 'age', '').map((c) => c.persistent_id)
+        expect(ranked[0]).toBe('age')
+        expect(ranked).toContain('age-alias')
+        expect(ranked).not.toContain(undefined)
+    })
+    it('cold exclude changes ordering without throwing', () => {
+        const ranked = rankCandidates(cands, 'age', '', new Set(['cde_name']))
+        expect(ranked.map((c) => c.persistent_id)).toContain('age-alias')
+    })
+})
+
+describe('coarse retrieval (stage 1)', () => {
+    it('scores from the shared COARSE weights (phrase-in-name dominates)', () => {
+        const nameHit = coarseScore(cde({ cde_name: 'blood pressure' }), 'blood pressure', ['blood', 'pressure'])
+        const defHit = coarseScore(cde({ cde_definition: 'blood pressure' }), 'blood pressure', ['blood', 'pressure'])
+        expect(nameHit).toBeGreaterThan(defHit)
+        expect(nameHit).toBe(COARSE.phrase.cde_name + COARSE.token.cde_name * 2)
+    })
+    it('qualifies a candidate when any token substring-hits an allowed column', () => {
+        expect(coarseQualifies(cde({ cde_definition: 'systolic value' }), ['systolic'])).toBe(true)
+        expect(coarseQualifies(cde({ cde_definition: 'systolic value' }), ['diastolic'])).toBe(false)
+    })
+    it('cols restricts which columns count (cold mode)', () => {
+        const c = cde({ preferred_question_text: 'age' })
+        const cold = SEARCH_COLS.filter((x) => x !== 'preferred_question_text')
+        expect(coarseQualifies(c, ['age'])).toBe(true)
+        expect(coarseQualifies(c, ['age'], cold)).toBe(false)
+    })
+    it('exposes a sane retrieval depth', () => {
+        expect(RETRIEVE).toBeGreaterThanOrEqual(100)
+    })
+})

--- a/src/stores/ontologyStore.js
+++ b/src/stores/ontologyStore.js
@@ -172,6 +172,102 @@ export const useOntologyStore = defineStore('ontology', () => {
         return mapRows(await duck.executeQuery(query, connectionId))
     }
 
+    // One full term record by exact curie — hydrates the detail panel when a term
+    // is reached by tree/breadcrumb navigation (search already returns full rows).
+    // Returns the normalized row or null.
+    const getByCurie = async (curie) => {
+        await ensureLoaded()
+        if (!sources.value.length) return null
+        const c = esc(curie)
+        const tables = sources.value.map((s) => `SELECT ${COLUMNS} FROM ${s.table}`)
+        const query = `
+            WITH terms AS (${tables.join(' UNION ALL ')})
+            SELECT ${COLUMNS} FROM terms WHERE curie = '${c}' LIMIT 1
+        `
+        const rows = await duck.executeQuery(query, connectionId)
+        return rows && rows.length ? normalizeRow(rows[0]) : null
+    }
+
+    const mapTree = (rows) =>
+        (rows || []).map((r) => ({
+            curie: r.curie == null ? '' : String(r.curie),
+            label: r.label == null ? '' : String(r.label),
+            ontology: r.ontology == null ? '' : String(r.ontology),
+            has_children: !!r.has_children,
+        }))
+
+    const tableFor = (ontology) => (sources.value.find((s) => s.ontology === ontology) || {}).table
+
+    // Top-level terms of one ontology — a tree root = a term none of whose parents
+    // are in this ontology's slice (parents empty, or all point outside). Each row
+    // carries has_children so the tree can decide whether to render an expand arrow.
+    const roots = async (ontology, { limit = 300 } = {}) => {
+        await ensureLoaded()
+        const table = tableFor(ontology)
+        if (!table) return []
+        const query = `
+            WITH all_terms AS (SELECT curie, label, ontology, parents FROM ${table})
+            SELECT r.curie, r.label, r.ontology,
+                EXISTS (SELECT 1 FROM all_terms t WHERE list_contains(string_split(t.parents, '|'), r.curie)) AS has_children
+            FROM all_terms r
+            WHERE r.parents IS NULL OR r.parents = ''
+                OR NOT EXISTS (SELECT 1 FROM all_terms p WHERE list_contains(string_split(r.parents, '|'), p.curie))
+            ORDER BY lower(r.label)
+            LIMIT ${Number(limit) || 300}
+        `
+        return mapTree(await duck.executeQuery(query, connectionId))
+    }
+
+    // Direct is_a children of a term (one level) — the lazy-load unit for the tree
+    // and the "narrower terms" list in the detail panel. has_children lets the tree
+    // show an expand arrow without a follow-up query.
+    const children = async (curie, { limit = 3000 } = {}) => {
+        await ensureLoaded()
+        if (!sources.value.length) return []
+        const c = esc(curie)
+        const query = `
+            WITH all_terms AS (${unionAll()})
+            SELECT k.curie, k.label, k.ontology,
+                EXISTS (SELECT 1 FROM all_terms t WHERE list_contains(string_split(t.parents, '|'), k.curie)) AS has_children
+            FROM all_terms k
+            WHERE list_contains(string_split(k.parents, '|'), '${c}')
+            ORDER BY lower(k.label)
+            LIMIT ${Number(limit) || 3000}
+        `
+        return mapTree(await duck.executeQuery(query, connectionId))
+    }
+
+    // Ancestors ordered general→specific (root first) with each term's min distance
+    // from the start — the breadcrumb trail above the tree. Recursion is depth-capped
+    // to stay bounded on diamond-shaped DAGs. Returns [{ curie, label, ontology, depth }].
+    const lineage = async (curie, { limit = 100, maxDepth = 50 } = {}) => {
+        await ensureLoaded()
+        if (!sources.value.length) return []
+        const c = esc(curie)
+        const query = `
+            WITH RECURSIVE all_terms AS (${unionAll()}),
+            acc AS (
+                SELECT curie, label, ontology, parents, 0 AS depth FROM all_terms WHERE curie = '${c}'
+                UNION ALL
+                SELECT t.curie, t.label, t.ontology, t.parents, a.depth + 1
+                FROM all_terms t JOIN acc a ON list_contains(string_split(a.parents, '|'), t.curie)
+                WHERE a.depth < ${Math.floor(Number(maxDepth)) || 50}
+            )
+            SELECT curie, label, ontology, min(depth) AS depth
+            FROM acc WHERE curie <> '${c}'
+            GROUP BY curie, label, ontology
+            ORDER BY depth DESC
+            LIMIT ${Number(limit) || 100}
+        `
+        const rows = await duck.executeQuery(query, connectionId)
+        return (rows || []).map((r) => ({
+            curie: r.curie == null ? '' : String(r.curie),
+            label: r.label == null ? '' : String(r.label),
+            ontology: r.ontology == null ? '' : String(r.ontology),
+            depth: r.depth == null ? 0 : Number(r.depth),
+        }))
+    }
+
     // Ancestors of a term (path toward the roots) — breadcrumb context / broadening.
     const ancestors = async (curie, { limit = 200 } = {}) => {
         await ensureLoaded()
@@ -190,7 +286,11 @@ export const useOntologyStore = defineStore('ontology', () => {
         return mapRows(await duck.executeQuery(query, connectionId))
     }
 
-    return { loading, loaded, error, sources, isConfigured, ensureLoaded, search, descendants, ancestors }
+    return {
+        loading, loaded, error, sources, isConfigured, ensureLoaded,
+        search, descendants, ancestors,
+        getByCurie, roots, children, lineage,
+    }
 })
 
 // DuckDB rows come back as Arrow rows; normalize to plain objects/strings.

--- a/src/stores/ontologyStore.js
+++ b/src/stores/ontologyStore.js
@@ -123,8 +123,14 @@ export const useOntologyStore = defineStore('ontology', () => {
         return (rows || []).map(normalizeRow)
     }
 
+    // Union of every loaded slice, obsolete terms excluded. Excluding them here
+    // keeps the whole is_a graph (roots/children/lineage/descendants/ancestors)
+    // free of deprecated concepts — which matters because obsolete OBO terms have
+    // their is_a parents stripped, so they would otherwise surface as spurious roots.
     const unionAll = () =>
-        sources.value.map((s) => `SELECT curie, label, ontology, parents FROM ${s.table}`).join(' UNION ALL ')
+        sources.value
+            .map((s) => `SELECT curie, label, ontology, parents FROM ${s.table} WHERE COALESCE(obsolete, false) = false`)
+            .join(' UNION ALL ')
 
     const mapRows = (rows) =>
         (rows || []).map((r) => ({
@@ -206,7 +212,7 @@ export const useOntologyStore = defineStore('ontology', () => {
         const table = tableFor(ontology)
         if (!table) return []
         const query = `
-            WITH all_terms AS (SELECT curie, label, ontology, parents FROM ${table})
+            WITH all_terms AS (SELECT curie, label, ontology, parents FROM ${table} WHERE COALESCE(obsolete, false) = false)
             SELECT r.curie, r.label, r.ontology,
                 EXISTS (SELECT 1 FROM all_terms t WHERE list_contains(string_split(t.parents, '|'), r.curie)) AS has_children
             FROM all_terms r

--- a/src/stores/ontologyStore.js
+++ b/src/stores/ontologyStore.js
@@ -29,87 +29,111 @@ export const useOntologyStore = defineStore('ontology', () => {
     const duck = useDuckDBStore()
 
     const loading = ref(false)
-    const loaded = ref(false)
+    const loaded = ref(false) // every ontology loaded (ensureLoaded)
     const error = ref('')
-    const sources = ref([]) // [{ ontology, ontology_version, count, table }]
+    const available = ref([]) // registry entries [{ ontology, slug, build, path, edges_path, ... }]
+    const sources = ref([]) // loaded [{ ontology, ontology_version, count, table, edgesTable }]
 
     let connectionId = null
-    let loadPromise = null
+    let registryPromise = null
+    let loadAllPromise = null
+    const ontologyPromises = {} // ontology name -> in-flight load (single-flight per ontology)
 
     const baseUrl = computed(() => (site.cdeCatalogUrl || '').replace(/\/+$/, ''))
     const isConfigured = computed(() => !!baseUrl.value)
 
-    // Read the registry and load every listed ontology's current slice into its
-    // own DuckDB table (search UNIONs across them). Single-flight.
-    const ensureLoaded = async () => {
-        if (loaded.value) return
-        if (loadPromise) return loadPromise
+    // Fetch the registry (cheap: one small JSON) and open the DuckDB connection —
+    // but load NO slices. This is all the browser needs before it can list the
+    // ontologies and lazily load the selected one. Single-flight.
+    const ensureRegistry = async () => {
+        if (available.value.length) return
+        if (registryPromise) return registryPromise
         if (!baseUrl.value) {
             error.value = 'Catalog URL is not configured (site.cdeCatalogUrl).'
             throw new Error(error.value)
         }
-
-        loading.value = true
-        error.value = ''
-        loadPromise = (async () => {
+        registryPromise = (async () => {
             try {
                 const registry = await fetchJson(`${baseUrl.value}/ontology/sources.json`)
                 const ontologies = registry.ontologies || []
                 if (!ontologies.length) throw new Error('ontology registry is empty')
-
-                const loadedSources = []
-                for (const o of ontologies) {
-                    const table = 'onto_' + String(o.slug || '').replace(/[^a-z0-9_]/gi, '_')
-                    // Register each slice as a VIEW (materialize:false), not a table:
-                    // DuckDB reads the parquet footer and then range-fetches only the
-                    // row-groups/columns a query touches (and caches them), instead of
-                    // downloading every slice — incl. the large definition column — up
-                    // front. Registration is metadata-only, so keeping all ontologies
-                    // registered stays cheap while cross-ontology search still works.
-                    // Slice is immutable per build, so key the cached load by build.
-                    await duck.loadParquetUrl(
-                        `${baseUrl.value}/${o.path}`,
-                        table,
-                        { materialize: false },
-                        VIEWER_ID,
-                        `${table}_${o.build}`
-                    )
-                    // is_a edges sidecar (sorted by parent) — a fast children lookup
-                    // for the tree. Optional: older slices predate it, in which case
-                    // children() falls back to scanning the parents column.
-                    let edgesTable = null
-                    if (o.edges_path) {
-                        edgesTable = table + '_edges'
-                        await duck.loadParquetUrl(
-                            `${baseUrl.value}/${o.edges_path}`,
-                            edgesTable,
-                            { materialize: false },
-                            VIEWER_ID,
-                            `${edgesTable}_${o.build}`
-                        )
-                    }
-                    loadedSources.push({
-                        ontology: o.ontology,
-                        ontology_version: o.ontology_version,
-                        count: o.count,
-                        table,
-                        edgesTable,
-                    })
-                }
-                sources.value = loadedSources
-
+                available.value = ontologies
                 const { connectionId: cid } = await duck.createConnection(VIEWER_ID)
                 connectionId = cid
-                loaded.value = true
+            } catch (e) {
+                error.value = e?.message || String(e)
+                throw e
+            } finally {
+                registryPromise = null
+            }
+        })()
+        return registryPromise
+    }
+
+    // Load one ontology's term + edges views on demand (single-flight per ontology).
+    // Each is registered as a VIEW (materialize:false): DuckDB reads the parquet
+    // footer, then range-fetches only the row-groups/columns a query touches (and
+    // caches them) — no upfront full download. Loading just the selected ontology
+    // keeps the browser's first paint fast; the picker loads them all via
+    // ensureLoaded for cross-ontology search.
+    const ensureOntology = async (ontologyName) => {
+        await ensureRegistry()
+        if (sources.value.some((s) => s.ontology === ontologyName)) return
+        if (ontologyPromises[ontologyName]) return ontologyPromises[ontologyName]
+        const o = available.value.find((e) => e.ontology === ontologyName)
+        if (!o) return
+
+        loading.value = true
+        ontologyPromises[ontologyName] = (async () => {
+            try {
+                const table = 'onto_' + String(o.slug || '').replace(/[^a-z0-9_]/gi, '_')
+                // Slice is immutable per build, so key the cached load by build.
+                const loads = [
+                    duck.loadParquetUrl(`${baseUrl.value}/${o.path}`, table, { materialize: false }, VIEWER_ID, `${table}_${o.build}`),
+                ]
+                // is_a edges sidecar (sorted by parent) — a fast children lookup for
+                // the tree. Optional: older slices predate it, in which case children()
+                // falls back to scanning the parents column. Loaded in parallel.
+                let edgesTable = null
+                if (o.edges_path) {
+                    edgesTable = table + '_edges'
+                    loads.push(
+                        duck.loadParquetUrl(`${baseUrl.value}/${o.edges_path}`, edgesTable, { materialize: false }, VIEWER_ID, `${edgesTable}_${o.build}`)
+                    )
+                }
+                await Promise.all(loads)
+                if (!sources.value.some((s) => s.ontology === ontologyName)) {
+                    sources.value = [
+                        ...sources.value,
+                        { ontology: o.ontology, ontology_version: o.ontology_version, count: o.count, table, edgesTable },
+                    ]
+                }
             } catch (e) {
                 error.value = e?.message || String(e)
                 throw e
             } finally {
                 loading.value = false
-                loadPromise = null
+                delete ontologyPromises[ontologyName]
             }
         })()
-        return loadPromise
+        return ontologyPromises[ontologyName]
+    }
+
+    // Load every ontology (cross-ontology search). Single-flight; ontologies load
+    // in parallel rather than one blocking round-trip each.
+    const ensureLoaded = async () => {
+        if (loaded.value) return
+        if (loadAllPromise) return loadAllPromise
+        loadAllPromise = (async () => {
+            try {
+                await ensureRegistry()
+                await Promise.all(available.value.map((o) => ensureOntology(o.ontology)))
+                loaded.value = true
+            } finally {
+                loadAllPromise = null
+            }
+        })()
+        return loadAllPromise
     }
 
     // Search-as-you-type over label + synonyms (+ exact curie), across all (or a
@@ -119,7 +143,14 @@ export const useOntologyStore = defineStore('ontology', () => {
     const search = async (rawTerm, { limit = 20, ontologies = null } = {}) => {
         const term = String(rawTerm || '').trim()
         if (!term) return []
-        await ensureLoaded()
+        // Scoped search (the browser) loads only the named ontologies; an unscoped
+        // search (the picker) loads all for cross-ontology matching.
+        if (ontologies && ontologies.length) {
+            await ensureRegistry()
+            await Promise.all(ontologies.map((o) => ensureOntology(o)))
+        } else {
+            await ensureLoaded()
+        }
 
         const t = esc(term)
         const like = `'%${t}%'`
@@ -203,7 +234,7 @@ export const useOntologyStore = defineStore('ontology', () => {
     // is reached by tree/breadcrumb navigation (search already returns full rows).
     // Returns the normalized row or null.
     const getByCurie = async (curie) => {
-        await ensureLoaded()
+        await ensureRegistry()
         if (!sources.value.length) return null
         const c = esc(curie)
         const tables = sources.value.map((s) => `SELECT ${COLUMNS} FROM ${s.table}`)
@@ -229,7 +260,7 @@ export const useOntologyStore = defineStore('ontology', () => {
     // are in this ontology's slice (parents empty, or all point outside). Each row
     // carries has_children so the tree can decide whether to render an expand arrow.
     const roots = async (ontology, { limit = 300 } = {}) => {
-        await ensureLoaded()
+        await ensureOntology(ontology)
         const table = tableFor(ontology)
         if (!table) return []
         const query = `
@@ -254,7 +285,7 @@ export const useOntologyStore = defineStore('ontology', () => {
     // precomputed. Fall back to scanning the parents string column for slices
     // published before edges existed.
     const children = async (curie, { limit = 3000 } = {}) => {
-        await ensureLoaded()
+        await ensureRegistry()
         if (!sources.value.length) return []
         const c = esc(curie)
         const lim = Number(limit) || 3000
@@ -287,7 +318,7 @@ export const useOntologyStore = defineStore('ontology', () => {
     // from the start — the breadcrumb trail above the tree. Recursion is depth-capped
     // to stay bounded on diamond-shaped DAGs. Returns [{ curie, label, ontology, depth }].
     const lineage = async (curie, { limit = 100, maxDepth = 50 } = {}) => {
-        await ensureLoaded()
+        await ensureRegistry()
         if (!sources.value.length) return []
         const c = esc(curie)
         const query = `
@@ -333,7 +364,8 @@ export const useOntologyStore = defineStore('ontology', () => {
     }
 
     return {
-        loading, loaded, error, sources, isConfigured, ensureLoaded,
+        loading, loaded, error, available, sources, isConfigured,
+        ensureRegistry, ensureOntology, ensureLoaded,
         search, descendants, ancestors,
         getByCurie, roots, children, lineage,
     }

--- a/src/stores/ontologyStore.js
+++ b/src/stores/ontologyStore.js
@@ -254,25 +254,42 @@ export const useOntologyStore = defineStore('ontology', () => {
             has_children: !!r.has_children,
         }))
 
-    const tableFor = (ontology) => (sources.value.find((s) => s.ontology === ontology) || {}).table
-
     // Top-level terms of one ontology — a tree root = a term none of whose parents
-    // are in this ontology's slice (parents empty, or all point outside). Each row
-    // carries has_children so the tree can decide whether to render an expand arrow.
+    // are in this ontology's slice. Each row carries has_children so the tree can
+    // decide whether to render an expand arrow.
+    //
+    // Computed as hash semi/anti-joins (a root is a term that is never an in-slice
+    // child; has_children = it appears as an in-slice parent), NOT the O(n²)
+    // correlated scan over the parents string — which took ~5s on a 20k-term slice.
+    // Prefers the edges sidecar; falls back to unnesting the parents column.
     const roots = async (ontology, { limit = 300 } = {}) => {
         await ensureOntology(ontology)
-        const table = tableFor(ontology)
-        if (!table) return []
-        const query = `
-            WITH all_terms AS (SELECT curie, label, ontology, parents FROM ${table} WHERE COALESCE(obsolete, false) = false)
-            SELECT r.curie, r.label, r.ontology,
-                EXISTS (SELECT 1 FROM all_terms t WHERE list_contains(string_split(t.parents, '|'), r.curie)) AS has_children
-            FROM all_terms r
-            WHERE r.parents IS NULL OR r.parents = ''
-                OR NOT EXISTS (SELECT 1 FROM all_terms p WHERE list_contains(string_split(r.parents, '|'), p.curie))
-            ORDER BY lower(r.label)
-            LIMIT ${Number(limit) || 300}
-        `
+        const src = sources.value.find((s) => s.ontology === ontology)
+        if (!src) return []
+        const lim = Number(limit) || 300
+
+        let query
+        if (src.edgesTable) {
+            query = `
+                WITH t AS (SELECT curie, label, ontology FROM ${src.table} WHERE COALESCE(obsolete, false) = false),
+                e AS (SELECT parent, child FROM ${src.edgesTable} WHERE parent IN (SELECT curie FROM t))
+                SELECT t.curie, t.label, t.ontology, (t.curie IN (SELECT parent FROM e)) AS has_children
+                FROM t
+                WHERE t.curie NOT IN (SELECT child FROM e)
+                ORDER BY lower(t.label)
+                LIMIT ${lim}
+            `
+        } else {
+            query = `
+                WITH t AS (SELECT curie, label, ontology, parents FROM ${src.table} WHERE COALESCE(obsolete, false) = false),
+                e AS (SELECT a.curie AS child, u.p AS parent FROM t a, unnest(string_split(a.parents, '|')) AS u(p) WHERE u.p <> '' AND u.p IN (SELECT curie FROM t))
+                SELECT t.curie, t.label, t.ontology, (t.curie IN (SELECT parent FROM e)) AS has_children
+                FROM t
+                WHERE t.curie NOT IN (SELECT child FROM e)
+                ORDER BY lower(t.label)
+                LIMIT ${lim}
+            `
+        }
         return mapTree(await duck.executeQuery(query, connectionId))
     }
 

--- a/src/stores/ontologyStore.js
+++ b/src/stores/ontologyStore.js
@@ -21,6 +21,8 @@ const VIEWER_ID = 'ontology'
 
 // The columns every slice shares (see cde-service ONT-1).
 const COLUMNS = 'curie, iri, label, synonyms, definition, ontology, ontology_version'
+// Extra columns fetched only for the detail panel (cross-refs, partonomy, merged ids).
+const DETAIL_COLUMNS = COLUMNS + ', xrefs, part_of, alt_ids'
 
 // Escape a user term for inlining into a single-quoted SQL literal.
 const esc = (s) => String(s || '').replace(/'/g, "''")
@@ -237,13 +239,36 @@ export const useOntologyStore = defineStore('ontology', () => {
         await ensureRegistry()
         if (!sources.value.length) return null
         const c = esc(curie)
-        const tables = sources.value.map((s) => `SELECT ${COLUMNS} FROM ${s.table}`)
+        const tables = sources.value.map((s) => `SELECT ${DETAIL_COLUMNS} FROM ${s.table}`)
+        // Match the curie, or an alt_id that folds into it (so a merged/retired id
+        // still resolves to the current term). Exact curie wins.
         const query = `
             WITH terms AS (${tables.join(' UNION ALL ')})
-            SELECT ${COLUMNS} FROM terms WHERE curie = '${c}' LIMIT 1
+            SELECT ${DETAIL_COLUMNS} FROM terms
+            WHERE curie = '${c}' OR list_contains(string_split(alt_ids, '|'), '${c}')
+            ORDER BY (curie = '${c}') DESC
+            LIMIT 1
         `
         const rows = await duck.executeQuery(query, connectionId)
         return rows && rows.length ? normalizeRow(rows[0]) : null
+    }
+
+    // Resolve display labels for a set of curies in one query (e.g. part_of targets).
+    // Returns a Map curie -> label.
+    const labelsFor = async (curies) => {
+        await ensureRegistry()
+        const list = (curies || []).map((c) => `'${esc(c)}'`)
+        const out = new Map()
+        if (!list.length || !sources.value.length) return out
+        const tables = sources.value.map((s) => `SELECT curie, label FROM ${s.table}`)
+        const query = `
+            WITH terms AS (${tables.join(' UNION ALL ')})
+            SELECT curie, label FROM terms WHERE curie IN (${list.join(', ')})
+        `
+        for (const r of (await duck.executeQuery(query, connectionId)) || []) {
+            out.set(String(r.curie), r.label == null ? '' : String(r.label))
+        }
+        return out
     }
 
     const mapTree = (rows) =>
@@ -384,7 +409,7 @@ export const useOntologyStore = defineStore('ontology', () => {
         loading, loaded, error, available, sources, isConfigured,
         ensureRegistry, ensureOntology, ensureLoaded,
         search, descendants, ancestors,
-        getByCurie, roots, children, lineage,
+        getByCurie, roots, children, lineage, labelsFor,
     }
 })
 
@@ -402,6 +427,9 @@ function normalizeRow(r) {
         definition: g('definition'),
         ontology: g('ontology'),
         ontology_version: g('ontology_version'),
+        xrefs: g('xrefs'),
+        part_of: g('part_of'),
+        alt_ids: g('alt_ids'),
     }
 }
 

--- a/src/stores/ontologyStore.js
+++ b/src/stores/ontologyStore.js
@@ -60,11 +60,17 @@ export const useOntologyStore = defineStore('ontology', () => {
                 const loadedSources = []
                 for (const o of ontologies) {
                     const table = 'onto_' + String(o.slug || '').replace(/[^a-z0-9_]/gi, '_')
+                    // Register each slice as a VIEW (materialize:false), not a table:
+                    // DuckDB reads the parquet footer and then range-fetches only the
+                    // row-groups/columns a query touches (and caches them), instead of
+                    // downloading every slice — incl. the large definition column — up
+                    // front. Registration is metadata-only, so keeping all ontologies
+                    // registered stays cheap while cross-ontology search still works.
                     // Slice is immutable per build, so key the cached load by build.
                     await duck.loadParquetUrl(
                         `${baseUrl.value}/${o.path}`,
                         table,
-                        { materialize: true },
+                        { materialize: false },
                         VIEWER_ID,
                         `${table}_${o.build}`
                     )

--- a/src/stores/ontologyStore.js
+++ b/src/stores/ontologyStore.js
@@ -123,50 +123,71 @@ export const useOntologyStore = defineStore('ontology', () => {
         return (rows || []).map(normalizeRow)
     }
 
-    // Walk the is_a hierarchy from a term via a recursive CTE over the `parents`
-    // edges. dir='down' = descendants (subtree), dir='up' = ancestors (toward the
-    // roots). Returns [{ curie, label, ontology }].
-    const walk = async (curie, dir, limit) => {
-        await ensureLoaded()
-        if (!sources.value.length) return []
-        const c = esc(curie)
-        const union = sources.value
-            .map((s) => `SELECT curie, label, ontology, parents FROM ${s.table}`)
-            .join(' UNION ALL ')
-        // down: keep terms whose parents include a node already in the set (children);
-        // up: keep terms that are a parent of a node already in the set.
-        const step =
-            dir === 'down'
-                ? `JOIN acc ON list_contains(string_split(t.parents, '|'), acc.curie)`
-                : `JOIN acc ON list_contains(string_split(acc.parents, '|'), t.curie)`
-        const query = `
-            WITH RECURSIVE all_terms AS (${union}),
-            acc AS (
-                SELECT curie, label, ontology, parents FROM all_terms WHERE curie = '${c}'
-                UNION
-                SELECT t.curie, t.label, t.ontology, t.parents FROM all_terms t ${step}
-            )
-            SELECT DISTINCT curie, label, ontology FROM acc LIMIT ${Number(limit) || 5000}
-        `
-        const rows = await duck.executeQuery(query, connectionId)
-        return (rows || []).map((r) => ({
+    const unionAll = () =>
+        sources.value.map((s) => `SELECT curie, label, ontology, parents FROM ${s.table}`).join(' UNION ALL ')
+
+    const mapRows = (rows) =>
+        (rows || []).map((r) => ({
             curie: r.curie == null ? '' : String(r.curie),
             label: r.label == null ? '' : String(r.label),
             ontology: r.ontology == null ? '' : String(r.ontology),
         }))
+
+    // Descendants of a term (the subtree) — the enumerable set an "ontology subtree
+    // value set" is built from. Two granularity controls:
+    //   maxDepth   — include only terms within N is_a levels of the root (null = all).
+    //   leavesOnly — keep only the most-specific terms in scope (no child in the set).
+    // Excludes the root itself unless includeSelf. Returns [{ curie, label, ontology }].
+    const descendants = async (curie, { includeSelf = false, maxDepth = null, leavesOnly = false, limit = 5000 } = {}) => {
+        await ensureLoaded()
+        if (!sources.value.length) return []
+        const c = esc(curie)
+        // Bound recursion by depth when set: only expand a node's children while its
+        // own depth is below the cap (root = depth 0).
+        const depthGuard =
+            maxDepth != null && maxDepth >= 0 ? `WHERE s.depth < ${Math.floor(Number(maxDepth))}` : ''
+
+        const filters = []
+        if (!includeSelf) filters.push(`curie <> '${c}'`)
+        if (leavesOnly) {
+            // A leaf in scope = a subtree node that no other subtree node lists as a
+            // parent (i.e. it has no in-scope children).
+            filters.push(
+                `curie NOT IN (SELECT DISTINCT p FROM sub, unnest(string_split(sub.parents, '|')) AS u(p) WHERE p <> '')`
+            )
+        }
+        const where = filters.length ? `WHERE ${filters.join(' AND ')}` : ''
+
+        const query = `
+            WITH RECURSIVE all_terms AS (${unionAll()}),
+            sub AS (
+                SELECT curie, label, ontology, parents, 0 AS depth FROM all_terms WHERE curie = '${c}'
+                UNION
+                SELECT t.curie, t.label, t.ontology, t.parents, s.depth + 1
+                FROM all_terms t JOIN sub s ON list_contains(string_split(t.parents, '|'), s.curie)
+                ${depthGuard}
+            )
+            SELECT DISTINCT curie, label, ontology FROM sub ${where} LIMIT ${Number(limit) || 5000}
+        `
+        return mapRows(await duck.executeQuery(query, connectionId))
     }
 
-    // All descendants of a term (the subtree) — the enumerable set an "ontology
-    // subtree value set" is built from. Excludes the term itself unless includeSelf.
-    const descendants = async (curie, { includeSelf = false, limit = 5000 } = {}) => {
-        const rows = await walk(curie, 'down', limit)
-        return includeSelf ? rows : rows.filter((r) => r.curie !== curie)
-    }
-
-    // All ancestors of a term (path toward the roots) — for breadcrumb context /
-    // broadening a search. Excludes the term itself.
+    // Ancestors of a term (path toward the roots) — breadcrumb context / broadening.
     const ancestors = async (curie, { limit = 200 } = {}) => {
-        return (await walk(curie, 'up', limit)).filter((r) => r.curie !== curie)
+        await ensureLoaded()
+        if (!sources.value.length) return []
+        const c = esc(curie)
+        const query = `
+            WITH RECURSIVE all_terms AS (${unionAll()}),
+            acc AS (
+                SELECT curie, label, ontology, parents FROM all_terms WHERE curie = '${c}'
+                UNION
+                SELECT t.curie, t.label, t.ontology, t.parents
+                FROM all_terms t JOIN acc ON list_contains(string_split(acc.parents, '|'), t.curie)
+            )
+            SELECT DISTINCT curie, label, ontology FROM acc WHERE curie <> '${c}' LIMIT ${Number(limit) || 200}
+        `
+        return mapRows(await duck.executeQuery(query, connectionId))
     }
 
     return { loading, loaded, error, sources, isConfigured, ensureLoaded, search, descendants, ancestors }

--- a/src/stores/ontologyStore.js
+++ b/src/stores/ontologyStore.js
@@ -1,0 +1,148 @@
+// @/stores/ontologyStore.js
+//
+// Client-side ontology term search (ONT-2). Loads the published ontology slices
+// (open annotation ontologies MONDO/HPO/UBERON/NCIt + a static UCUM unit list)
+// from the catalog bucket into DuckDB-WASM via the shared duckdbStore, then does
+// search-as-you-type over label/synonyms — zero-API-latency, offline, the same
+// read path as the CDE catalog. Slices are public, so no auth.
+//
+// Used by the property editor to link a standard ontology term to a custom-model
+// property (an `x-pennsieve-concept` annotation). Read-only; the term is
+// snapshotted onto the property at pick time.
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import * as site from '@/site-config/site.json'
+import { useDuckDBStore } from '@/stores/duckdbStore'
+
+const VIEWER_ID = 'ontology'
+
+// One value-list of the columns every slice shares (see cde-service ONT-1).
+const COLUMNS = 'curie, iri, label, synonyms, definition, ontology, ontology_version'
+
+// Escape a user term for inlining into a single-quoted SQL literal.
+const esc = (s) => String(s || '').replace(/'/g, "''")
+
+export const useOntologyStore = defineStore('ontology', () => {
+    const duck = useDuckDBStore()
+
+    const loading = ref(false)
+    const loaded = ref(false)
+    const error = ref('')
+    const version = ref('') // our slice-build version
+    const sources = ref([]) // [{ ontology, ontology_version, count, table }]
+
+    let connectionId = null
+    let loadPromise = null
+
+    const baseUrl = computed(() => (site.cdeCatalogUrl || '').replace(/\/+$/, ''))
+    const isConfigured = computed(() => !!baseUrl.value)
+
+    const sliceUrl = (path) => `${baseUrl.value}/ontology/versions/${version.value}/${path}`
+
+    // Resolve the current slice build and load every slice into DuckDB (one table
+    // per ontology; search UNIONs across them). Single-flight.
+    const ensureLoaded = async () => {
+        if (loaded.value) return
+        if (loadPromise) return loadPromise
+        if (!baseUrl.value) {
+            error.value = 'Catalog URL is not configured (site.cdeCatalogUrl).'
+            throw new Error(error.value)
+        }
+
+        loading.value = true
+        error.value = ''
+        loadPromise = (async () => {
+            try {
+                const latest = await fetchJson(`${baseUrl.value}/ontology/latest.json`)
+                const v = latest.version
+                if (!v) throw new Error('ontology latest.json has no version')
+                version.value = v
+
+                const manifest = await fetchJson(`${baseUrl.value}/ontology/versions/${v}/manifest.json`)
+                const ontologies = manifest.ontologies || []
+                if (!ontologies.length) throw new Error('ontology manifest is empty')
+
+                const loadedSources = []
+                for (const o of ontologies) {
+                    const table = 'onto_' + o.path.replace(/\.parquet$/i, '').replace(/[^a-z0-9_]/gi, '_')
+                    await duck.loadParquetUrl(sliceUrl(o.path), table, { materialize: true }, VIEWER_ID, `${table}_${v}`)
+                    loadedSources.push({
+                        ontology: o.ontology,
+                        ontology_version: o.ontology_version,
+                        count: o.count,
+                        table,
+                    })
+                }
+                sources.value = loadedSources
+
+                const { connectionId: cid } = await duck.createConnection(VIEWER_ID)
+                connectionId = cid
+                loaded.value = true
+            } catch (e) {
+                error.value = e?.message || String(e)
+                throw e
+            } finally {
+                loading.value = false
+                loadPromise = null
+            }
+        })()
+        return loadPromise
+    }
+
+    // Search-as-you-type over label + synonyms (+ exact curie), across all (or a
+    // filtered subset of) loaded ontologies. Obsolete terms are excluded. Returns
+    // [{ curie, iri, label, synonyms, definition, ontology, ontology_version }],
+    // best matches first.
+    const search = async (rawTerm, { limit = 20, ontologies = null } = {}) => {
+        const term = String(rawTerm || '').trim()
+        if (!term) return []
+        await ensureLoaded()
+
+        const t = esc(term)
+        const like = `'%${t}%'`
+        const tables = sources.value
+            .filter((s) => !ontologies || ontologies.includes(s.ontology))
+            .map((s) => `SELECT ${COLUMNS} FROM ${s.table} WHERE COALESCE(obsolete, false) = false`)
+        if (!tables.length) return []
+
+        const query = `
+            WITH terms AS (${tables.join(' UNION ALL ')})
+            SELECT ${COLUMNS}
+            FROM terms
+            WHERE label ILIKE ${like} OR synonyms ILIKE ${like} OR curie ILIKE '${t}%'
+            ORDER BY
+                (lower(label) = lower('${t}')) DESC,          -- exact label
+                (lower(curie) = lower('${t}')) DESC,          -- exact curie
+                (label ILIKE '${t}%') DESC,                   -- label prefix
+                length(label) ASC
+            LIMIT ${Number(limit) || 20}
+        `
+        const rows = await duck.executeQuery(query, connectionId)
+        return (rows || []).map(normalizeRow)
+    }
+
+    return { loading, loaded, error, version, sources, isConfigured, ensureLoaded, search }
+})
+
+// DuckDB rows come back as Arrow rows; normalize to plain objects/strings.
+function normalizeRow(r) {
+    const g = (k) => {
+        const v = r[k]
+        return v == null ? '' : String(v)
+    }
+    return {
+        curie: g('curie'),
+        iri: g('iri'),
+        label: g('label'),
+        synonyms: g('synonyms'),
+        definition: g('definition'),
+        ontology: g('ontology'),
+        ontology_version: g('ontology_version'),
+    }
+}
+
+async function fetchJson(url) {
+    const res = await fetch(url, { cache: 'no-cache' })
+    if (!res.ok) throw new Error(`GET ${url} -> ${res.status}`)
+    return res.json()
+}

--- a/src/stores/ontologyStore.js
+++ b/src/stores/ontologyStore.js
@@ -6,9 +6,12 @@
 // search-as-you-type over label/synonyms — zero-API-latency, offline, the same
 // read path as the CDE catalog. Slices are public, so no auth.
 //
-// Used by the property editor to link a standard ontology term to a custom-model
-// property (an `x-pennsieve-concept` annotation). Read-only; the term is
-// snapshotted onto the property at pick time.
+// Each ontology is published + versioned independently: a single registry
+// (ontology/sources.json) points at each ontology's current slice
+// (ontology/<slug>/versions/<build>/<slug>.parquet), so ontologies can be added
+// or refreshed one at a time.
+//
+// Used to link a standard ontology term to a dataset tag / custom-model property.
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import * as site from '@/site-config/site.json'
@@ -16,7 +19,7 @@ import { useDuckDBStore } from '@/stores/duckdbStore'
 
 const VIEWER_ID = 'ontology'
 
-// One value-list of the columns every slice shares (see cde-service ONT-1).
+// The columns every slice shares (see cde-service ONT-1).
 const COLUMNS = 'curie, iri, label, synonyms, definition, ontology, ontology_version'
 
 // Escape a user term for inlining into a single-quoted SQL literal.
@@ -28,7 +31,6 @@ export const useOntologyStore = defineStore('ontology', () => {
     const loading = ref(false)
     const loaded = ref(false)
     const error = ref('')
-    const version = ref('') // our slice-build version
     const sources = ref([]) // [{ ontology, ontology_version, count, table }]
 
     let connectionId = null
@@ -37,10 +39,8 @@ export const useOntologyStore = defineStore('ontology', () => {
     const baseUrl = computed(() => (site.cdeCatalogUrl || '').replace(/\/+$/, ''))
     const isConfigured = computed(() => !!baseUrl.value)
 
-    const sliceUrl = (path) => `${baseUrl.value}/ontology/versions/${version.value}/${path}`
-
-    // Resolve the current slice build and load every slice into DuckDB (one table
-    // per ontology; search UNIONs across them). Single-flight.
+    // Read the registry and load every listed ontology's current slice into its
+    // own DuckDB table (search UNIONs across them). Single-flight.
     const ensureLoaded = async () => {
         if (loaded.value) return
         if (loadPromise) return loadPromise
@@ -53,19 +53,21 @@ export const useOntologyStore = defineStore('ontology', () => {
         error.value = ''
         loadPromise = (async () => {
             try {
-                const latest = await fetchJson(`${baseUrl.value}/ontology/latest.json`)
-                const v = latest.version
-                if (!v) throw new Error('ontology latest.json has no version')
-                version.value = v
-
-                const manifest = await fetchJson(`${baseUrl.value}/ontology/versions/${v}/manifest.json`)
-                const ontologies = manifest.ontologies || []
-                if (!ontologies.length) throw new Error('ontology manifest is empty')
+                const registry = await fetchJson(`${baseUrl.value}/ontology/sources.json`)
+                const ontologies = registry.ontologies || []
+                if (!ontologies.length) throw new Error('ontology registry is empty')
 
                 const loadedSources = []
                 for (const o of ontologies) {
-                    const table = 'onto_' + o.path.replace(/\.parquet$/i, '').replace(/[^a-z0-9_]/gi, '_')
-                    await duck.loadParquetUrl(sliceUrl(o.path), table, { materialize: true }, VIEWER_ID, `${table}_${v}`)
+                    const table = 'onto_' + String(o.slug || '').replace(/[^a-z0-9_]/gi, '_')
+                    // Slice is immutable per build, so key the cached load by build.
+                    await duck.loadParquetUrl(
+                        `${baseUrl.value}/${o.path}`,
+                        table,
+                        { materialize: true },
+                        VIEWER_ID,
+                        `${table}_${o.build}`
+                    )
                     loadedSources.push({
                         ontology: o.ontology,
                         ontology_version: o.ontology_version,
@@ -121,7 +123,7 @@ export const useOntologyStore = defineStore('ontology', () => {
         return (rows || []).map(normalizeRow)
     }
 
-    return { loading, loaded, error, version, sources, isConfigured, ensureLoaded, search }
+    return { loading, loaded, error, sources, isConfigured, ensureLoaded, search }
 })
 
 // DuckDB rows come back as Arrow rows; normalize to plain objects/strings.

--- a/src/stores/ontologyStore.js
+++ b/src/stores/ontologyStore.js
@@ -123,7 +123,53 @@ export const useOntologyStore = defineStore('ontology', () => {
         return (rows || []).map(normalizeRow)
     }
 
-    return { loading, loaded, error, sources, isConfigured, ensureLoaded, search }
+    // Walk the is_a hierarchy from a term via a recursive CTE over the `parents`
+    // edges. dir='down' = descendants (subtree), dir='up' = ancestors (toward the
+    // roots). Returns [{ curie, label, ontology }].
+    const walk = async (curie, dir, limit) => {
+        await ensureLoaded()
+        if (!sources.value.length) return []
+        const c = esc(curie)
+        const union = sources.value
+            .map((s) => `SELECT curie, label, ontology, parents FROM ${s.table}`)
+            .join(' UNION ALL ')
+        // down: keep terms whose parents include a node already in the set (children);
+        // up: keep terms that are a parent of a node already in the set.
+        const step =
+            dir === 'down'
+                ? `JOIN acc ON list_contains(string_split(t.parents, '|'), acc.curie)`
+                : `JOIN acc ON list_contains(string_split(acc.parents, '|'), t.curie)`
+        const query = `
+            WITH RECURSIVE all_terms AS (${union}),
+            acc AS (
+                SELECT curie, label, ontology, parents FROM all_terms WHERE curie = '${c}'
+                UNION
+                SELECT t.curie, t.label, t.ontology, t.parents FROM all_terms t ${step}
+            )
+            SELECT DISTINCT curie, label, ontology FROM acc LIMIT ${Number(limit) || 5000}
+        `
+        const rows = await duck.executeQuery(query, connectionId)
+        return (rows || []).map((r) => ({
+            curie: r.curie == null ? '' : String(r.curie),
+            label: r.label == null ? '' : String(r.label),
+            ontology: r.ontology == null ? '' : String(r.ontology),
+        }))
+    }
+
+    // All descendants of a term (the subtree) — the enumerable set an "ontology
+    // subtree value set" is built from. Excludes the term itself unless includeSelf.
+    const descendants = async (curie, { includeSelf = false, limit = 5000 } = {}) => {
+        const rows = await walk(curie, 'down', limit)
+        return includeSelf ? rows : rows.filter((r) => r.curie !== curie)
+    }
+
+    // All ancestors of a term (path toward the roots) — for breadcrumb context /
+    // broadening a search. Excludes the term itself.
+    const ancestors = async (curie, { limit = 200 } = {}) => {
+        return (await walk(curie, 'up', limit)).filter((r) => r.curie !== curie)
+    }
+
+    return { loading, loaded, error, sources, isConfigured, ensureLoaded, search, descendants, ancestors }
 })
 
 // DuckDB rows come back as Arrow rows; normalize to plain objects/strings.

--- a/src/stores/ontologyStore.js
+++ b/src/stores/ontologyStore.js
@@ -74,11 +74,26 @@ export const useOntologyStore = defineStore('ontology', () => {
                         VIEWER_ID,
                         `${table}_${o.build}`
                     )
+                    // is_a edges sidecar (sorted by parent) — a fast children lookup
+                    // for the tree. Optional: older slices predate it, in which case
+                    // children() falls back to scanning the parents column.
+                    let edgesTable = null
+                    if (o.edges_path) {
+                        edgesTable = table + '_edges'
+                        await duck.loadParquetUrl(
+                            `${baseUrl.value}/${o.edges_path}`,
+                            edgesTable,
+                            { materialize: false },
+                            VIEWER_ID,
+                            `${edgesTable}_${o.build}`
+                        )
+                    }
                     loadedSources.push({
                         ontology: o.ontology,
                         ontology_version: o.ontology_version,
                         count: o.count,
                         table,
+                        edgesTable,
                     })
                 }
                 sources.value = loadedSources
@@ -233,10 +248,29 @@ export const useOntologyStore = defineStore('ontology', () => {
     // Direct is_a children of a term (one level) — the lazy-load unit for the tree
     // and the "narrower terms" list in the detail panel. has_children lets the tree
     // show an expand arrow without a follow-up query.
+    //
+    // Prefer the per-ontology edges sidecar (sorted by parent): `WHERE parent = X`
+    // prunes to a few row groups over range requests, and child_has_children is
+    // precomputed. Fall back to scanning the parents string column for slices
+    // published before edges existed.
     const children = async (curie, { limit = 3000 } = {}) => {
         await ensureLoaded()
         if (!sources.value.length) return []
         const c = esc(curie)
+        const lim = Number(limit) || 3000
+
+        const edgeTables = sources.value.map((s) => s.edgesTable).filter(Boolean)
+        if (edgeTables.length) {
+            const union = edgeTables
+                .map(
+                    (t) =>
+                        `SELECT child AS curie, child_label AS label, child_ontology AS ontology, child_has_children AS has_children FROM ${t} WHERE parent = '${c}'`
+                )
+                .join(' UNION ALL ')
+            const query = `SELECT curie, label, ontology, has_children FROM (${union}) ORDER BY lower(label) LIMIT ${lim}`
+            return mapTree(await duck.executeQuery(query, connectionId))
+        }
+
         const query = `
             WITH all_terms AS (${unionAll()})
             SELECT k.curie, k.label, k.ontology,
@@ -244,7 +278,7 @@ export const useOntologyStore = defineStore('ontology', () => {
             FROM all_terms k
             WHERE list_contains(string_split(k.parents, '|'), '${c}')
             ORDER BY lower(k.label)
-            LIMIT ${Number(limit) || 3000}
+            LIMIT ${lim}
         `
         return mapTree(await duck.executeQuery(query, connectionId))
     }


### PR DESCRIPTION
Deploys the **ONT-2 dataset-tags** slice to the dev environment for testing. Part of the Ontology epic (draft PR to main: #772).

Ontology-assisted dataset tagging — `ontologyStore.js` + the `BfDatasetSettings.vue` tag-search wiring. Verified working locally against the MONDO slice already on the dev catalog bucket.

Note: this branch is based on \`main\`, so merging to \`dev\` also carries the main commits \`dev\` is currently behind on — expected given dev/main have diverged; flag if that's not desired and I'll rebase the ontology commit onto \`dev\` for a clean single-commit dev PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)