### PR TITLE
deploy(dev): metadata record UI polish — object summaries, resize, hover previews

### DIFF
--- a/src/components/bf-navigation/BfNavigation.vue
+++ b/src/components/bf-navigation/BfNavigation.vue
@@ -158,6 +158,19 @@
       </bf-navigation-item>
 
       <bf-navigation-item
+        v-if="!(pageNotFound || isWelcomeOrg) && !isWorkspaceGuest"
+        id="nav-resources"
+        :link="{ name: 'workspace-resources', params: { orgId: activeOrganizationId } }"
+        label="Resources"
+        :condensed="primaryNavCondensed"
+        :styleColor="navStyleColor"
+      >
+        <template v-slot:icon>
+          <IconCollection :width="20" :height="20" color="currentColor" />
+        </template>
+      </bf-navigation-item>
+
+      <bf-navigation-item
         v-if="hasAdminRights && !pageNotFound && !isWorkspaceGuest"
         :link="{ name: 'workspace-settings-overview', params: { orgId: activeOrganizationId } }"
         label="Settings"
@@ -204,6 +217,7 @@ import IconPublic from "../icons/IconPublic.vue";
 import IconSPARCLogo from "../icons/IconSPARCLogo.vue";
 import IconI3HLogo from "../icons/IconI3HLogo.vue";
 import IconHealInitiative from "../icons/IconHealInitiative.vue";
+import IconCollection from "../icons/IconCollection.vue";
 import CustomTheme from "../../mixins/custom-theme";
 
 export default {
@@ -239,6 +253,7 @@ export default {
     IconTeam,
     IconIntegrations,
     IconHealInitiative,
+    IconCollection,
   },
   mixins: [CustomTheme],
 

--- a/src/components/datasets/metadata/models/CdeGallery.vue
+++ b/src/components/datasets/metadata/models/CdeGallery.vue
@@ -1,5 +1,16 @@
 <template>
   <bf-stage>
+    <template #actions>
+      <stage-actions>
+        <template #left>
+          <a class="back-to-resources-link" @click="goBackToResources">
+            <IconArrowLeft :height="12" :width="12" />
+            Resources
+          </a>
+        </template>
+      </stage-actions>
+    </template>
+
     <div class="cde-gallery">
       <div class="cg-head">
         <h2>CDE Catalog</h2>
@@ -235,12 +246,24 @@
 
 <script setup>
 import { ref, reactive, computed, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import { Search } from '@element-plus/icons-vue'
 import debounce from 'lodash.debounce'
 import { useCdeCatalogStore } from '@/stores/cdeCatalogStore'
 import CdeFacets from './CdeFacets.vue'
+import StageActions from '@/components/shared/StageActions/StageActions.vue'
+import IconArrowLeft from '@/components/icons/IconArrowLeft.vue'
 
 const store = useCdeCatalogStore()
+
+const router = useRouter()
+const route = useRoute()
+
+// Reachable from MyWorkspace and org workspaces — back within the same context.
+const goBackToResources = () => {
+  const orgId = route.params.orgId
+  router.push(orgId ? { name: 'workspace-resources', params: { orgId } } : { name: 'resources' })
+}
 
 const term = ref('')
 const facets = ref({ disease: [], domain: [], tier: [] }) // multi-select facet state
@@ -402,10 +425,25 @@ onMounted(async () => {
 <style scoped lang="scss">
 @use '../../../../styles/theme' as theme;
 
+.back-to-resources-link {
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+  gap: 4px;
+  color: theme.$purple_3;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 .cde-gallery {
   min-height: 500px;
-  /* bf-stage gives only 8px top vs 32px sides; add 24px so the top inset matches. */
-  padding-top: 24px;
+  /* The stage-actions bar (back link) above already provides the top inset. */
+  padding-top: 0;
 }
 .cg-head h2 {
   font-size: 20px;

--- a/src/components/datasets/metadata/models/ModelSpecViewer.vue
+++ b/src/components/datasets/metadata/models/ModelSpecViewer.vue
@@ -23,6 +23,7 @@ import IconPencil from "@/components/icons/IconPencil.vue";
 import IconAddTemplate from "@/components/icons/IconAddTemplate.vue";
 import IconPlus from "@/components/icons/IconPlus.vue";
 import IconTrash from "@/components/icons/IconTrash.vue";
+import IconArrowLeft from "@/components/icons/IconArrowLeft.vue";
 
 const props = defineProps({
   datasetId: {
@@ -100,6 +101,19 @@ const templateData = ref()
 
 // Computed to determine if we're viewing a template
 const isTemplate = computed(() => props.isTemplate || !!props.templateId)
+
+// Back link to the list this detail page belongs to
+const backLinkLabel = computed(() => (isTemplate.value ? 'Template Gallery' : 'Models'))
+
+const goBackToList = () => {
+  router.push({
+    name: isTemplate.value ? 'new-model-from-template' : 'models-list',
+    params: {
+      orgId: router.currentRoute.value.params.orgId,
+      datasetId: router.currentRoute.value.params.datasetId
+    }
+  })
+}
 
 // Use composablesOKay
 const {
@@ -874,6 +888,11 @@ const PropertyTree = defineComponent({
     <template v-if="!hideSelector" #actions>
       <stage-actions>
         <template #left>
+          <a class="back-to-list-link" @click="goBackToList">
+            <IconArrowLeft :height="12" :width="12" />
+            {{ backLinkLabel }}
+          </a>
+
           <!-- Version selector -->
           <div v-if="!hideSelector" class="version-controls">
             <!-- Model version selector -->
@@ -1685,28 +1704,38 @@ const PropertyTree = defineComponent({
   }
 }
 
+.back-to-list-link {
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+  gap: 4px;
+  margin-right: 16px;
+  color: theme.$purple_3;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 // Version controls styling
 .version-controls {
   display: flex;
   align-items: center;
+  align-self: center;
   gap: 12px;
   
   .version-dropdown {
     width: 160px;
-    height: 32px;
-    
-    :deep(.el-input__wrapper) {
-      height: 32px;
+
+    // Element Plus 2.5+ select renders .el-select__wrapper (no .el-input__*)
+    :deep(.el-select__wrapper) {
+      min-height: 32px;
       border-radius: 4px;
-      border: 1px solid theme.$gray_2;
       background-color: theme.$white;
-    }
-    
-    :deep(.el-input__inner) {
-      height: 32px;
-      line-height: 32px;
       font-size: 14px;
-      color: theme.$gray_6;
     }
   }
 }

--- a/src/components/datasets/metadata/models/OntologyBrowser.vue
+++ b/src/components/datasets/metadata/models/OntologyBrowser.vue
@@ -1,5 +1,16 @@
 <template>
   <bf-stage>
+    <template #actions>
+      <stage-actions>
+        <template #left>
+          <a class="back-to-resources-link" @click="goBackToResources">
+            <IconArrowLeft :height="12" :width="12" />
+            Resources
+          </a>
+        </template>
+      </stage-actions>
+    </template>
+
     <div class="ontology-browser">
       <div class="ob-head">
         <div class="ob-title-row">
@@ -252,11 +263,23 @@
 
 <script setup>
 import { ref, reactive, computed, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import { Search, Check, PriceTag, Collection, QuestionFilled, InfoFilled, Calendar, List } from '@element-plus/icons-vue'
 import debounce from 'lodash.debounce'
 import { useOntologyStore } from '@/stores/ontologyStore'
+import StageActions from '@/components/shared/StageActions/StageActions.vue'
+import IconArrowLeft from '@/components/icons/IconArrowLeft.vue'
 
 const store = useOntologyStore()
+
+const router = useRouter()
+const route = useRoute()
+
+// Reachable from MyWorkspace and org workspaces — back within the same context.
+const goBackToResources = () => {
+  const orgId = route.params.orgId
+  router.push(orgId ? { name: 'workspace-resources', params: { orgId } } : { name: 'resources' })
+}
 
 const CHILD_DISPLAY_CAP = 60 // chips in the drawer "narrower terms" list
 
@@ -508,10 +531,25 @@ onMounted(async () => {
 <style scoped lang="scss">
 @use '../../../../styles/theme' as theme;
 
+.back-to-resources-link {
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+  gap: 4px;
+  color: theme.$purple_3;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 .ontology-browser {
   min-height: 500px;
-  /* bf-stage gives only 8px top vs 32px sides; add 24px so the top inset matches. */
-  padding-top: 24px;
+  /* The stage-actions bar (back link) above already provides the top inset. */
+  padding-top: 0;
 }
 .ob-title-row {
   display: flex;

--- a/src/components/datasets/metadata/models/modelList.vue
+++ b/src/components/datasets/metadata/models/modelList.vue
@@ -42,22 +42,11 @@
               </template>
             </bf-card>
           </button>
-          <button
-            @click="openCdeGallery"
-          >
-            <bf-card
-              title="CDE Catalog"
-              card-copy="Browse common data elements and bundles"
-            >
-              <template #icon>
-                <icon-collection
-                  class="card-icon"
-                  :height="48"
-                  :width="48"
-                />
-              </template>
-            </bf-card>
-          </button>
+        </div>
+
+        <div class="resources-hint">
+          Looking for reference catalogs?
+          <a @click="openResources">Browse CDEs and ontologies →</a>
         </div>
 
         <div >
@@ -127,7 +116,6 @@ import { useMetadataStore } from '@/stores/metadataStore.js'
 import IconOverview from "@/components/icons/IconOverview.vue";
 import BfCard from "@/components/shared/bf-card/BfCard.vue";
 import IconAddTemplate from "@/components/icons/IconAddTemplate.vue";
-import IconCollection from "@/components/icons/IconCollection.vue";
 import ModelListItem from "@/components/datasets/metadata/models/modelListItem.vue";
 import CreateModelWizard from "@/components/datasets/metadata/models/CreateModelWizard.vue";
 // Dynamic import to avoid circular dependency issues
@@ -198,15 +186,15 @@ const openTemplateGallery = () => {
   })
 }
 
-const openCdeGallery = () => {
+const openResources = () => {
   router.push({
-    name: 'cde-gallery',
+    name: 'workspace-resources',
     params: {
-      datasetId: props.datasetId,
       orgId: props.orgId,
     }
   })
 }
+
 
 </script>
 
@@ -233,8 +221,23 @@ const openCdeGallery = () => {
 
   .graph-management-cards {
     display: flex;
-    margin-bottom: 48px;
+    margin-bottom: 16px;
+  }
 
+  .resources-hint {
+    margin-bottom: 48px;
+    font-size: 13px;
+    color: theme.$gray_5;
+
+    a {
+      color: theme.$purple_3;
+      font-weight: 500;
+      cursor: pointer;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
 
   .gallery-link {

--- a/src/components/datasets/metadata/records/ListRecords.vue
+++ b/src/components/datasets/metadata/records/ListRecords.vue
@@ -5,7 +5,7 @@ import { ArrowDown, View, InfoFilled } from '@element-plus/icons-vue'
 import { useRouter } from 'vue-router'
 import { useMetadataStore } from '@/stores/metadataStore.js'
 import { useOntologyStore } from '@/stores/ontologyStore.js'
-import { summarizeObject } from '@/utils/objectSummary.js'
+import { summarizeObject, stripHtml } from '@/utils/objectSummary.js'
 import MultiModelFilter from '../../explore/GraphExplorer/MultiModelFilter.vue'
 import IconPlus from '@/components/icons/IconPlus.vue'
 import StageActions from "@/components/shared/StageActions/StageActions.vue";
@@ -698,11 +698,6 @@ const resolveSubtreeLabels = async () => {
 }
 
 watch([records, modelSchema], () => { resolveSubtreeLabels() })
-
-// Source text can carry literal HTML (e.g. "<br />" in NLM reference fields) —
-// strip tags for the one-line cell display.
-const stripHtml = (s) =>
-  s.includes('<') ? s.replace(/<\/?[a-z][^>]*>/gi, ' ').replace(/\s+/g, ' ').trim() : s
 
 const formatCellValue = (value, column) => {
   if (value === null || value === undefined) {

--- a/src/components/datasets/metadata/records/ListRecords.vue
+++ b/src/components/datasets/metadata/records/ListRecords.vue
@@ -368,12 +368,12 @@ const fetchModel = async () => {
     
     if (model.value?.latest_version?.schema) {
       modelSchema.value = model.value.latest_version.schema
-      // Initialize selected version based on route param or default to all versions
+      // Initialize selected version based on route param or default to latest
       if (!selectedVersion.value) {
         if (props.versionId) {
           selectedVersion.value = props.versionId
         } else {
-          selectedVersion.value = 'all'
+          selectedVersion.value = 'latest'
         }
       }
       

--- a/src/components/datasets/metadata/records/ListRecords.vue
+++ b/src/components/datasets/metadata/records/ListRecords.vue
@@ -1,10 +1,11 @@
 <script setup>
-import { ref, computed, onMounted, watch, nextTick } from 'vue'
-import { ElTable, ElTableColumn, ElCard, ElButton, ElSelect, ElOption, ElMessage, ElDropdown, ElDropdownMenu, ElDropdownItem, ElIcon, ElTag, ElDivider, ElTooltip } from 'element-plus'
+import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
+import { ElTable, ElTableColumn, ElCard, ElButton, ElSelect, ElOption, ElMessage, ElDropdown, ElDropdownMenu, ElDropdownItem, ElIcon, ElTag, ElDivider, ElTooltip, ElCheckbox } from 'element-plus'
 import { ArrowDown, View, InfoFilled } from '@element-plus/icons-vue'
 import { useRouter } from 'vue-router'
 import { useMetadataStore } from '@/stores/metadataStore.js'
 import { useOntologyStore } from '@/stores/ontologyStore.js'
+import { summarizeObject } from '@/utils/objectSummary.js'
 import MultiModelFilter from '../../explore/GraphExplorer/MultiModelFilter.vue'
 import IconPlus from '@/components/icons/IconPlus.vue'
 import StageActions from "@/components/shared/StageActions/StageActions.vue";
@@ -90,6 +91,76 @@ const tableColumns = computed(() => {
     codedTip: codedColumnTip(property)
   }))
 })
+
+// Sparse schemas (e.g. CDE models) carry many properties with no values on a
+// given page — hide those columns by default, with a toggle to show them.
+const showEmptyColumns = ref(false)
+
+const columnHasData = (column) => records.value.some(r => {
+  const v = r.value?.[column.key]
+  if (v == null || v === '') return false
+  if (Array.isArray(v)) return v.length > 0
+  if (typeof v === 'object') return Object.keys(v).length > 0
+  return true
+})
+
+const emptyColumnCount = computed(() =>
+  records.value.length ? tableColumns.value.filter(c => !columnHasData(c)).length : 0
+)
+
+const visibleColumns = computed(() =>
+  showEmptyColumns.value || !emptyColumnCount.value
+    ? tableColumns.value
+    : tableColumns.value.filter(columnHasData)
+)
+
+// --- Column resize ----------------------------------------------------------
+// Custom drag-resize via a handle element on each header cell's right edge:
+// Element Plus's built-in version only applies the new width on mouseup (and
+// requires border mode), so widths here are applied live while dragging. The
+// handle carries cursor: col-resize in CSS, so the browser resolves the hover
+// cursor natively. Widths persist by column key.
+const columnWidths = ref({})
+const MIN_COLUMN_WIDTH = 80
+
+let resizeState = null
+
+const startColumnResize = (column, e) => {
+  const th = e.target.closest('th')
+  if (!th) return
+  resizeState = {
+    key: column.key,
+    startX: e.clientX,
+    startWidth: th.getBoundingClientRect().width,
+    raf: null
+  }
+  document.body.style.cursor = 'col-resize'
+  document.body.style.userSelect = 'none'
+  document.addEventListener('mousemove', onResizing)
+  document.addEventListener('mouseup', endResize)
+}
+
+const onResizing = (e) => {
+  if (!resizeState || resizeState.raf) return
+  const { clientX } = e
+  resizeState.raf = requestAnimationFrame(() => {
+    if (!resizeState) return
+    resizeState.raf = null
+    const width = Math.max(MIN_COLUMN_WIDTH, resizeState.startWidth + (clientX - resizeState.startX))
+    columnWidths.value = { ...columnWidths.value, [resizeState.key]: width }
+  })
+}
+
+const endResize = () => {
+  if (resizeState?.raf) cancelAnimationFrame(resizeState.raf)
+  resizeState = null
+  document.body.style.cursor = ''
+  document.body.style.userSelect = ''
+  document.removeEventListener('mousemove', onResizing)
+  document.removeEventListener('mouseup', endResize)
+}
+
+onBeforeUnmount(endResize)
 
 // Describe a column's coded-value source for a header tooltip, or null if it isn't
 // backed by an ontology / CDE value set.
@@ -628,6 +699,11 @@ const resolveSubtreeLabels = async () => {
 
 watch([records, modelSchema], () => { resolveSubtreeLabels() })
 
+// Source text can carry literal HTML (e.g. "<br />" in NLM reference fields) —
+// strip tags for the one-line cell display.
+const stripHtml = (s) =>
+  s.includes('<') ? s.replace(/<\/?[a-z][^>]*>/gi, ' ').replace(/\s+/g, ' ').trim() : s
+
 const formatCellValue = (value, column) => {
   if (value === null || value === undefined) {
     return ''
@@ -665,46 +741,28 @@ const formatCellValue = (value, column) => {
     }
   }
   
-  // Handle arrays
-  if (column.type === 'array' || Array.isArray(value)) {
-    if (Array.isArray(value)) {
-      if (value.length === 0) {
-        return '[]'
+  // Handle arrays: one-line summary per item, capped at 3 items
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return ''
+    }
+    const preview = value.slice(0, 3).map(item => {
+      if (typeof item === 'object' && item !== null) {
+        return summarizeObject(item)
       }
-      // For arrays, show count and preview of first few items
-      const preview = value.slice(0, 3).map(item => {
-        if (typeof item === 'object' && item !== null) {
-          return '{...}'
-        }
-        return JSON.stringify(item)
-      }).join(', ')
-      
-      const suffix = value.length > 3 ? `, ... +${value.length - 3} more` : ''
-      return `[${preview}${suffix}]`
-    }
-    return String(value)
+      return stripHtml(String(item))
+    }).join(' · ')
+
+    const suffix = value.length > 3 ? ` · +${value.length - 3} more` : ''
+    return `${preview}${suffix}`
   }
-  
+
   // Handle objects
-  if (column.type === 'object' || (typeof value === 'object' && value !== null && !Array.isArray(value))) {
-    const keys = Object.keys(value)
-    if (keys.length === 0) {
-      return '{}'
-    }
-    // For objects, show key count and preview of first few keys
-    const preview = keys.slice(0, 2).map(key => {
-      const val = value[key]
-      const displayVal = val === null ? 'null' : 
-                        typeof val === 'object' ? '{...}' : 
-                        JSON.stringify(val)
-      return `${key}: ${displayVal}`
-    }).join(', ')
-    
-    const suffix = keys.length > 2 ? `, ... +${keys.length - 2} more` : ''
-    return `{${preview}${suffix}}`
+  if (typeof value === 'object' && value !== null) {
+    return summarizeObject(value)
   }
-  
-  return String(value)
+
+  return stripHtml(String(value))
 }
 
 // Helper function to get a record display name
@@ -943,8 +1001,15 @@ onMounted(async () => {
       <div class="records-controls">
         <div class="records-controls-left">
           <span class="records-count">{{ recordsHeading }}</span>
+          <el-checkbox
+            v-if="emptyColumnCount > 0"
+            v-model="showEmptyColumns"
+            class="empty-columns-toggle"
+          >
+            Show empty columns ({{ emptyColumnCount }})
+          </el-checkbox>
         </div>
-        
+
         <div v-if="hasNextPage || hasPreviousPage" class="pagination-controls">
           <el-button
             :disabled="!hasPreviousPage"
@@ -974,10 +1039,11 @@ onMounted(async () => {
         >
           <!-- Dynamic columns from model schema -->
           <el-table-column
-            v-for="column in tableColumns"
+            v-for="column in visibleColumns"
             :key="column.key"
             :prop="`value.${column.key}`"
             :label="column.label"
+            :width="columnWidths[column.key]"
             :min-width="120"
             show-overflow-tooltip
           >
@@ -988,6 +1054,11 @@ onMounted(async () => {
                   <el-icon class="coded-indicator"><InfoFilled /></el-icon>
                 </el-tooltip>
               </span>
+              <span
+                class="col-resize-handle"
+                @mousedown.prevent.stop="startColumnResize(column, $event)"
+                @click.stop
+              />
             </template>
             <template #default="{ row }">
               {{ formatCellValue(row.value[column.key], column) }}
@@ -1322,10 +1393,23 @@ onMounted(async () => {
       }
       
       .records-controls-left {
+        display: flex;
+        align-items: center;
+
         .records-count {
           color: theme.$gray_5;
           font-size: 14px;
           font-weight: 500;
+        }
+
+        .empty-columns-toggle {
+          margin-left: 24px;
+
+          :deep(.el-checkbox__label) {
+            color: theme.$gray_5;
+            font-size: 14px;
+            font-weight: 400;
+          }
         }
         
         .page-size-selector {
@@ -1383,20 +1467,33 @@ onMounted(async () => {
       :deep(.el-table) {
         .el-table__header {
           background-color: theme.$gray_1;
-          
+
           th {
             background-color: theme.$gray_1 !important;
             color: theme.$gray_6;
             font-weight: 600;
             border-bottom: 1px solid theme.$gray_2;
+            position: relative;
           }
         }
-        
+
+        // Drag handle on the header cell's right edge. Kept fully inside its
+        // own cell — an overhang into the neighbor gets covered by that th.
+        .col-resize-handle {
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          right: 0;
+          width: 8px;
+          cursor: col-resize;
+          z-index: 1;
+        }
+
         .el-table__row {
           &:hover {
             background-color: theme.$gray_1;
           }
-          
+
           td {
             border-bottom: 1px solid theme.$gray_2;
             color: theme.$gray_6;

--- a/src/components/datasets/metadata/records/RecordSpecViewer.vue
+++ b/src/components/datasets/metadata/records/RecordSpecViewer.vue
@@ -5,7 +5,7 @@ import { useRouter, useRoute } from 'vue-router'
 import { useMetadataStore } from '@/stores/metadataStore.js'
 import { useOntologyStore } from '@/stores/ontologyStore.js'
 import { useRecordData } from '@/composables/useRecordData.js'
-import { summarizeObject } from '@/utils/objectSummary.js'
+import { summarizeObject, stripHtml } from '@/utils/objectSummary.js'
 
 // Import components
 import BfStage from '@/components/layout/BfStage/BfStage.vue'
@@ -391,18 +391,18 @@ const formatPropertyValue = (value, property) => {
     // Arrays of objects: one summary pill per item instead of "[object Object]".
     if (value.some((v) => v != null && typeof v === 'object')) {
       const items = value.map((v) =>
-        v != null && typeof v === 'object' ? summarizeObject(v) : String(v)
+        v != null && typeof v === 'object' ? summarizeObject(v) : stripHtml(String(v))
       )
       return { display: '', items, isNull: false }
     }
-    return { display: value.join(', '), isNull: false }
+    return { display: value.map((v) => stripHtml(String(v))).join(', '), isNull: false }
   }
 
   if (typeof value === 'object') {
     return { display: summarizeObject(value), isNull: false }
   }
-  
-  return { display: String(value), isNull: false }
+
+  return { display: stripHtml(String(value)), isNull: false }
 }
 
 // Resolve labels for the record's subtree value-set codes (no inline labels in the

--- a/src/components/datasets/metadata/records/RecordSpecViewer.vue
+++ b/src/components/datasets/metadata/records/RecordSpecViewer.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
-import { ElCard, ElTag, ElMessage, ElButton, ElPagination, ElMessageBox } from 'element-plus'
+import { ElCard, ElTag, ElMessage, ElButton, ElPagination, ElMessageBox, ElPopover } from 'element-plus'
 import { useRouter, useRoute } from 'vue-router'
 import { useMetadataStore } from '@/stores/metadataStore.js'
 import { useOntologyStore } from '@/stores/ontologyStore.js'
@@ -544,6 +544,54 @@ const getRecordDisplayValue = (record) => {
   
   // Fall back to record ID
   return `Record ${record.id.slice(0, 8)}...`
+}
+
+// --- Related-record hover preview -------------------------------------------
+// The relationships payload includes each linked record's full value and
+// model_id, so the hover card is built from data already loaded — no fetch.
+const relatedModelName = (record) => {
+  const m = metadataStore.modelById(record?.model_id)
+  return m?.display_name || m?.name || 'Record'
+}
+
+const previewFieldValue = (v) => {
+  if (Array.isArray(v)) {
+    const items = v.slice(0, 2).map((x) =>
+      x != null && typeof x === 'object' ? summarizeObject(x) : stripHtml(String(x))
+    )
+    return items.join(' · ') + (v.length > 2 ? ` · +${v.length - 2} more` : '')
+  }
+  if (v != null && typeof v === 'object') return summarizeObject(v)
+  if (typeof v === 'boolean') return v ? 'Yes' : 'No'
+  return stripHtml(String(v))
+}
+
+// First few non-empty fields of the linked record, in schema order when the
+// related model's schema is loaded (with property titles as labels).
+const recordPreviewFields = (record, max = 6) => {
+  const data = record?.value
+  if (!data) return { fields: [], more: 0 }
+
+  const schemaProps = metadataStore.modelById(record.model_id)?.latest_version?.schema?.properties
+  const keys = schemaProps
+    ? Object.keys(schemaProps).filter((k) => k in data)
+    : Object.keys(data)
+
+  const nonEmpty = keys.filter((k) => {
+    const v = data[k]
+    if (v == null || v === '') return false
+    if (Array.isArray(v) && !v.length) return false
+    return true
+  })
+
+  return {
+    fields: nonEmpty.slice(0, max).map((k) => ({
+      key: k,
+      label: schemaProps?.[k]?.title || k,
+      value: previewFieldValue(data[k])
+    })),
+    more: Math.max(0, nonEmpty.length - max)
+  }
 }
 
 // Pagination methods
@@ -1179,11 +1227,30 @@ onMounted(async () => {
                     :key="`inbound-${index}`"
                     class="relationship-item"
                   >
-                    <div class="relationship-content clickable" @click="goToRelatedRecord(relationship.record)" :title="'Click to view record'">
-                      <el-tag size="small" class="relationship-type inbound">{{ relationship.relationship_type }}</el-tag>
-                      <span class="record-title">{{ getRecordDisplayValue(relationship.record) }}</span>
-                      <IconArrowRight class="nav-icon" :width="12" :height="12" />
-                    </div>
+                    <el-popover placement="top-start" :width="340" trigger="hover" :show-after="350" popper-class="record-preview-popover">
+                      <template #reference>
+                        <div class="relationship-content clickable" @click="goToRelatedRecord(relationship.record)">
+                          <el-tag size="small" class="relationship-type inbound">{{ relationship.relationship_type }}</el-tag>
+                          <span class="record-title">{{ getRecordDisplayValue(relationship.record) }}</span>
+                          <IconArrowRight class="nav-icon" :width="12" :height="12" />
+                        </div>
+                      </template>
+                      <div class="record-preview">
+                        <div class="record-preview-header">
+                          <span class="record-preview-model">{{ relatedModelName(relationship.record) }}</span>
+                          <span class="record-preview-title">{{ getRecordDisplayValue(relationship.record) }}</span>
+                        </div>
+                        <div class="record-preview-fields">
+                          <div v-for="f in recordPreviewFields(relationship.record).fields" :key="f.key" class="record-preview-field">
+                            <span class="field-label">{{ f.label }}</span>
+                            <span class="field-value">{{ f.value }}</span>
+                          </div>
+                        </div>
+                        <div v-if="recordPreviewFields(relationship.record).more" class="record-preview-more">
+                          +{{ recordPreviewFields(relationship.record).more }} more fields — click to open
+                        </div>
+                      </div>
+                    </el-popover>
                     <el-button
                       @click.stop="deleteRelationship(relationship, 'inbound')"
                       link
@@ -1220,11 +1287,30 @@ onMounted(async () => {
                     :key="`outbound-${index}`"
                     class="relationship-item"
                   >
-                    <div class="relationship-content clickable" @click="goToRelatedRecord(relationship.record)" :title="'Click to view record'">
-                      <el-tag size="small" class="relationship-type outbound">{{ relationship.relationship_type }}</el-tag>
-                      <span class="record-title">{{ getRecordDisplayValue(relationship.record) }}</span>
-                      <IconArrowRight class="nav-icon" :width="12" :height="12" />
-                    </div>
+                    <el-popover placement="top-start" :width="340" trigger="hover" :show-after="350" popper-class="record-preview-popover">
+                      <template #reference>
+                        <div class="relationship-content clickable" @click="goToRelatedRecord(relationship.record)">
+                          <el-tag size="small" class="relationship-type outbound">{{ relationship.relationship_type }}</el-tag>
+                          <span class="record-title">{{ getRecordDisplayValue(relationship.record) }}</span>
+                          <IconArrowRight class="nav-icon" :width="12" :height="12" />
+                        </div>
+                      </template>
+                      <div class="record-preview">
+                        <div class="record-preview-header">
+                          <span class="record-preview-model">{{ relatedModelName(relationship.record) }}</span>
+                          <span class="record-preview-title">{{ getRecordDisplayValue(relationship.record) }}</span>
+                        </div>
+                        <div class="record-preview-fields">
+                          <div v-for="f in recordPreviewFields(relationship.record).fields" :key="f.key" class="record-preview-field">
+                            <span class="field-label">{{ f.label }}</span>
+                            <span class="field-value">{{ f.value }}</span>
+                          </div>
+                        </div>
+                        <div v-if="recordPreviewFields(relationship.record).more" class="record-preview-more">
+                          +{{ recordPreviewFields(relationship.record).more }} more fields — click to open
+                        </div>
+                      </div>
+                    </el-popover>
                     <el-button
                       @click.stop="deleteRelationship(relationship, 'outbound')"
                       link
@@ -2142,6 +2228,67 @@ onMounted(async () => {
 
   .mr-8 {
     margin-right: 8px;
+  }
+}
+</style>
+
+<!-- Unscoped: the popover popper is teleported to <body>. -->
+<style lang="scss">
+@use '../../../../styles/theme';
+
+.record-preview-popover {
+  .record-preview-header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding-bottom: 8px;
+    margin-bottom: 8px;
+    border-bottom: 1px solid theme.$gray_2;
+
+    .record-preview-model {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+      color: theme.$gray_4;
+    }
+
+    .record-preview-title {
+      font-size: 14px;
+      font-weight: 600;
+      color: theme.$gray_6;
+    }
+  }
+
+  .record-preview-field {
+    display: flex;
+    gap: 8px;
+    font-size: 13px;
+    line-height: 1.5;
+    margin-bottom: 4px;
+
+    .field-label {
+      flex: 0 0 112px;
+      color: theme.$gray_4;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .field-value {
+      flex: 1;
+      color: theme.$gray_6;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+  }
+
+  .record-preview-more {
+    margin-top: 8px;
+    font-size: 12px;
+    color: theme.$gray_4;
   }
 }
 </style>

--- a/src/components/datasets/metadata/records/RecordSpecViewer.vue
+++ b/src/components/datasets/metadata/records/RecordSpecViewer.vue
@@ -12,6 +12,7 @@ import BfStage from '@/components/layout/BfStage/BfStage.vue'
 import StageActions from '@/components/shared/StageActions/StageActions.vue'
 import BfButton from '@/components/shared/bf-button/BfButton.vue'
 import IconArrowRight from '@/components/icons/IconArrowRight.vue'
+import IconArrowLeft from '@/components/icons/IconArrowLeft.vue'
 import IconPencil from '@/components/icons/IconPencil.vue'
 import PsButtonDropdown from '@/components/shared/ps-button-dropdown/PsButtonDropdown.vue'
 import IconTrash from "@/components/icons/IconTrash.vue"
@@ -1071,12 +1072,10 @@ onMounted(async () => {
     <template #actions>
       <stage-actions>
         <template #left>
-<!--          <bf-button @click="goBackToRecords" size="small">-->
-<!--            <template #prefix>-->
-<!--              <IconArrowLeft class="mr-8" :height="16" :width="16" />-->
-<!--            </template>-->
-<!--            Back to Records-->
-<!--          </bf-button>-->
+          <a class="back-to-records-link" @click="goBackToRecords">
+            <IconArrowLeft :height="12" :width="12" />
+            {{ model?.display_name || model?.name || 'Model' }} Records
+          </a>
         </template>
         <template #right>
           <template v-if="quickActionsVisible">
@@ -2228,6 +2227,20 @@ onMounted(async () => {
 
   .mr-8 {
     margin-right: 8px;
+  }
+
+  .back-to-records-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: theme.$purple_3;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }
 </style>

--- a/src/components/datasets/metadata/records/RecordSpecViewer.vue
+++ b/src/components/datasets/metadata/records/RecordSpecViewer.vue
@@ -5,6 +5,7 @@ import { useRouter, useRoute } from 'vue-router'
 import { useMetadataStore } from '@/stores/metadataStore.js'
 import { useOntologyStore } from '@/stores/ontologyStore.js'
 import { useRecordData } from '@/composables/useRecordData.js'
+import { summarizeObject } from '@/utils/objectSummary.js'
 
 // Import components
 import BfStage from '@/components/layout/BfStage/BfStage.vue'
@@ -387,11 +388,18 @@ const formatPropertyValue = (value, property) => {
   }
   
   if (Array.isArray(value)) {
+    // Arrays of objects: one summary pill per item instead of "[object Object]".
+    if (value.some((v) => v != null && typeof v === 'object')) {
+      const items = value.map((v) =>
+        v != null && typeof v === 'object' ? summarizeObject(v) : String(v)
+      )
+      return { display: '', items, isNull: false }
+    }
     return { display: value.join(', '), isNull: false }
   }
-  
+
   if (typeof value === 'object') {
-    return { display: JSON.stringify(value, null, 2), isNull: false }
+    return { display: summarizeObject(value), isNull: false }
   }
   
   return { display: String(value), isNull: false }
@@ -1104,7 +1112,14 @@ onMounted(async () => {
             >
               <span class="attribute-name">{{ prop.label }}:</span>
               <span class="attribute-value" :class="{ 'is-null': prop.formatted.isNull }">
-                {{ prop.formatted.display }}
+                <template v-if="prop.formatted.items">
+                  <span
+                    v-for="(item, idx) in prop.formatted.items"
+                    :key="idx"
+                    class="attribute-object-item"
+                  >{{ item }}</span>
+                </template>
+                <template v-else>{{ prop.formatted.display }}</template>
                 <span v-if="prop.formatted.code" class="attribute-code" :title="`Stored value: ${prop.formatted.code}`">{{ prop.formatted.code }}</span>
               </span>
             </div>
@@ -1743,6 +1758,25 @@ onMounted(async () => {
                 font-size: 11px;
                 font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
                 vertical-align: middle;
+              }
+
+              .attribute-object-item {
+                display: inline-block;
+                margin: 0 8px 4px 0;
+                padding: 2px 8px;
+                border-radius: 4px;
+                background: theme.$gray_1;
+                color: theme.$gray_6;
+                font-size: 13px;
+                white-space: nowrap;
+                max-width: 400px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                vertical-align: middle;
+
+                &:last-child {
+                  margin-right: 0;
+                }
               }
             }
           }

--- a/src/router/MyWorkSpace/ResourcesList.vue
+++ b/src/router/MyWorkSpace/ResourcesList.vue
@@ -11,23 +11,15 @@
       <user-dashboard-card
         title="CDE Catalog"
         description="Browse common data elements and bundles indexed from the NLM CDE Repository"
-        :route="{ name: 'cde-catalog' }"
+        :route="cdeCatalogRoute"
         icon="cde-catalog"
       />
 
       <user-dashboard-card
         title="Ontology Browser"
         description="Explore standard biomedical ontologies (MONDO, HPO, UBERON, NCIt) and their hierarchy"
-        :route="{ name: 'ontology-browser' }"
+        :route="ontologyBrowserRoute"
         icon="ontology-browser"
-      />
-
-      <user-dashboard-card
-        title="Model Templates"
-        description="Browse reusable model templates"
-        :route="{ name: 'resources' }"
-        icon="model-templates"
-        :coming-soon="true"
       />
     </div>
   </div>
@@ -38,7 +30,24 @@ import UserDashboardCard from "@/components/user/dashboard/UserDashboardCard.vue
 
 export default {
   name: "ResourcesList",
-  components: { UserDashboardCard }
+  components: { UserDashboardCard },
+  computed: {
+    // Rendered both in MyWorkspace (/my-workspace/resources) and in an org
+    // workspace (/:orgId/resources) — route the cards within the same context.
+    orgId() {
+      return this.$route.params.orgId || null;
+    },
+    cdeCatalogRoute() {
+      return this.orgId
+        ? { name: "workspace-cde-catalog", params: { orgId: this.orgId } }
+        : { name: "cde-catalog" };
+    },
+    ontologyBrowserRoute() {
+      return this.orgId
+        ? { name: "workspace-ontology-browser", params: { orgId: this.orgId } }
+        : { name: "ontology-browser" };
+    }
+  }
 };
 </script>
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -91,6 +91,7 @@ const Settings = () => import('./OrgSettings/Settings.vue')
 const OrgSettings = () => import('../components/OrgSettings/OrgSettings.vue')
 
 const People = () => import('./people/People.vue')
+const WorkspaceResources = () => import('./resources/WorkspaceResources.vue')
 const PeopleList = () => import('../components/people/list/PeopleList.vue')
 
 const Teams = () => import('./teams/Teams.vue')
@@ -1407,22 +1408,6 @@ const router = createRouter({
                   }
                 },
                 {
-                  path: 'cde-gallery',
-                  name: 'cde-gallery',
-                  props: true,
-                  meta: {
-                    backLink: { name: "Models", to: "models-list" },
-                    breadcrumbs: [
-                      { name: "Metadata", to: "metadata" },
-                      { name: "Models", to: "models-list" },
-                      { name: "CDE Catalog", current: true }
-                    ]
-                  },
-                  components: {
-                    stage: CdeGallery
-                  }
-                },
-                {
                   path: 'details/:modelId',
                   name: 'model-details',
                   props: true,
@@ -1639,6 +1624,42 @@ const router = createRouter({
             },
           ]
         },
+      ]
+    },
+    {
+      // Org-level resources hub — same shared catalogs as the MyWorkspace
+      // version (the content is global), reachable from the workspace nav.
+      path: '/:orgId/resources',
+      components: {
+        page: WorkspaceResources,
+        navigation: BfNavigation
+      },
+      props: true,
+      children: [
+        {
+          name: 'workspace-resources',
+          path: '',
+          components: {
+            stage: ResourcesList
+          },
+          props: true
+        },
+        {
+          name: 'workspace-cde-catalog',
+          path: 'cde-catalog',
+          components: {
+            stage: CdeGallery
+          },
+          props: true
+        },
+        {
+          name: 'workspace-ontology-browser',
+          path: 'ontology-browser',
+          components: {
+            stage: OntologyBrowser
+          },
+          props: true
+        }
       ]
     },
     {

--- a/src/router/resources/WorkspaceResources.vue
+++ b/src/router/resources/WorkspaceResources.vue
@@ -1,0 +1,37 @@
+<template>
+  <bf-page class="bf-workspace-resources">
+    <template #heading>
+      <bf-rafter
+        class="primary"
+        :org-id="orgId"
+      >
+        <template #breadcrumb>
+          <org-breadcrumb page-name="Resources" />
+        </template>
+      </bf-rafter>
+    </template>
+
+    <template #stage>
+      <router-view name="stage" />
+    </template>
+  </bf-page>
+</template>
+
+<script>
+import BfRafter from "../../components/shared/bf-rafter/BfRafter.vue";
+import OrgBreadcrumb from "../../components/shared/OrgBreadcrumb/OrgBreadcrumb.vue";
+
+export default {
+  name: 'WorkspaceResources',
+  components: {
+    BfRafter,
+    OrgBreadcrumb
+  },
+  props: {
+    orgId: {
+      type: String,
+      default: ''
+    }
+  }
+}
+</script>

--- a/src/utils/objectSummary.js
+++ b/src/utils/objectSummary.js
@@ -1,0 +1,25 @@
+/**
+ * One-line human summary for an object value (e.g. an xref entry). Prefers a
+ * name-ish + value-ish key pair ("NINDS: C57136"), falling back to the first
+ * few primitive fields as "key: value" pairs.
+ */
+export function summarizeObject(obj) {
+  const primitives = Object.entries(obj).filter(
+    ([, v]) => v != null && typeof v !== 'object'
+  )
+  const pick = (keys) => {
+    for (const key of keys) {
+      const hit = primitives.find(([k]) => k.toLowerCase() === key)
+      if (hit) return String(hit[1])
+    }
+    return null
+  }
+  const name = pick(['label', 'name', 'title', 'system', 'source', 'key', 'type'])
+  const val = pick(['value', 'id', 'code', 'identifier', 'url'])
+  if (name && val && name !== val) return `${name}: ${val}`
+  if (name || val) return name || val
+  if (primitives.length) {
+    return primitives.slice(0, 3).map(([k, v]) => `${k}: ${v}`).join(', ')
+  }
+  return JSON.stringify(obj)
+}

--- a/src/utils/objectSummary.js
+++ b/src/utils/objectSummary.js
@@ -1,4 +1,12 @@
 /**
+ * Strip literal HTML tags from source text (e.g. "<br />" in NLM reference
+ * fields) for plain-text display. Leaves non-tag uses of "<" alone.
+ */
+export function stripHtml(s) {
+  return s.includes('<') ? s.replace(/<\/?[a-z][^>]*>/gi, ' ').replace(/\s+/g, ' ').trim() : s
+}
+
+/**
  * One-line human summary for an object value (e.g. an xref entry). Prefers a
  * name-ish + value-ish key pair ("NINDS: C57136"), falling back to the first
  * few primitive fields as "key: value" pairs.


### PR DESCRIPTION
Cherry-picks this week's metadata record UI work from `feat/ontology-dataset-tags` (epic PR #772) for testing on dev.

## Changes
- **Object rendering**: arrays of objects render as one-line summaries ("NINDS: C57136") instead of `[object Object]` — pills in record detail, joined previews in the records table (shared `objectSummary.js` util)
- **HTML stripping**: literal tags (e.g. `<br />` in NLM reference fields) removed from table cells and record detail values
- **Records table**: live column drag-resize (CSS-cursor handle per header, widths applied while dragging), plus a "Show empty columns (N)" toggle that hides value-less columns on the current page
- **Relationship hover previews**: hovering a relationship row on record detail shows a popover with the linked record's model, display value, and first six populated fields (no extra fetch)
- **Back links**: record detail → "{Model} Records"; model/template detail → "Models" / "Template Gallery" (also fixes the version select's stale el-input selectors that left it top-aligned)
- **Records list** defaults to the latest model version instead of All Versions
- **Workspace Resources hub**: new "Resources" item in the org primary nav → `/:orgId/resources` with CDE Catalog and Ontology Browser (context-aware, still available in MyWorkspace). The CDE Catalog card and dataset-scoped route are removed from the models page, replaced by a small "Browse CDEs and ontologies" link; both catalogs get a "← Resources" back link

## Testing
Verified against the CDE dataset in dev (records table + record detail at `/metadata/records/...`, models page, org nav → Resources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
