### PR TITLE
deploy(dev): fix array value-set properties in the record form

### DIFF
--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -558,6 +558,11 @@ const applySubtree = async () => {
 // anchor always; under the cap an enum (codes) + display labels; over the cap the
 // subtree reference (membership-enforced at record write, VALSET-style).
 const applyValueDomain = (schema, vd) => {
+  // For an array property the constraint applies per item, so enum/format land
+  // on `items` (a property-level enum would require the whole array to equal one
+  // code and always fail). The x-pennsieve-* annotations stay on the property,
+  // where the rest of the app reads them.
+  const target = schema.type === 'array' && schema.items ? schema.items : schema
   schema['x-pennsieve-concept'] = {
     curie: vd.root_curie,
     label: vd.root_label,
@@ -566,9 +571,9 @@ const applyValueDomain = (schema, vd) => {
   }
   // The values are ontology codes, not a formatted string — a date/email/uri
   // format would contradict the value set.
-  delete schema.format
+  delete target.format
   if (vd.over_cap) {
-    delete schema.enum
+    delete target.enum
     const ref = {
       tier: 'subtree',
       ontology: vd.ontology,
@@ -580,8 +585,8 @@ const applyValueDomain = (schema, vd) => {
     if (vd.leaves_only) ref.leaves_only = true
     schema['x-pennsieve-concept-valueset'] = ref
   } else {
-    schema.type = schema.type || 'string'
-    schema.enum = vd.members.map((m) => m.code)
+    target.type = target.type || 'string'
+    target.enum = vd.members.map((m) => m.code)
     schema['x-pennsieve-concept-values'] = vd.members
   }
 }

--- a/src/components/datasets/metadata/records/RecordSpecGenerator.vue
+++ b/src/components/datasets/metadata/records/RecordSpecGenerator.vue
@@ -478,13 +478,19 @@ const updateRecord = async () => {
 // A required CDE binding whose value set was too large to inline (or has no
 // published values) carries `x-pennsieve-cde-valueset` instead of an `enum`.
 // Surface it so the field reads as controlled-by-a-CDE rather than free-form.
-const cdeValueSet = (property) => property?.property?.['x-pennsieve-cde-valueset'] || null
+// For array-typed properties the value-set annotations/enum may sit on `items`.
+const cdeValueSet = (property) =>
+  property?.property?.['x-pennsieve-cde-valueset'] ||
+  property?.property?.items?.['x-pennsieve-cde-valueset'] ||
+  null
 
 // An over-cap ontology value set carries `x-pennsieve-concept-valueset` (tier:"subtree",
 // with `ontology` + `root`) instead of an enum. It's browsable/searchable, so the field
 // becomes a subtree-restricted remote search rather than a plain text box.
 const conceptValueSet = (property) => {
-  const vs = property?.property?.['x-pennsieve-concept-valueset']
+  const vs =
+    property?.property?.['x-pennsieve-concept-valueset'] ||
+    property?.property?.items?.['x-pennsieve-concept-valueset']
   return vs && vs.ontology && vs.root ? vs : null
 }
 
@@ -503,6 +509,8 @@ const enumOptionLabels = (property) => {
   const vals =
     property?.property?.['x-pennsieve-concept-values'] ||
     property?.property?.['x-pennsieve-cde-values'] ||
+    property?.property?.items?.['x-pennsieve-concept-values'] ||
+    property?.property?.items?.['x-pennsieve-cde-values'] ||
     []
   const map = {}
   for (const v of vals) {
@@ -546,15 +554,21 @@ const runSubtreeSearch = async (key, vs, query) => {
 
 const renderSubtreeSelect = (property, vs) => {
   const { key } = property
-  const current = formData.value[key]
+  // Array-typed properties take multiple codes from the same value set.
+  const isMulti = property.type === 'array'
+  const raw = formData.value[key]
+  const currentCodes = Array.isArray(raw) ? raw : raw != null && raw !== '' ? [raw] : []
   const opts = subtreeOptions.value[key] || []
-  // Always keep the current value selectable so its label shows even before searching.
+  // Always keep the current value(s) selectable so their labels show even before searching.
   const merged = [...opts]
-  if (current != null && current !== '' && !merged.some((o) => o.code === current)) {
-    merged.unshift({ code: current, label: subtreeValueLabels.value[current] || current })
+  for (const code of currentCodes) {
+    if (!merged.some((o) => o.code === code)) {
+      merged.unshift({ code, label: subtreeValueLabels.value[code] || code })
+    }
   }
   return h(ElSelect, {
-    modelValue: current,
+    modelValue: isMulti ? currentCodes : raw,
+    multiple: isMulti,
     'onUpdate:modelValue': (value) => {
       formData.value[key] = value
       if (nullKeyFields.value[key]) nullKeyFields.value[key] = false
@@ -580,13 +594,21 @@ const renderFormFieldInput = (property) => {
     return renderSubtreeSelect(property, conceptVs)
   }
 
-  if (enumValues && enumValues.length > 0) {
+  // Arrays of enum items (e.g. multi-value coded fields) carry the enum on `items`.
+  const itemsEnum = type === 'array' ? property.property?.items?.enum : null
+  const effectiveEnum = enumValues && enumValues.length > 0 ? enumValues : itemsEnum
+
+  if (effectiveEnum && effectiveEnum.length > 0) {
     // Enum stores codes; show human labels when a values annotation carries them
     // (CDE-materialized or ontology value domains), so the dropdown reads
     // "type 2 diabetes mellitus" while the record stores "MONDO:0005148".
+    const isMulti = type === 'array'
     const labels = enumOptionLabels(property)
     return h(ElSelect, {
-      modelValue: formData.value[key],
+      modelValue: isMulti
+        ? (Array.isArray(formData.value[key]) ? formData.value[key] : [])
+        : formData.value[key],
+      multiple: isMulti,
       'onUpdate:modelValue': (value) => {
         formData.value[key] = value
         // If user selects a value, uncheck the null checkbox
@@ -598,7 +620,7 @@ const renderFormFieldInput = (property) => {
       clearable: true,
       filterable: true,
       size: 'default'
-    }, () => enumValues.map(option =>
+    }, () => effectiveEnum.map(option =>
       h(ElOption, { key: option, label: labels[option] || option, value: option })
     ))
   }
@@ -1046,11 +1068,30 @@ const cleanSchemaForValidation = (schema) => {
     return cleaned
   }
   
+  // Some models (built before the PropertyForm fix) carry a value-set enum on an
+  // array property itself; JSON Schema applies enum to the whole array value, so
+  // every record fails with "must be equal to one of the allowed values". Move
+  // the enum onto items, where it was always meant to apply.
+  const fixArrayEnums = (obj) => {
+    if (!obj || typeof obj !== 'object') return obj
+    if (Array.isArray(obj)) return obj.map(fixArrayEnums)
+
+    const processed = {}
+    for (const [key, value] of Object.entries(obj)) {
+      processed[key] = typeof value === 'object' && value !== null ? fixArrayEnums(value) : value
+    }
+    if (processed.type === 'array' && Array.isArray(processed.enum)) {
+      processed.items = { ...(processed.items || {}), enum: processed.enum }
+      delete processed.enum
+    }
+    return processed
+  }
+
   // First add x-pennsieve-key properties to required arrays
   const schemaWithPennsieveKeys = addPennsieveKeysToRequired(cleanedSchema)
-  
+
   // Then remove problematic references
-  return removeRefs(schemaWithPennsieveKeys)
+  return fixArrayEnums(removeRefs(schemaWithPennsieveKeys))
 }
 
 // Validation helper functions


### PR DESCRIPTION
Cherry-pick from `feat/ontology-dataset-tags` (epic PR #772). Follow-up to #777.

## Changes
Array properties bound to a value set were unusable in the create/update record form: the input rendered as a single dropdown storing a scalar ("must be array"), and the generated model schema put the value-set enum on the property itself, so JSON Schema checked the whole array against scalar codes ("must be equal to one of the allowed values").

- Record form: subtree and inline-enum selects render as multi-selects for array-typed properties, binding a real array of codes; value-set detection also reads annotations/enum from `items`
- PropertyForm: `applyValueDomain` targets `items` for array properties (enum/format per item; `x-pennsieve-*` annotations stay on the property)
- `cleanSchemaForValidation` normalizes already-saved models with the broken property-level enum shape before ajv compiles them, so existing models validate without re-editing

## Testing
Verified locally against a model with an array MONDO value-set property — multi-select, array payload, validation passing on create and update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)