### PR TITLE
deploy(dev): value-set picker + record-label value display (labels not codes)

### DIFF
--- a/src/components/datasets/metadata/models/ModelSpecViewer.vue
+++ b/src/components/datasets/metadata/models/ModelSpecViewer.vue
@@ -557,6 +557,19 @@ const PropertyTree = defineComponent({
       return baseType
     }
     
+    // code -> display label from a materialized value-list annotation (ontology
+    // `x-pennsieve-concept-values` or CDE `x-pennsieve-cde-values`). Empty when
+    // none — the enum then shows the raw codes.
+    const enumLabels = (property) => {
+      const vals = property['x-pennsieve-concept-values'] || property['x-pennsieve-cde-values'] || []
+      const map = {}
+      for (const v of vals) {
+        const code = v?.code ?? v?.value
+        if (code != null) map[code] = v.label || String(code)
+      }
+      return map
+    }
+
     const getNestedConstraints = (property) => {
       const constraints = []
       
@@ -593,9 +606,14 @@ const PropertyTree = defineComponent({
         constraints.push('unique')
       }
       
-      // Enum values
+      // Enum values — show labels (not raw codes like MONDO:xxx) and cap the list.
       if (property.enum) {
-        constraints.push(`values: [${property.enum.join(', ')}]`)
+        const labels = enumLabels(property)
+        const display = property.enum.map((v) => labels[v] || v)
+        const CAP = 10
+        const shown = display.slice(0, CAP).join(', ')
+        const more = display.length - CAP
+        constraints.push(`values: [${shown}${more > 0 ? `, +${more} more` : ''}]`)
       }
       
       return constraints

--- a/src/components/datasets/metadata/models/OntologyTreePicker.vue
+++ b/src/components/datasets/metadata/models/OntologyTreePicker.vue
@@ -1,0 +1,254 @@
+<template>
+  <el-dialog
+    :model-value="modelValue"
+    title="Browse ontology"
+    width="580px"
+    @update:model-value="$emit('update:modelValue', $event)"
+    @open="onOpen"
+  >
+    <div class="otp">
+      <div class="otp-controls">
+        <el-select v-model="scope" style="width: 160px" @change="onScopeChange">
+          <el-option v-for="o in options" :key="o.ontology" :label="o.ontology" :value="o.ontology" />
+        </el-select>
+        <el-input
+          v-model="term"
+          style="flex: 1"
+          placeholder="Search this ontology, or browse the tree below"
+          clearable
+          @input="onSearch"
+        >
+          <template #prefix><el-icon><Search /></el-icon></template>
+        </el-input>
+      </div>
+
+      <div class="otp-body">
+        <div v-if="loading" class="otp-status">Loading…</div>
+
+        <!-- Search results -->
+        <template v-else-if="term.trim()">
+          <div v-if="searching" class="otp-status">Searching…</div>
+          <div v-else-if="!results.length" class="otp-status">No matching terms.</div>
+          <ul v-else class="otp-results">
+            <li
+              v-for="r in results"
+              :key="r.curie"
+              :class="{ active: selected && selected.curie === r.curie }"
+              @click="pick(r)"
+            >
+              <span class="otp-label">{{ r.label }}</span>
+              <span class="otp-code">{{ r.curie }}</span>
+            </li>
+          </ul>
+        </template>
+
+        <!-- Lazy tree -->
+        <el-tree
+          v-else
+          :key="scope"
+          class="otp-tree"
+          node-key="curie"
+          :props="treeProps"
+          :load="loadNode"
+          lazy
+          :expand-on-click-node="false"
+          highlight-current
+          empty-text="No terms"
+          @node-click="pick"
+        >
+          <template #default="{ data }">
+            <span class="otp-node" :class="{ active: selected && selected.curie === data.curie }">
+              <span class="otp-label">{{ data.label }}</span>
+              <span class="otp-code">{{ data.curie }}</span>
+            </span>
+          </template>
+        </el-tree>
+      </div>
+    </div>
+
+    <template #footer>
+      <div class="otp-footer">
+        <span v-if="selected" class="otp-selected">
+          Selected: <strong>{{ selected.label }}</strong> <span class="otp-code">{{ selected.curie }}</span>
+        </span>
+        <span v-else class="otp-selected otp-muted">Pick a term to use as the value-set root.</span>
+        <span class="otp-spacer" />
+        <el-button @click="$emit('update:modelValue', false)">Cancel</el-button>
+        <el-button type="primary" :disabled="!selected" @click="confirm">Use this term</el-button>
+      </div>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { Search } from '@element-plus/icons-vue'
+import debounce from 'lodash.debounce'
+import { useOntologyStore } from '@/stores/ontologyStore'
+
+defineProps({ modelValue: Boolean })
+const emit = defineEmits(['update:modelValue', 'select'])
+
+const store = useOntologyStore()
+
+// UCUM is a flat unit list — not a browsable tree.
+const options = computed(() => (store.available || []).filter((o) => o.ontology !== 'UCUM'))
+const scope = ref('')
+const loading = ref(false)
+const term = ref('')
+const results = ref([])
+const searching = ref(false)
+const selected = ref(null)
+
+const treeProps = { label: 'label', children: 'children', isLeaf: (d) => !d.has_children }
+// Terms in a slice share the ontology's version (the tree rows don't carry it).
+const scopeVersion = () => (store.available || []).find((o) => o.ontology === scope.value)?.ontology_version || ''
+
+const loadOntology = async () => {
+  loading.value = true
+  try {
+    if (scope.value) await store.ensureOntology(scope.value)
+  } catch {
+    /* leave the tree empty on failure */
+  } finally {
+    loading.value = false
+  }
+}
+
+const onOpen = async () => {
+  selected.value = null
+  term.value = ''
+  results.value = []
+  loading.value = true
+  try {
+    await store.ensureRegistry()
+    if (!scope.value && options.value.length) {
+      scope.value = (options.value.find((o) => o.ontology === 'MONDO') || options.value[0]).ontology
+    }
+  } catch {
+    /* registry unavailable */
+  }
+  await loadOntology()
+}
+
+const onScopeChange = async () => {
+  selected.value = null
+  term.value = ''
+  results.value = []
+  await loadOntology()
+}
+
+const loadNode = async (node, resolve) => {
+  try {
+    resolve(node.level === 0 ? await store.roots(scope.value) : await store.children(node.data.curie))
+  } catch {
+    resolve([])
+  }
+}
+
+const onSearch = debounce(async () => {
+  const q = term.value.trim()
+  if (!q) {
+    results.value = []
+    return
+  }
+  searching.value = true
+  try {
+    results.value = await store.search(q, { limit: 25, ontologies: [scope.value] })
+  } catch {
+    results.value = []
+  } finally {
+    searching.value = false
+  }
+}, 250)
+
+const pick = (node) => {
+  if (!node || !node.curie) return
+  selected.value = { curie: node.curie, label: node.label, ontology: scope.value, ontology_version: scopeVersion() }
+}
+
+const confirm = () => {
+  if (!selected.value) return
+  emit('select', { ...selected.value })
+  emit('update:modelValue', false)
+}
+</script>
+
+<style scoped lang="scss">
+@use '../../../../styles/theme' as theme;
+
+.otp-controls {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.otp-body {
+  min-height: 260px;
+  max-height: 340px;
+  overflow: auto;
+  border: 1px solid theme.$gray_2;
+  border-radius: 4px;
+  padding: 8px;
+}
+.otp-status {
+  color: theme.$gray_4;
+  font-size: 14px;
+  padding: 8px;
+}
+.otp-results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  li {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 6px 10px;
+    border-radius: 3px;
+    cursor: pointer;
+    &:hover {
+      background: theme.$gray_1;
+    }
+    &.active {
+      background: theme.$purple_tint;
+    }
+  }
+}
+.otp-node {
+  display: inline-flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding-right: 8px;
+  &.active .otp-label {
+    color: theme.$purple_2;
+    font-weight: 500;
+  }
+}
+.otp-label {
+  color: theme.$gray_6;
+}
+.otp-code {
+  flex-shrink: 0;
+  font-size: 11px;
+  color: theme.$gray_4;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.otp-footer {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.otp-selected {
+  font-size: 13px;
+  color: theme.$gray_6;
+}
+.otp-muted {
+  color: theme.$gray_4;
+}
+.otp-spacer {
+  flex: 1;
+}
+</style>

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -278,7 +278,7 @@
               <el-option v-for="t in manualTypes" :key="t.value" :label="t.label" :value="t.value" />
             </el-select>
           </el-form-item>
-          <el-form-item v-if="manual.type === 'string' && !subtreeRoot" label="Format">
+          <el-form-item v-if="manual.type === 'string' && !hasControlledValues" label="Format">
             <el-select v-model="manual.format">
               <el-option v-for="f in stringFormats" :key="f.value" :label="f.label" :value="f.value" />
             </el-select>
@@ -927,11 +927,12 @@ function manualValueSchema() {
   const en = parseCsv(manual.enumInput)
   const withConstraints = (obj) => {
     if (t === 'string') {
-      if (manual.format && manual.format !== 'plain') obj.format = manual.format
-      // Skip length/pattern when the value is drawn from a controlled set — they'd
-      // be redundant and could reject valid codes (and may be stale from before the
-      // value set was chosen).
+      // Skip format/length/pattern when the value is drawn from a controlled set
+      // (a manual enum or an ontology value set) — the enum already fixes the exact
+      // allowed values, so these are redundant and can be contradictory (an enum value
+      // that doesn't satisfy the format leaves the field unsatisfiable).
       if (!hasControlledValues.value) {
+        if (manual.format && manual.format !== 'plain') obj.format = manual.format
         if (isNum(manual.minLength)) obj.minLength = parseInt(manual.minLength, 10)
         if (isNum(manual.maxLength)) obj.maxLength = parseInt(manual.maxLength, 10)
         if (manual.pattern) obj.pattern = manual.pattern

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -294,36 +294,34 @@
         <div class="pf-section-title">Data values</div>
         <el-form label-position="top">
           <el-form-item label="Allowed values">
-            <el-input v-model="manual.enumInput" placeholder="Comma-separated, e.g. Low, Medium, High" />
-            <!-- Prototype: fill allowed values from an ontology subtree -->
-            <div style="margin-top: 8px; width: 100%">
-              <el-input
-                v-model="ontoTerm"
-                placeholder="…or fill from an ontology term's subtree — e.g. diabetes, seizure"
-                @input="runOntoSearch"
-              >
-                <template #prefix><el-icon><Search /></el-icon></template>
-              </el-input>
-              <ul
-                v-if="ontoResults.length"
-                style="list-style: none; margin: 8px 0 0; padding: 0; border: 1px solid var(--el-border-color); border-radius: 4px; max-height: 200px; overflow: auto"
-              >
-                <li
-                  v-for="c in ontoResults"
-                  :key="c.curie"
-                  style="display: flex; justify-content: space-between; gap: 8px; padding: 8px 16px; cursor: pointer"
-                  @click="selectSubtreeRoot(c)"
+            <!-- Type a list, or fill from an ontology term's subtree. -->
+            <template v-if="!subtreeRoot">
+              <el-input v-model="manual.enumInput" placeholder="Comma-separated, e.g. Low, Medium, High" />
+              <div style="margin-top: 8px; width: 100%">
+                <el-input
+                  v-model="ontoTerm"
+                  placeholder="…or fill from an ontology term's subtree — e.g. diabetes, seizure"
+                  @input="runOntoSearch"
                 >
-                  <span>{{ c.label }}</span>
-                  <span style="flex-shrink: 0; font-size: 12px; opacity: 0.6">{{ ontoMeta(c) }}</span>
-                </li>
-              </ul>
-              <!-- Granularity controls once a root is chosen -->
-              <div
-                v-if="subtreeRoot"
-                style="margin-top: 8px; display: flex; gap: 12px; align-items: center; flex-wrap: wrap"
-              >
-                <span style="font-size: 12px">From <strong>{{ subtreeRoot.label }}</strong>:</span>
+                  <template #prefix><el-icon><Search /></el-icon></template>
+                </el-input>
+                <ul v-if="ontoResults.length" class="onto-results">
+                  <li v-for="c in ontoResults" :key="c.curie" @click="selectSubtreeRoot(c)">
+                    <span>{{ c.label }}</span>
+                    <span class="onto-results-meta">{{ ontoMeta(c) }}</span>
+                  </li>
+                </ul>
+              </div>
+            </template>
+
+            <!-- A term is chosen: granularity + a readable preview of the members. -->
+            <div v-else class="onto-subtree">
+              <div class="onto-subtree-head">
+                <span>From <strong>{{ subtreeRoot.label }}</strong>
+                  <span class="onto-subtree-code">{{ subtreeRoot.curie }}</span></span>
+                <el-button text @click="clearSubtree">change</el-button>
+              </div>
+              <div class="onto-subtree-controls">
                 <el-select v-model="subtreeDepth" style="width: 160px" @change="applySubtree">
                   <el-option label="All descendants" value="all" />
                   <el-option label="Direct children" value="1" />
@@ -331,7 +329,19 @@
                   <el-option label="3 levels" value="3" />
                 </el-select>
                 <el-checkbox v-model="subtreeLeaves" @change="applySubtree">Most specific only</el-checkbox>
-                <el-button text @click="clearSubtree">clear</el-button>
+              </div>
+              <div v-if="valueDomain" class="onto-subtree-count">
+                {{ valueDomain.count.toLocaleString() }}
+                value{{ valueDomain.count === 1 ? '' : 's' }} · {{ subtreeScopeLabel }}
+              </div>
+              <ul v-if="subtreePreview.length" class="onto-subtree-list">
+                <li v-for="m in subtreePreview" :key="m.curie">
+                  <span class="onto-subtree-item-label">{{ m.label }}</span>
+                  <span class="onto-subtree-code">{{ m.curie }}</span>
+                </li>
+              </ul>
+              <div v-if="valueDomain && valueDomain.count > subtreePreview.length" class="onto-subtree-more">
+                …and {{ (valueDomain.count - subtreePreview.length).toLocaleString() }} more
               </div>
               <div v-if="subtreeNote" class="wiz-hint" style="margin-top: 6px">{{ subtreeNote }}</div>
             </div>
@@ -410,6 +420,15 @@ const subtreeDepth = ref('all') // 'all' | '1' | '2' | '3'
 const subtreeLeaves = ref(false)
 const valueDomain = ref(null) // the materialized ontology-subtree value domain (or null)
 const SUBTREE_INLINE_CAP = 512
+const PREVIEW_CAP = 200 // rows rendered in the selection preview (large sets show a sample + count)
+const subtreePreview = ref([]) // [{ curie, label }] — a readable preview of the resolved members
+
+const subtreeScopeLabel = computed(() => {
+  const vd = valueDomain.value
+  if (!vd) return ''
+  const depth = vd.max_depth == null ? 'all descendants' : `depth ≤ ${vd.max_depth}`
+  return depth + (vd.leaves_only ? ', most-specific only' : '')
+})
 
 // A property's values are a controlled set when an ontology subtree is chosen or
 // an allowed-values list is typed in. Then length/pattern don't apply — the value
@@ -443,7 +462,10 @@ const selectSubtreeRoot = (term) => {
 const clearSubtree = () => {
   subtreeRoot.value = null
   valueDomain.value = null
+  subtreePreview.value = []
   subtreeNote.value = ''
+  ontoTerm.value = ''
+  ontoResults.value = []
 }
 
 // Resolve the value set from the chosen root + granularity (depth / leaves-only)
@@ -459,9 +481,6 @@ const applySubtree = async () => {
     const maxDepth = subtreeDepth.value === 'all' ? null : Number(subtreeDepth.value)
     const descs = await ontology.descendants(root.curie, { maxDepth, leavesOnly: subtreeLeaves.value, limit: 10000 })
     const memberTerms = subtreeLeaves.value ? descs : [{ curie: root.curie, label: root.label }, ...descs]
-    const scope =
-      (subtreeDepth.value === 'all' ? 'all descendants' : `depth ≤ ${subtreeDepth.value}`) +
-      (subtreeLeaves.value ? ', most-specific only' : '')
 
     const overCap = memberTerms.length > SUBTREE_INLINE_CAP
     valueDomain.value = {
@@ -476,19 +495,17 @@ const applySubtree = async () => {
       over_cap: overCap,
       members: overCap ? null : memberTerms.map((m) => ({ code: m.curie, label: m.label })),
     }
-
-    if (overCap) {
-      manual.enumInput = '' // don't inline; stored as a subtree reference at build
-      subtreeNote.value =
-        `${memberTerms.length} values from “${root.label}” (${scope}) — over the ${SUBTREE_INLINE_CAP} inline cap, ` +
-        `so this is stored as a subtree reference (root + version + granularity) enforced by a membership check, not an inline list. ` +
-        `Narrow the root or lower the depth to inline it.`
-    } else {
-      manual.enumInput = memberTerms.map((m) => m.curie).join(', ') // codes; labels attached at build
-      subtreeNote.value = `${memberTerms.length} values from “${root.label}” (${scope}) — inlined as an enum with display labels.`
-    }
+    // Readable preview (labels, not codes). enumInput stays empty — the schema is
+    // built from valueDomain, so we never dump raw curies into the visible box.
+    subtreePreview.value = memberTerms.slice(0, PREVIEW_CAP).map((m) => ({ curie: m.curie, label: m.label }))
+    manual.enumInput = ''
+    subtreeNote.value = overCap
+      ? `Over the ${SUBTREE_INLINE_CAP}-value inline cap — stored as a subtree reference (root + version + granularity) ` +
+        `and enforced by a membership check rather than an inline list. Narrow the root or lower the depth to inline it.`
+      : ''
   } catch (e) {
     valueDomain.value = null
+    subtreePreview.value = []
     subtreeNote.value = 'Could not load subtree: ' + (e?.message || e)
   }
 }
@@ -1085,6 +1102,90 @@ function manualValueSchema() {
   :deep(.el-form-item) {
     flex: 1;
   }
+}
+
+/* Ontology term search results */
+.onto-results {
+  list-style: none;
+  width: 100%;
+  margin: 8px 0 0;
+  padding: 0;
+  border: 1px solid theme.$gray_2;
+  border-radius: 4px;
+  max-height: 200px;
+  overflow: auto;
+  li {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 8px 12px;
+    cursor: pointer;
+    &:hover {
+      background: theme.$gray_1;
+    }
+  }
+}
+.onto-results-meta {
+  flex-shrink: 0;
+  font-size: 12px;
+  color: theme.$gray_4;
+}
+
+/* Selected-subtree preview */
+.onto-subtree {
+  width: 100%;
+  border: 1px solid theme.$gray_2;
+  border-radius: 4px;
+  padding: 12px;
+}
+.onto-subtree-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 13px;
+  color: theme.$gray_6;
+}
+.onto-subtree-code {
+  font-size: 11px;
+  color: theme.$gray_4;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.onto-subtree-controls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 8px;
+}
+.onto-subtree-count {
+  margin-top: 8px;
+  font-size: 12px;
+  color: theme.$gray_5;
+}
+.onto-subtree-list {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 6px 0 0;
+  border-top: 1px solid theme.$gray_1;
+  max-height: 180px;
+  overflow: auto;
+  li {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 3px 0;
+  }
+}
+.onto-subtree-item-label {
+  color: theme.$gray_6;
+  font-size: 13px;
+}
+.onto-subtree-more {
+  margin-top: 6px;
+  font-size: 12px;
+  color: theme.$gray_4;
 }
 .wiz-manual-flags {
   display: flex;

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -297,14 +297,20 @@
             <!-- Type a list, or fill from an ontology term's subtree. -->
             <template v-if="!subtreeRoot">
               <el-input v-model="manual.enumInput" placeholder="Comma-separated, e.g. Low, Medium, High" />
-              <div style="margin-top: 8px; width: 100%">
+              <div style="margin-top: 8px; width: 100%; display: flex; gap: 8px">
+                <el-select v-model="ontoScope" style="width: 150px" @change="runOntoSearch">
+                  <el-option v-for="o in ontoOptions" :key="o.ontology" :label="o.ontology" :value="o.ontology" />
+                </el-select>
                 <el-input
                   v-model="ontoTerm"
-                  placeholder="…or fill from an ontology term's subtree — e.g. diabetes, seizure"
+                  style="flex: 1"
+                  :placeholder="`…or fill from a ${ontoScope || 'an ontology'} term's subtree — e.g. diabetes`"
                   @input="runOntoSearch"
                 >
                   <template #prefix><el-icon><Search /></el-icon></template>
                 </el-input>
+              </div>
+              <div style="width: 100%">
                 <ul v-if="ontoResults.length" class="onto-results">
                   <li v-for="c in ontoResults" :key="c.curie" @click="selectSubtreeRoot(c)">
                     <span>{{ c.label }}</span>
@@ -392,7 +398,7 @@
 // Single-screen property builder (progressive disclosure — no inner steps).
 // Rendered inline in the create-model Properties step, and inside a dialog by
 // AddPropertyWizard. Emits `save` with an array of property defs.
-import { ref, reactive, computed } from 'vue'
+import { ref, reactive, computed, onMounted } from 'vue'
 import { ElMessage } from 'element-plus'
 import { Link, EditPen, Search, Close } from '@element-plus/icons-vue'
 import debounce from 'lodash.debounce'
@@ -436,11 +442,30 @@ const hasControlledValues = computed(
   () => !!valueDomain.value || !!(manual.enumInput && manual.enumInput.trim())
 )
 
+// Scope the term search to one ontology: searching every ontology at once scans
+// ~600k+ terms (NCiT + ChEBI + …) and is slow; a single ontology loads only that
+// slice and scans only its columns.
+const ontoScope = ref('')
+const ontoOptions = computed(() => (ontology.available || []).filter((o) => o.ontology !== 'UCUM'))
+
+onMounted(async () => {
+  try {
+    await ontology.ensureRegistry()
+    if (!ontoScope.value && ontoOptions.value.length) {
+      const pref = ontoOptions.value.find((o) => o.ontology === 'MONDO') || ontoOptions.value[0]
+      ontoScope.value = pref.ontology
+    }
+  } catch {
+    /* registry unavailable — search falls back to all loaded ontologies */
+  }
+})
+
 const runOntoSearch = debounce(async () => {
   const q = ontoTerm.value.trim()
   if (!q) { ontoResults.value = []; return }
   try {
-    ontoResults.value = (await ontology.search(q, { limit: 6 })).filter((r) => r.ontology !== 'UCUM')
+    const ontologies = ontoScope.value ? [ontoScope.value] : null
+    ontoResults.value = (await ontology.search(q, { limit: 8, ontologies })).filter((r) => r.ontology !== 'UCUM')
   } catch (e) {
     ontoResults.value = []
   }

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -324,25 +324,28 @@
                 style="margin-top: 8px; display: flex; gap: 12px; align-items: center; flex-wrap: wrap"
               >
                 <span style="font-size: 12px">From <strong>{{ subtreeRoot.label }}</strong>:</span>
-                <el-select v-model="subtreeDepth" size="small" style="width: 160px" @change="applySubtree">
+                <el-select v-model="subtreeDepth" style="width: 160px" @change="applySubtree">
                   <el-option label="All descendants" value="all" />
                   <el-option label="Direct children" value="1" />
                   <el-option label="2 levels" value="2" />
                   <el-option label="3 levels" value="3" />
                 </el-select>
-                <el-checkbox v-model="subtreeLeaves" size="small" @change="applySubtree">Most specific only</el-checkbox>
-                <el-button text size="small" @click="clearSubtree">clear</el-button>
+                <el-checkbox v-model="subtreeLeaves" @change="applySubtree">Most specific only</el-checkbox>
+                <el-button text @click="clearSubtree">clear</el-button>
               </div>
               <div v-if="subtreeNote" class="wiz-hint" style="margin-top: 6px">{{ subtreeNote }}</div>
             </div>
           </el-form-item>
-          <template v-if="manual.type === 'string'">
+          <template v-if="manual.type === 'string' && !hasControlledValues">
             <div class="wiz-two">
               <el-form-item label="Min length"><el-input v-model="manual.minLength" /></el-form-item>
               <el-form-item label="Max length"><el-input v-model="manual.maxLength" /></el-form-item>
             </div>
             <el-form-item label="Pattern (regex)"><el-input v-model="manual.pattern" /></el-form-item>
           </template>
+          <p v-else-if="manual.type === 'string'" class="wiz-hint" style="margin-top: 0">
+            Values come from the allowed list above, so length and pattern don't apply.
+          </p>
           <div v-if="manual.type === 'number' || manual.type === 'integer'" class="wiz-two">
             <el-form-item label="Minimum"><el-input v-model="manual.minimum" /></el-form-item>
             <el-form-item label="Maximum"><el-input v-model="manual.maximum" /></el-form-item>
@@ -407,6 +410,13 @@ const subtreeDepth = ref('all') // 'all' | '1' | '2' | '3'
 const subtreeLeaves = ref(false)
 const valueDomain = ref(null) // the materialized ontology-subtree value domain (or null)
 const SUBTREE_INLINE_CAP = 512
+
+// A property's values are a controlled set when an ontology subtree is chosen or
+// an allowed-values list is typed in. Then length/pattern don't apply — the value
+// is validated by membership, and a stray constraint would reject valid codes.
+const hasControlledValues = computed(
+  () => !!valueDomain.value || !!(manual.enumInput && manual.enumInput.trim())
+)
 
 const runOntoSearch = debounce(async () => {
   const q = ontoTerm.value.trim()
@@ -844,9 +854,14 @@ function manualValueSchema() {
   const withConstraints = (obj) => {
     if (t === 'string') {
       if (manual.format && manual.format !== 'plain') obj.format = manual.format
-      if (isNum(manual.minLength)) obj.minLength = parseInt(manual.minLength, 10)
-      if (isNum(manual.maxLength)) obj.maxLength = parseInt(manual.maxLength, 10)
-      if (manual.pattern) obj.pattern = manual.pattern
+      // Skip length/pattern when the value is drawn from a controlled set — they'd
+      // be redundant and could reject valid codes (and may be stale from before the
+      // value set was chosen).
+      if (!hasControlledValues.value) {
+        if (isNum(manual.minLength)) obj.minLength = parseInt(manual.minLength, 10)
+        if (isNum(manual.maxLength)) obj.maxLength = parseInt(manual.maxLength, 10)
+        if (manual.pattern) obj.pattern = manual.pattern
+      }
     }
     if (t === 'number' || t === 'integer') {
       if (isNum(manual.minimum)) obj.minimum = parseFloat(manual.minimum)

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -278,7 +278,7 @@
               <el-option v-for="t in manualTypes" :key="t.value" :label="t.label" :value="t.value" />
             </el-select>
           </el-form-item>
-          <el-form-item v-if="manual.type === 'string'" label="Format">
+          <el-form-item v-if="manual.type === 'string' && !subtreeRoot" label="Format">
             <el-select v-model="manual.format">
               <el-option v-for="f in stringFormats" :key="f.value" :label="f.label" :value="f.value" />
             </el-select>
@@ -564,6 +564,9 @@ const applyValueDomain = (schema, vd) => {
     ontology: vd.ontology,
     ontology_version: vd.ontology_version,
   }
+  // The values are ontology codes, not a formatted string — a date/email/uri
+  // format would contradict the value set.
+  delete schema.format
   if (vd.over_cap) {
     delete schema.enum
     const ref = {

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -299,7 +299,6 @@
             <div style="margin-top: 8px; width: 100%">
               <el-input
                 v-model="ontoTerm"
-                size="small"
                 placeholder="…or fill from an ontology term's subtree — e.g. diabetes, seizure"
                 @input="runOntoSearch"
               >

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -340,8 +340,11 @@
                 <el-checkbox v-model="subtreeLeaves" @change="applySubtree">Most specific only</el-checkbox>
               </div>
               <div v-if="valueDomain" class="onto-subtree-count">
-                {{ valueDomain.count.toLocaleString() }}
-                value{{ valueDomain.count === 1 ? '' : 's' }} · {{ subtreeScopeLabel }}
+                <template v-if="valueDomain.over_cap">More than {{ SUBTREE_INLINE_CAP }} values</template>
+                <template v-else
+                  >{{ valueDomain.count.toLocaleString() }} value{{ valueDomain.count === 1 ? '' : 's' }}</template
+                >
+                · {{ subtreeScopeLabel }}
               </div>
               <ul v-if="subtreePreview.length" class="onto-subtree-list">
                 <li v-for="m in subtreePreview" :key="m.curie">
@@ -349,7 +352,13 @@
                   <span class="onto-subtree-code">{{ m.curie }}</span>
                 </li>
               </ul>
-              <div v-if="valueDomain && valueDomain.count > subtreePreview.length" class="onto-subtree-more">
+              <div v-if="valueDomain && valueDomain.over_cap" class="onto-subtree-more">
+                Showing a sample — the full set is enforced by reference, not listed.
+              </div>
+              <div
+                v-else-if="valueDomain && valueDomain.count > subtreePreview.length"
+                class="onto-subtree-more"
+              >
                 …and {{ (valueDomain.count - subtreePreview.length).toLocaleString() }} more
               </div>
               <div v-if="subtreeNote" class="wiz-hint" style="margin-top: 6px">{{ subtreeNote }}</div>
@@ -510,10 +519,14 @@ const applySubtree = async () => {
   subtreeNote.value = 'Loading…'
   try {
     const maxDepth = subtreeDepth.value === 'all' ? null : Number(subtreeDepth.value)
-    const descs = await ontology.descendants(root.curie, { maxDepth, leavesOnly: subtreeLeaves.value, limit: 10000 })
-    const memberTerms = subtreeLeaves.value ? descs : [{ curie: root.curie, label: root.label }, ...descs]
+    // Bounded resolution: stops once it passes the inline cap, so a broad root
+    // doesn't enumerate the whole ontology (over-cap becomes a reference anyway).
+    const { members, overCap } = await ontology.subtreeMembers(root.curie, root.label, {
+      maxDepth,
+      leavesOnly: subtreeLeaves.value,
+      cap: SUBTREE_INLINE_CAP,
+    })
 
-    const overCap = memberTerms.length > SUBTREE_INLINE_CAP
     valueDomain.value = {
       kind: 'subtree',
       ontology: root.ontology,
@@ -522,16 +535,16 @@ const applySubtree = async () => {
       ontology_version: root.ontology_version,
       max_depth: maxDepth,
       leaves_only: subtreeLeaves.value,
-      count: memberTerms.length,
+      count: overCap ? null : members.length, // exact only when inlined; unknown over-cap
       over_cap: overCap,
-      members: overCap ? null : memberTerms.map((m) => ({ code: m.curie, label: m.label })),
+      members: overCap ? null : members.map((m) => ({ code: m.curie, label: m.label })),
     }
     // Readable preview (labels, not codes). enumInput stays empty — the schema is
     // built from valueDomain, so we never dump raw curies into the visible box.
-    subtreePreview.value = memberTerms.slice(0, PREVIEW_CAP).map((m) => ({ curie: m.curie, label: m.label }))
+    subtreePreview.value = members.slice(0, PREVIEW_CAP).map((m) => ({ curie: m.curie, label: m.label }))
     manual.enumInput = ''
     subtreeNote.value = overCap
-      ? `Over the ${SUBTREE_INLINE_CAP}-value inline cap — stored as a subtree reference (root + version + granularity) ` +
+      ? `More than ${SUBTREE_INLINE_CAP} values — stored as a subtree reference (root + version + granularity) ` +
         `and enforced by a membership check rather than an inline list. Narrow the root or lower the depth to inline it.`
       : ''
   } catch (e) {
@@ -558,8 +571,8 @@ const applyValueDomain = (schema, vd) => {
       ontology: vd.ontology,
       root: vd.root_curie,
       ontology_version: vd.ontology_version,
-      count: vd.count,
     }
+    if (vd.count != null) ref.count = vd.count // unknown for a broad (bounded) subtree
     if (vd.max_depth != null) ref.max_depth = vd.max_depth
     if (vd.leaves_only) ref.leaves_only = true
     schema['x-pennsieve-concept-valueset'] = ref

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -309,6 +309,7 @@
                 >
                   <template #prefix><el-icon><Search /></el-icon></template>
                 </el-input>
+                <el-button @click="pickerOpen = true">Browse…</el-button>
               </div>
               <div style="width: 100%">
                 <ul v-if="ontoResults.length" class="onto-results">
@@ -350,6 +351,7 @@
               </div>
               <div v-if="subtreeNote" class="wiz-hint" style="margin-top: 6px">{{ subtreeNote }}</div>
             </div>
+            <OntologyTreePicker v-model="pickerOpen" @select="selectSubtreeRoot" />
           </el-form-item>
           <template v-if="manual.type === 'string' && !hasControlledValues">
             <div class="wiz-two">
@@ -405,6 +407,7 @@ import debounce from 'lodash.debounce'
 import { useCdeCatalogStore } from '@/stores/cdeCatalogStore'
 import { useOntologyStore } from '@/stores/ontologyStore'
 import CdeFacets from './CdeFacets.vue'
+import OntologyTreePicker from './OntologyTreePicker.vue'
 
 const props = defineProps({
   existingProperties: { type: Array, default: () => [] },
@@ -447,6 +450,7 @@ const hasControlledValues = computed(
 // slice and scans only its columns.
 const ontoScope = ref('')
 const ontoOptions = computed(() => (ontology.available || []).filter((o) => o.ontology !== 'UCUM'))
+const pickerOpen = ref(false) // the browse-the-tree dialog
 
 onMounted(async () => {
   try {

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -499,14 +499,6 @@ const clearSubtree = () => {
   ontoResults.value = []
 }
 
-// An ontology subtree is string codes — drop it if the type leaves Text.
-watch(
-  () => manual.type,
-  (t) => {
-    if (t !== 'string') clearSubtree()
-  }
-)
-
 // Resolve the value set from the chosen root + granularity (depth / leaves-only)
 // and hold it as a materialized value_domain. Under the inline cap it carries the
 // {code,label} members (materialized to an enum + labels at build); over the cap
@@ -614,6 +606,16 @@ const manual = reactive({
   maxItems: '',
   uniqueItems: false,
 })
+
+// An ontology subtree is string codes — drop it if the type leaves Text.
+// (Defined after `manual` so its getter doesn't hit the TDZ at setup.)
+watch(
+  () => manual.type,
+  (t) => {
+    if (t !== 'string') clearSubtree()
+  }
+)
+
 const options = reactive({ required: false, isKey: false, isSensitive: false })
 
 const optionFlags = [

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -297,28 +297,31 @@
             <!-- Type a list, or fill from an ontology term's subtree. -->
             <template v-if="!subtreeRoot">
               <el-input v-model="manual.enumInput" placeholder="Comma-separated, e.g. Low, Medium, High" />
-              <div style="margin-top: 8px; width: 100%; display: flex; gap: 8px">
-                <el-select v-model="ontoScope" style="width: 150px" @change="runOntoSearch">
-                  <el-option v-for="o in ontoOptions" :key="o.ontology" :label="o.ontology" :value="o.ontology" />
-                </el-select>
-                <el-input
-                  v-model="ontoTerm"
-                  style="flex: 1"
-                  :placeholder="`…or fill from a ${ontoScope || 'an ontology'} term's subtree — e.g. diabetes`"
-                  @input="runOntoSearch"
-                >
-                  <template #prefix><el-icon><Search /></el-icon></template>
-                </el-input>
-                <el-button @click="pickerOpen = true">Browse…</el-button>
-              </div>
-              <div style="width: 100%">
-                <ul v-if="ontoResults.length" class="onto-results">
-                  <li v-for="c in ontoResults" :key="c.curie" @click="selectSubtreeRoot(c)">
-                    <span>{{ c.label }}</span>
-                    <span class="onto-results-meta">{{ ontoMeta(c) }}</span>
-                  </li>
-                </ul>
-              </div>
+              <!-- Ontology value sets are string codes, so only for Text. -->
+              <template v-if="manual.type === 'string'">
+                <div style="margin-top: 8px; width: 100%; display: flex; gap: 8px">
+                  <el-select v-model="ontoScope" style="width: 150px" @change="runOntoSearch">
+                    <el-option v-for="o in ontoOptions" :key="o.ontology" :label="o.ontology" :value="o.ontology" />
+                  </el-select>
+                  <el-input
+                    v-model="ontoTerm"
+                    style="flex: 1"
+                    :placeholder="`…or fill from a ${ontoScope || 'an ontology'} term's subtree — e.g. diabetes`"
+                    @input="runOntoSearch"
+                  >
+                    <template #prefix><el-icon><Search /></el-icon></template>
+                  </el-input>
+                  <el-button @click="pickerOpen = true">Browse…</el-button>
+                </div>
+                <div style="width: 100%">
+                  <ul v-if="ontoResults.length" class="onto-results">
+                    <li v-for="c in ontoResults" :key="c.curie" @click="selectSubtreeRoot(c)">
+                      <span>{{ c.label }}</span>
+                      <span class="onto-results-meta">{{ ontoMeta(c) }}</span>
+                    </li>
+                  </ul>
+                </div>
+              </template>
             </template>
 
             <!-- A term is chosen: granularity + a readable preview of the members. -->
@@ -400,7 +403,7 @@
 // Single-screen property builder (progressive disclosure — no inner steps).
 // Rendered inline in the create-model Properties step, and inside a dialog by
 // AddPropertyWizard. Emits `save` with an array of property defs.
-import { ref, reactive, computed, onMounted } from 'vue'
+import { ref, reactive, computed, onMounted, watch } from 'vue'
 import { ElMessage } from 'element-plus'
 import { Link, EditPen, Search, Close } from '@element-plus/icons-vue'
 import debounce from 'lodash.debounce'
@@ -495,6 +498,14 @@ const clearSubtree = () => {
   ontoTerm.value = ''
   ontoResults.value = []
 }
+
+// An ontology subtree is string codes — drop it if the type leaves Text.
+watch(
+  () => manual.type,
+  (t) => {
+    if (t !== 'string') clearSubtree()
+  }
+)
 
 // Resolve the value set from the chosen root + granularity (depth / leaves-only)
 // and hold it as a materialized value_domain. Under the inline cap it carries the

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -317,8 +317,7 @@
             <!-- A term is chosen: granularity + a readable preview of the members. -->
             <div v-else class="onto-subtree">
               <div class="onto-subtree-head">
-                <span>From <strong>{{ subtreeRoot.label }}</strong>
-                  <span class="onto-subtree-code">{{ subtreeRoot.curie }}</span></span>
+                <span>From <strong>{{ subtreeRoot.label }}</strong> <span class="onto-subtree-code">{{ subtreeRoot.curie }}</span></span>
                 <el-button text @click="clearSubtree">change</el-button>
               </div>
               <div class="onto-subtree-controls">

--- a/src/components/datasets/metadata/records/ListRecords.vue
+++ b/src/components/datasets/metadata/records/ListRecords.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed, onMounted, watch, nextTick } from 'vue'
-import { ElTable, ElTableColumn, ElCard, ElButton, ElSelect, ElOption, ElMessage, ElDropdown, ElDropdownMenu, ElDropdownItem, ElIcon, ElTag, ElDivider } from 'element-plus'
-import { ArrowDown, View } from '@element-plus/icons-vue'
+import { ElTable, ElTableColumn, ElCard, ElButton, ElSelect, ElOption, ElMessage, ElDropdown, ElDropdownMenu, ElDropdownItem, ElIcon, ElTag, ElDivider, ElTooltip } from 'element-plus'
+import { ArrowDown, View, InfoFilled } from '@element-plus/icons-vue'
 import { useRouter } from 'vue-router'
 import { useMetadataStore } from '@/stores/metadataStore.js'
 import { useOntologyStore } from '@/stores/ontologyStore.js'
@@ -85,9 +85,29 @@ const tableColumns = computed(() => {
     // the human label (e.g. "epilepsy") instead of the stored code ("MONDO:0005027").
     valueLabels: buildValueLabels(property),
     // Over-cap value sets ship no inline labels — resolve them from this ontology.
-    subtreeOntology: property['x-pennsieve-concept-valueset']?.ontology || null
+    subtreeOntology: property['x-pennsieve-concept-valueset']?.ontology || null,
+    // Tooltip text when this column holds coded values (null when it doesn't).
+    codedTip: codedColumnTip(property)
   }))
 })
+
+// Describe a column's coded-value source for a header tooltip, or null if it isn't
+// backed by an ontology / CDE value set.
+const codedColumnTip = (property) => {
+  const cde =
+    property['x-pennsieve-cde-values'] || property['x-pennsieve-cde-valueset'] || property['x-pennsieve-cde']
+  const system =
+    property['x-pennsieve-concept-valueset']?.ontology ||
+    property['x-pennsieve-concept']?.ontology ||
+    null
+  const isConcept =
+    property['x-pennsieve-concept-values'] ||
+    property['x-pennsieve-concept-valueset'] ||
+    property['x-pennsieve-concept']
+  if (!isConcept && !cde) return null
+  const source = system ? `the ${system} ontology` : cde ? 'a linked CDE value set' : 'a controlled value set'
+  return `Coded values — each entry is a term from ${source}, stored as a code (e.g. MONDO:0015005) and shown here by its label.`
+}
 
 // Build a { code: label } lookup from a property's materialized value annotation.
 // Returns null when the property has no controlled value labels.
@@ -961,6 +981,14 @@ onMounted(async () => {
             :min-width="120"
             show-overflow-tooltip
           >
+            <template #header>
+              <span class="column-header">
+                {{ column.label }}
+                <el-tooltip v-if="column.codedTip" :content="column.codedTip" placement="top" :show-after="200">
+                  <el-icon class="coded-indicator"><InfoFilled /></el-icon>
+                </el-tooltip>
+              </span>
+            </template>
             <template #default="{ row }">
               {{ formatCellValue(row.value[column.key], column) }}
             </template>
@@ -1335,7 +1363,19 @@ onMounted(async () => {
       border: none;
       //box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
       //border-radius: 8px;
-      
+
+      .column-header {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+
+        .coded-indicator {
+          font-size: 13px;
+          color: theme.$gray_4;
+          cursor: help;
+        }
+      }
+
       :deep(.el-card__body) {
         padding: 0;
       }

--- a/src/components/datasets/metadata/records/ListRecords.vue
+++ b/src/components/datasets/metadata/records/ListRecords.vue
@@ -4,6 +4,7 @@ import { ElTable, ElTableColumn, ElCard, ElButton, ElSelect, ElOption, ElMessage
 import { ArrowDown, View } from '@element-plus/icons-vue'
 import { useRouter } from 'vue-router'
 import { useMetadataStore } from '@/stores/metadataStore.js'
+import { useOntologyStore } from '@/stores/ontologyStore.js'
 import MultiModelFilter from '../../explore/GraphExplorer/MultiModelFilter.vue'
 import IconPlus from '@/components/icons/IconPlus.vue'
 import StageActions from "@/components/shared/StageActions/StageActions.vue";
@@ -27,7 +28,12 @@ const props = defineProps({
 
 // Store and router
 const metadataStore = useMetadataStore()
+const ontologyStore = useOntologyStore()
 const router = useRouter()
+
+// Code→label lookup for over-cap ontology value sets (tier:"subtree"), which carry
+// no inline labels in the schema — resolved lazily from the ontology slices.
+const subtreeLabels = ref({})
 
 // Reactive data
 const records = ref([])
@@ -74,9 +80,27 @@ const tableColumns = computed(() => {
     key,
     label: property.title || key,
     type: property.type,
-    format: property.format
+    format: property.format,
+    // Code→label map for controlled value sets (ontology / CDE), so cells render
+    // the human label (e.g. "epilepsy") instead of the stored code ("MONDO:0005027").
+    valueLabels: buildValueLabels(property),
+    // Over-cap value sets ship no inline labels — resolve them from this ontology.
+    subtreeOntology: property['x-pennsieve-concept-valueset']?.ontology || null
   }))
 })
+
+// Build a { code: label } lookup from a property's materialized value annotation.
+// Returns null when the property has no controlled value labels.
+const buildValueLabels = (property) => {
+  const vals = property['x-pennsieve-concept-values'] || property['x-pennsieve-cde-values']
+  if (!Array.isArray(vals) || !vals.length) return null
+  const map = {}
+  for (const v of vals) {
+    const code = v?.code ?? v?.value
+    if (code != null) map[code] = v.label || String(code)
+  }
+  return Object.keys(map).length ? map : null
+}
 
 const hasRecords = computed(() => records.value.length > 0)
 
@@ -551,11 +575,55 @@ const selectModel = (command) => {
   })
 }
 
+// Resolve labels for over-cap (subtree) value-set codes on the current page. Inline
+// value sets already carry their labels in the schema; this only covers columns whose
+// codes aren't in the schema. Fail-open: on any error the codes stay shown as-is.
+const resolveSubtreeLabels = async () => {
+  const cols = tableColumns.value.filter(c => c.subtreeOntology)
+  if (!cols.length || !records.value.length) return
+
+  const needed = new Set()
+  for (const c of cols) {
+    for (const rec of records.value) {
+      const v = rec.value?.[c.key]
+      if (v == null) continue
+      for (const code of Array.isArray(v) ? v : [v]) {
+        if (typeof code === 'string' && !subtreeLabels.value[code]) needed.add(code)
+      }
+    }
+  }
+  if (!needed.size) return
+
+  try {
+    const onts = [...new Set(cols.map(c => c.subtreeOntology))]
+    await Promise.all(onts.map(o => ontologyStore.ensureOntology(o)))
+    const map = await ontologyStore.labelsFor([...needed])
+    const next = { ...subtreeLabels.value }
+    for (const [code, label] of map) if (label) next[code] = label
+    subtreeLabels.value = next
+  } catch {
+    /* leave codes as-is */
+  }
+}
+
+watch([records, modelSchema], () => { resolveSubtreeLabels() })
+
 const formatCellValue = (value, column) => {
   if (value === null || value === undefined) {
     return ''
   }
-  
+
+  // Controlled value set (ontology / CDE): show the label, fall back to the code
+  // when a value isn't resolved yet (subtree labels load async) or isn't in the
+  // set (e.g. a code from a since-narrowed value set).
+  if (column.valueLabels || column.subtreeOntology) {
+    const toLabel = v => (column.valueLabels && column.valueLabels[v]) || subtreeLabels.value[v] || v
+    if (Array.isArray(value)) {
+      return value.map(toLabel).join(', ')
+    }
+    return toLabel(value)
+  }
+
   // Format based on column type
   if (column.type === 'number' || column.type === 'integer') {
     return Number(value).toLocaleString()

--- a/src/components/datasets/metadata/records/RecordSpecGenerator.vue
+++ b/src/components/datasets/metadata/records/RecordSpecGenerator.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted, watch, h } from 'vue'
 import { ElCard, ElForm, ElFormItem, ElInput, ElInputNumber, ElSelect, ElOption, ElDatePicker, ElMessage, ElButton } from 'element-plus'
 import { useRouter, useRoute } from 'vue-router'
 import { useMetadataStore } from '@/stores/metadataStore.js'
+import { useOntologyStore } from '@/stores/ontologyStore.js'
 import Ajv from 'ajv'
 import addFormats from 'ajv-formats'
 
@@ -30,8 +31,16 @@ const props = defineProps({
 })
 
 const metadataStore = useMetadataStore()
+const ontologyStore = useOntologyStore()
 const router = useRouter()
 const route = useRoute()
+
+// Over-cap ontology value sets (tier:"subtree") have no inline enum — the field is a
+// remote search over the value set's ontology, restricted to the subtree. These hold
+// the per-field search results, loading flags, and resolved labels for current values.
+const subtreeOptions = ref({})     // key -> [{ code, label }]
+const subtreeSearching = ref({})   // key -> bool
+const subtreeValueLabels = ref({}) // code -> label (to display already-stored values)
 
 // Reactive data
 const model = ref(null)
@@ -471,6 +480,22 @@ const updateRecord = async () => {
 // Surface it so the field reads as controlled-by-a-CDE rather than free-form.
 const cdeValueSet = (property) => property?.property?.['x-pennsieve-cde-valueset'] || null
 
+// An over-cap ontology value set carries `x-pennsieve-concept-valueset` (tier:"subtree",
+// with `ontology` + `root`) instead of an enum. It's browsable/searchable, so the field
+// becomes a subtree-restricted remote search rather than a plain text box.
+const conceptValueSet = (property) => {
+  const vs = property?.property?.['x-pennsieve-concept-valueset']
+  return vs && vs.ontology && vs.root ? vs : null
+}
+
+const conceptValueSetHint = (property) => {
+  const vs = conceptValueSet(property)
+  if (!vs) return ''
+  const anchor = property?.property?.['x-pennsieve-concept']
+  const rootLabel = anchor?.label || vs.root
+  return `Search ${vs.ontology} for a term under “${rootLabel}”.`
+}
+
 // code -> display label for an enum, from a materialized value-list annotation
 // (ontology `x-pennsieve-concept-values` or CDE `x-pennsieve-cde-values`). Empty
 // map when none — the enum then shows the raw codes.
@@ -498,10 +523,63 @@ const cdeValueSetHint = (property) => {
   return `Bound to a CDE value set (${count ? count + ' ' : ''}allowed values${system}) too large to list here — refer to the CDE for the allowed codes.`
 }
 
+// Remote search within a subtree value set, storing the code + showing the label.
+const runSubtreeSearch = async (key, vs, query) => {
+  const term = String(query || '').trim()
+  if (!term) {
+    subtreeOptions.value = { ...subtreeOptions.value, [key]: [] }
+    return
+  }
+  subtreeSearching.value = { ...subtreeSearching.value, [key]: true }
+  try {
+    const hits = await ontologyStore.searchSubtree(vs.root, term, { ontology: vs.ontology, limit: 25 })
+    subtreeOptions.value = {
+      ...subtreeOptions.value,
+      [key]: hits.map((h) => ({ code: h.curie, label: h.label || h.curie }))
+    }
+  } catch {
+    subtreeOptions.value = { ...subtreeOptions.value, [key]: [] }
+  } finally {
+    subtreeSearching.value = { ...subtreeSearching.value, [key]: false }
+  }
+}
+
+const renderSubtreeSelect = (property, vs) => {
+  const { key } = property
+  const current = formData.value[key]
+  const opts = subtreeOptions.value[key] || []
+  // Always keep the current value selectable so its label shows even before searching.
+  const merged = [...opts]
+  if (current != null && current !== '' && !merged.some((o) => o.code === current)) {
+    merged.unshift({ code: current, label: subtreeValueLabels.value[current] || current })
+  }
+  return h(ElSelect, {
+    modelValue: current,
+    'onUpdate:modelValue': (value) => {
+      formData.value[key] = value
+      if (nullKeyFields.value[key]) nullKeyFields.value[key] = false
+    },
+    placeholder: `Search ${vs.ontology}…`,
+    clearable: true,
+    filterable: true,
+    remote: true,
+    remoteMethod: (q) => runSubtreeSearch(key, vs, q),
+    loading: !!subtreeSearching.value[key],
+    reserveKeyword: false,
+    size: 'default'
+  }, () => merged.map((o) => h(ElOption, { key: o.code, label: o.label, value: o.code })))
+}
+
 // Helper function for rendering just the form input
 const renderFormFieldInput = (property) => {
   const { key, type, format, enum: enumValues } = property
-  
+
+  // Over-cap ontology value set → subtree-restricted remote search (no inline enum).
+  const conceptVs = conceptValueSet(property)
+  if (conceptVs) {
+    return renderSubtreeSelect(property, conceptVs)
+  }
+
   if (enumValues && enumValues.length > 0) {
     // Enum stores codes; show human labels when a values annotation carries them
     // (CDE-materialized or ontology value domains), so the dropdown reads
@@ -1020,11 +1098,40 @@ const getSuggestion = (error) => {
   }
 }
 
+// Resolve labels for subtree value-set codes already stored on the record, so an
+// edited field shows "epilepsy" rather than the raw "MONDO:0015005" on load.
+const resolveSubtreeValueLabels = async () => {
+  const cols = schemaProperties.value.filter((p) => conceptValueSet(p))
+  if (!cols.length) return
+  const needed = new Set()
+  const onts = new Set()
+  for (const p of cols) {
+    const vs = conceptValueSet(p)
+    const v = formData.value[p.key]
+    if (v == null || v === '') continue
+    for (const code of Array.isArray(v) ? v : [v]) {
+      if (typeof code === 'string' && !subtreeValueLabels.value[code]) needed.add(code)
+    }
+    if (vs?.ontology) onts.add(vs.ontology)
+  }
+  if (!needed.size) return
+  try {
+    await Promise.all([...onts].map((o) => ontologyStore.ensureOntology(o)))
+    const map = await ontologyStore.labelsFor([...needed])
+    const next = { ...subtreeValueLabels.value }
+    for (const [code, label] of map) if (label) next[code] = label
+    subtreeValueLabels.value = next
+  } catch {
+    /* leave codes as-is */
+  }
+}
+
 // Initialize
 onMounted(async () => {
   await fetchModel()
   if (isUpdateMode.value) {
     await fetchExistingRecord()
+    await resolveSubtreeValueLabels()
   }
 })
 </script>
@@ -1166,7 +1273,7 @@ onMounted(async () => {
                     Key
                   </el-tag>
                   <el-tag
-                    v-if="cdeValueSet(property)"
+                    v-if="cdeValueSet(property) || conceptValueSet(property)"
                     size="small"
                     effect="plain"
                     class="tag-valueset"
@@ -1198,6 +1305,11 @@ onMounted(async () => {
                 <!-- CDE value-set reference (too large to inline / unpublished) -->
                 <div v-if="cdeValueSet(property)" class="cde-valueset-hint">
                   {{ cdeValueSetHint(property) }}
+                </div>
+
+                <!-- Ontology subtree value set — searchable, restricted to the branch -->
+                <div v-if="conceptValueSet(property)" class="cde-valueset-hint">
+                  {{ conceptValueSetHint(property) }}
                 </div>
 
                 <!-- Validation Error Display -->

--- a/src/components/datasets/metadata/records/RecordSpecViewer.vue
+++ b/src/components/datasets/metadata/records/RecordSpecViewer.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { ElCard, ElTag, ElMessage, ElButton, ElPagination, ElMessageBox } from 'element-plus'
 import { useRouter, useRoute } from 'vue-router'
 import { useMetadataStore } from '@/stores/metadataStore.js'
+import { useOntologyStore } from '@/stores/ontologyStore.js'
 import { useRecordData } from '@/composables/useRecordData.js'
 
 // Import components
@@ -40,8 +41,13 @@ const props = defineProps({
 })
 
 const metadataStore = useMetadataStore()
+const ontologyStore = useOntologyStore()
 const router = useRouter()
 const route = useRoute()
+
+// Code→label lookup for over-cap (subtree) value sets, which carry no inline labels
+// in the schema — resolved lazily from the ontology slices for the loaded record.
+const subtreeLabels = ref({})
 
 // Reactive data
 const record = ref(null)
@@ -323,11 +329,36 @@ const goToUpdateRecord = () => {
 }
 
 
+// { code: label } lookup for a property's inline value set (ontology / CDE), or null.
+const inlineValueLabels = (property) => {
+  const vals = property['x-pennsieve-concept-values'] || property['x-pennsieve-cde-values']
+  if (!Array.isArray(vals) || !vals.length) return null
+  const map = {}
+  for (const v of vals) {
+    const code = v?.code ?? v?.value
+    if (code != null) map[code] = v.label || String(code)
+  }
+  return Object.keys(map).length ? map : null
+}
+
 const formatPropertyValue = (value, property) => {
   if (value === null || value === undefined) {
     return { display: 'N/A', isNull: true }
   }
-  
+
+  // Controlled value set (ontology / CDE): show the label, not the stored code.
+  // Inline sets carry labels in the schema; over-cap subtree sets resolve async
+  // via the ontology slices. Falls back to the code until/unless resolved.
+  const inline = inlineValueLabels(property)
+  const isSubtree = !!property['x-pennsieve-concept-valueset']
+  if (inline || isSubtree) {
+    const toLabel = (v) => (inline && inline[v]) || subtreeLabels.value[v] || v
+    if (Array.isArray(value)) {
+      return { display: value.map(toLabel).join(', '), isNull: false }
+    }
+    return { display: toLabel(value), isNull: false }
+  }
+
   // Handle different property types
   if (property.type === 'boolean') {
     return { display: value ? 'Yes' : 'No', isNull: false }
@@ -363,6 +394,41 @@ const formatPropertyValue = (value, property) => {
   
   return { display: String(value), isNull: false }
 }
+
+// Resolve labels for the record's subtree value-set codes (no inline labels in the
+// schema). Fail-open: codes stay shown as-is on any error.
+const resolveSubtreeLabels = async () => {
+  const schema = modelSchema.value
+  const data = recordData.value
+  if (!schema?.properties || !data) return
+  const props = Object.entries(schema.properties).filter(([, p]) => p['x-pennsieve-concept-valueset'])
+  if (!props.length) return
+
+  const needed = new Set()
+  const onts = new Set()
+  for (const [key, p] of props) {
+    const v = data[key]
+    if (v == null) continue
+    for (const code of Array.isArray(v) ? v : [v]) {
+      if (typeof code === 'string' && !subtreeLabels.value[code]) needed.add(code)
+    }
+    const o = p['x-pennsieve-concept-valueset']?.ontology
+    if (o) onts.add(o)
+  }
+  if (!needed.size) return
+
+  try {
+    await Promise.all([...onts].map((o) => ontologyStore.ensureOntology(o)))
+    const map = await ontologyStore.labelsFor([...needed])
+    const next = { ...subtreeLabels.value }
+    for (const [code, label] of map) if (label) next[code] = label
+    subtreeLabels.value = next
+  } catch {
+    /* leave codes as-is */
+  }
+}
+
+watch(recordData, () => { resolveSubtreeLabels() })
 
 const getPropertyTypeDisplay = (property) => {
   let type = property.type || 'string'

--- a/src/components/datasets/metadata/records/RecordSpecViewer.vue
+++ b/src/components/datasets/metadata/records/RecordSpecViewer.vue
@@ -428,7 +428,9 @@ const resolveSubtreeLabels = async () => {
   }
 }
 
-watch(recordData, () => { resolveSubtreeLabels() })
+// Watch both: the record and the schema load from separate (parallel) fetches, so
+// either can win the race — resolve once whichever lands last is in place.
+watch([recordData, modelSchema], () => { resolveSubtreeLabels() })
 
 const getPropertyTypeDisplay = (property) => {
   let type = property.type || 'string'
@@ -990,7 +992,10 @@ watch([() => props.modelId, () => props.recordId], async () => {
 // Initialize
 onMounted(async () => {
   await Promise.all([fetchModel(), fetchRecord(), fetchPackages(), fetchRelationships(), fetchRecordHistory()])
-  
+  // Both model + record are now loaded — resolve subtree labels regardless of which
+  // fetch won the race (the watcher may have fired too early to see both).
+  resolveSubtreeLabels()
+
   // If we have an as_of parameter, set up preview state to match
   if (props.as_of) {
     previewTimestamp.value = props.as_of

--- a/src/components/datasets/metadata/records/RecordSpecViewer.vue
+++ b/src/components/datasets/metadata/records/RecordSpecViewer.vue
@@ -115,7 +115,8 @@ const recordProperties = computed(() => {
     format: property.format,
     description: property.description,
     value: recordData.value[key],
-    property: property
+    property: property,
+    formatted: formatPropertyValue(recordData.value[key], property)
   }))
 })
 
@@ -353,10 +354,11 @@ const formatPropertyValue = (value, property) => {
   const isSubtree = !!property['x-pennsieve-concept-valueset']
   if (inline || isSubtree) {
     const toLabel = (v) => (inline && inline[v]) || subtreeLabels.value[v] || v
-    if (Array.isArray(value)) {
-      return { display: value.map(toLabel).join(', '), isNull: false }
-    }
-    return { display: toLabel(value), isNull: false }
+    const codeStr = Array.isArray(value) ? value.join(', ') : String(value)
+    const display = Array.isArray(value) ? value.map(toLabel).join(', ') : toLabel(value)
+    // Surface the underlying code alongside the label so it's clear the stored value
+    // is a coded term — but only once a label actually resolved (else it's redundant).
+    return { display, isNull: false, code: display !== codeStr ? codeStr : null }
   }
 
   // Handle different property types
@@ -1101,8 +1103,9 @@ onMounted(async () => {
               class="attribute-item"
             >
               <span class="attribute-name">{{ prop.label }}:</span>
-              <span class="attribute-value" :class="{ 'is-null': formatPropertyValue(prop.value, prop.property).isNull }">
-                {{ formatPropertyValue(prop.value, prop.property).display }}
+              <span class="attribute-value" :class="{ 'is-null': prop.formatted.isNull }">
+                {{ prop.formatted.display }}
+                <span v-if="prop.formatted.code" class="attribute-code" :title="`Stored value: ${prop.formatted.code}`">{{ prop.formatted.code }}</span>
               </span>
             </div>
           </div>
@@ -1725,10 +1728,21 @@ onMounted(async () => {
               color: theme.$gray_6;
               font-size: 14px;
               line-height: 1.4;
-              
+
               &.is-null {
                 color: theme.$gray_4;
                 font-style: italic;
+              }
+
+              .attribute-code {
+                margin-left: 8px;
+                padding: 1px 6px;
+                border-radius: 3px;
+                background: theme.$gray_1;
+                color: theme.$gray_4;
+                font-size: 11px;
+                font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                vertical-align: middle;
               }
             }
           }

--- a/src/composables/usePropertyFormatting.js
+++ b/src/composables/usePropertyFormatting.js
@@ -95,11 +95,21 @@ export function usePropertyFormatting() {
       constraints.push('unique')
     }
     
-    // Enum values
+    // Enum values — show display labels (not raw codes like MONDO:xxx) from the
+    // materialized value annotation, and cap the list at 10 with "+N more".
     if (property.enum) {
-      constraints.push(`values: [${property.enum.join(', ')}]`)
+      const vals = property['x-pennsieve-concept-values'] || property['x-pennsieve-cde-values'] || []
+      const labels = {}
+      for (const v of vals) {
+        const code = v?.code ?? v?.value
+        if (code != null) labels[code] = v.label || String(code)
+      }
+      const CAP = 10
+      const display = property.enum.map((v) => labels[v] || v)
+      const more = display.length - CAP
+      constraints.push(`values: [${display.slice(0, CAP).join(', ')}${more > 0 ? `, +${more} more` : ''}]`)
     }
-    
+
     return constraints
   }
 

--- a/src/stores/ontologyStore.js
+++ b/src/stores/ontologyStore.js
@@ -405,10 +405,56 @@ export const useOntologyStore = defineStore('ontology', () => {
         return mapRows(await duck.executeQuery(query, connectionId))
     }
 
+    // Bounded subtree membership for building a value set. BFS the is_a edges
+    // level-by-level from the root (one pruned query per level) and STOP as soon as
+    // the count passes `cap` — a broad root (e.g. a whole disease branch) resolves
+    // in a few queries instead of enumerating the entire ontology via the recursive
+    // descendants CTE (which ignores LIMIT and can take seconds). Over-cap sets are
+    // stored as a subtree reference anyway, so the full list isn't needed. Returns
+    // { members: [{ curie, label }], overCap } (members holds cap+1 when overCap).
+    const subtreeMembers = async (rootCurie, rootLabel, { maxDepth = null, leavesOnly = false, cap = 512 } = {}) => {
+        await ensureRegistry()
+        const edgeTables = sources.value.map((s) => s.edgesTable).filter(Boolean)
+        if (!edgeTables.length) {
+            // No edges sidecar — fall back to the (slower) recursive descendants, capped.
+            const descs = await descendants(rootCurie, { maxDepth, leavesOnly, limit: cap + 1 })
+            const mapped = descs.map((d) => ({ curie: d.curie, label: d.label }))
+            const members = leavesOnly ? mapped : [{ curie: rootCurie, label: rootLabel }, ...mapped]
+            return { members, overCap: members.length > cap }
+        }
+
+        const members = []
+        const seen = new Set([rootCurie])
+        if (!leavesOnly) members.push({ curie: rootCurie, label: rootLabel })
+
+        let frontier = [rootCurie]
+        let depth = 0
+        while (frontier.length && members.length <= cap) {
+            if (maxDepth != null && depth >= maxDepth) break
+            const inList = frontier.map((c) => `'${esc(c)}'`).join(', ')
+            const union = edgeTables
+                .map((t) => `SELECT child AS curie, child_label AS label, child_has_children AS has_children FROM ${t} WHERE parent IN (${inList})`)
+                .join(' UNION ALL ')
+            const rows = await duck.executeQuery(`SELECT DISTINCT curie, label, has_children FROM (${union})`, connectionId)
+            const next = []
+            for (const r of rows || []) {
+                const curie = r.curie == null ? '' : String(r.curie)
+                if (!curie || seen.has(curie)) continue
+                seen.add(curie)
+                if (!leavesOnly || !r.has_children) members.push({ curie, label: r.label == null ? '' : String(r.label) })
+                next.push(curie)
+                if (members.length > cap) break
+            }
+            frontier = next
+            depth++
+        }
+        return { members, overCap: members.length > cap }
+    }
+
     return {
         loading, loaded, error, available, sources, isConfigured,
         ensureRegistry, ensureOntology, ensureLoaded,
-        search, descendants, ancestors,
+        search, descendants, ancestors, subtreeMembers,
         getByCurie, roots, children, lineage, labelsFor,
     }
 })

--- a/src/stores/ontologyStore.js
+++ b/src/stores/ontologyStore.js
@@ -177,6 +177,38 @@ export const useOntologyStore = defineStore('ontology', () => {
         return (rows || []).map(normalizeRow)
     }
 
+    // Search restricted to a subtree — the interactive entry path for an over-cap
+    // "ontology subtree value set" (records validate against subtree membership, so a
+    // free search would surface out-of-set terms that then fail on save). Over-searches
+    // within the ontology, then keeps only hits that descend from (or equal) the root,
+    // via one batched upward is_a walk. Returns [{ curie, label, ontology, ... }].
+    const searchSubtree = async (rootCurie, rawTerm, { ontology = null, limit = 20 } = {}) => {
+        const root = String(rootCurie || '').trim()
+        const term = String(rawTerm || '').trim()
+        if (!root || !term) return []
+        const lim = Number(limit) || 20
+        const hits = await search(term, { limit: lim * 3, ontologies: ontology ? [ontology] : null })
+        if (!hits.length) return []
+
+        const inList = hits.map((h) => `'${esc(h.curie)}'`).join(', ')
+        const r = esc(root)
+        // Walk parents up from every candidate at once; a candidate is in-subtree when
+        // its ancestor closure reaches the root (or it IS the root).
+        const query = `
+            WITH RECURSIVE all_terms AS (${unionAll()}),
+            walk AS (
+                SELECT curie AS seed, curie AS node, parents FROM all_terms WHERE curie IN (${inList})
+                UNION
+                SELECT w.seed, t.curie AS node, t.parents
+                FROM all_terms t JOIN walk w ON list_contains(string_split(w.parents, '|'), t.curie)
+            )
+            SELECT DISTINCT seed FROM walk WHERE node = '${r}'
+        `
+        const rows = await duck.executeQuery(query, connectionId)
+        const keep = new Set((rows || []).map((x) => String(x.seed)))
+        return hits.filter((h) => keep.has(h.curie)).slice(0, lim)
+    }
+
     // Union of every loaded slice, obsolete terms excluded. Excluding them here
     // keeps the whole is_a graph (roots/children/lineage/descendants/ancestors)
     // free of deprecated concepts — which matters because obsolete OBO terms have
@@ -454,7 +486,7 @@ export const useOntologyStore = defineStore('ontology', () => {
     return {
         loading, loaded, error, available, sources, isConfigured,
         ensureRegistry, ensureOntology, ensureLoaded,
-        search, descendants, ancestors, subtreeMembers,
+        search, searchSubtree, descendants, ancestors, subtreeMembers,
         getByCurie, roots, children, lineage, labelsFor,
     }
 })


### PR DESCRIPTION
Next dev deploy for the property-editor ontology value-set flow (on top of #774, already merged). App-only, no backend/data changes.

## Highlights
- **Tree-picker dialog** — a "Browse…" button opens `OntologyTreePicker` to choose a value-set root visually (ontology dropdown + scoped search + lazy is_a tree). Same subtree resolution + preview as typing.
- **Bounded subtree resolution** — selecting a broad root used to hang (the recursive descendants CTE ignores LIMIT; MONDO's disease root ≈ 13.6s). New `ontology.subtreeMembers()` does a level-by-level BFS over the edges sidecar and stops at the inline cap — the same root now resolves in ~24ms. Over-cap shows "More than N values" + a sample (it's a reference anyway).
- **Readable preview** — picking a term shows the member terms by **label** (curie muted) with count + scope, instead of dumping a comma list of raw curies.
- **Faster search** — an ontology dropdown scopes the term search to one vocabulary instead of scanning all ~600k+ terms.
- **Text-only** — the ontology picker only shows for `string` properties; length/pattern hidden when a controlled value set is active; switching type away from Text drops the selection.
- **Polish** — full-height inputs, label/curie spacing, and a TDZ fix for the type watcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)