### PR TITLE
feat(ontology-browser): ontologies vs termsets, registry-driven metadata, termset value sets

### DIFF
--- a/src/components/bf-navigation/BfNavigation.vue
+++ b/src/components/bf-navigation/BfNavigation.vue
@@ -158,6 +158,19 @@
       </bf-navigation-item>
 
       <bf-navigation-item
+        v-if="!(pageNotFound || isWelcomeOrg) && !isWorkspaceGuest"
+        id="nav-resources"
+        :link="{ name: 'workspace-resources', params: { orgId: activeOrganizationId } }"
+        label="Resources"
+        :condensed="primaryNavCondensed"
+        :styleColor="navStyleColor"
+      >
+        <template v-slot:icon>
+          <IconCollection :width="20" :height="20" color="currentColor" />
+        </template>
+      </bf-navigation-item>
+
+      <bf-navigation-item
         v-if="hasAdminRights && !pageNotFound && !isWorkspaceGuest"
         :link="{ name: 'workspace-settings-overview', params: { orgId: activeOrganizationId } }"
         label="Settings"
@@ -204,6 +217,7 @@ import IconPublic from "../icons/IconPublic.vue";
 import IconSPARCLogo from "../icons/IconSPARCLogo.vue";
 import IconI3HLogo from "../icons/IconI3HLogo.vue";
 import IconHealInitiative from "../icons/IconHealInitiative.vue";
+import IconCollection from "../icons/IconCollection.vue";
 import CustomTheme from "../../mixins/custom-theme";
 
 export default {
@@ -239,6 +253,7 @@ export default {
     IconTeam,
     IconIntegrations,
     IconHealInitiative,
+    IconCollection,
   },
   mixins: [CustomTheme],
 

--- a/src/components/datasets/metadata/models/CdeGallery.vue
+++ b/src/components/datasets/metadata/models/CdeGallery.vue
@@ -1,5 +1,16 @@
 <template>
   <bf-stage>
+    <template #actions>
+      <stage-actions>
+        <template #left>
+          <a class="back-to-resources-link" @click="goBackToResources">
+            <IconArrowLeft :height="12" :width="12" />
+            Resources
+          </a>
+        </template>
+      </stage-actions>
+    </template>
+
     <div class="cde-gallery">
       <div class="cg-head">
         <h2>CDE Catalog</h2>
@@ -235,12 +246,24 @@
 
 <script setup>
 import { ref, reactive, computed, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import { Search } from '@element-plus/icons-vue'
 import debounce from 'lodash.debounce'
 import { useCdeCatalogStore } from '@/stores/cdeCatalogStore'
 import CdeFacets from './CdeFacets.vue'
+import StageActions from '@/components/shared/StageActions/StageActions.vue'
+import IconArrowLeft from '@/components/icons/IconArrowLeft.vue'
 
 const store = useCdeCatalogStore()
+
+const router = useRouter()
+const route = useRoute()
+
+// Reachable from MyWorkspace and org workspaces — back within the same context.
+const goBackToResources = () => {
+  const orgId = route.params.orgId
+  router.push(orgId ? { name: 'workspace-resources', params: { orgId } } : { name: 'resources' })
+}
 
 const term = ref('')
 const facets = ref({ disease: [], domain: [], tier: [] }) // multi-select facet state
@@ -402,10 +425,25 @@ onMounted(async () => {
 <style scoped lang="scss">
 @use '../../../../styles/theme' as theme;
 
+.back-to-resources-link {
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+  gap: 4px;
+  color: theme.$purple_3;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 .cde-gallery {
   min-height: 500px;
-  /* bf-stage gives only 8px top vs 32px sides; add 24px so the top inset matches. */
-  padding-top: 24px;
+  /* The stage-actions bar (back link) above already provides the top inset. */
+  padding-top: 0;
 }
 .cg-head h2 {
   font-size: 20px;

--- a/src/components/datasets/metadata/models/ModelSpecViewer.vue
+++ b/src/components/datasets/metadata/models/ModelSpecViewer.vue
@@ -23,6 +23,7 @@ import IconPencil from "@/components/icons/IconPencil.vue";
 import IconAddTemplate from "@/components/icons/IconAddTemplate.vue";
 import IconPlus from "@/components/icons/IconPlus.vue";
 import IconTrash from "@/components/icons/IconTrash.vue";
+import IconArrowLeft from "@/components/icons/IconArrowLeft.vue";
 
 const props = defineProps({
   datasetId: {
@@ -100,6 +101,19 @@ const templateData = ref()
 
 // Computed to determine if we're viewing a template
 const isTemplate = computed(() => props.isTemplate || !!props.templateId)
+
+// Back link to the list this detail page belongs to
+const backLinkLabel = computed(() => (isTemplate.value ? 'Template Gallery' : 'Models'))
+
+const goBackToList = () => {
+  router.push({
+    name: isTemplate.value ? 'new-model-from-template' : 'models-list',
+    params: {
+      orgId: router.currentRoute.value.params.orgId,
+      datasetId: router.currentRoute.value.params.datasetId
+    }
+  })
+}
 
 // Use composablesOKay
 const {
@@ -874,6 +888,11 @@ const PropertyTree = defineComponent({
     <template v-if="!hideSelector" #actions>
       <stage-actions>
         <template #left>
+          <a class="back-to-list-link" @click="goBackToList">
+            <IconArrowLeft :height="12" :width="12" />
+            {{ backLinkLabel }}
+          </a>
+
           <!-- Version selector -->
           <div v-if="!hideSelector" class="version-controls">
             <!-- Model version selector -->
@@ -1685,28 +1704,38 @@ const PropertyTree = defineComponent({
   }
 }
 
+.back-to-list-link {
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+  gap: 4px;
+  margin-right: 16px;
+  color: theme.$purple_3;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 // Version controls styling
 .version-controls {
   display: flex;
   align-items: center;
+  align-self: center;
   gap: 12px;
   
   .version-dropdown {
     width: 160px;
-    height: 32px;
-    
-    :deep(.el-input__wrapper) {
-      height: 32px;
+
+    // Element Plus 2.5+ select renders .el-select__wrapper (no .el-input__*)
+    :deep(.el-select__wrapper) {
+      min-height: 32px;
       border-radius: 4px;
-      border: 1px solid theme.$gray_2;
       background-color: theme.$white;
-    }
-    
-    :deep(.el-input__inner) {
-      height: 32px;
-      line-height: 32px;
       font-size: 14px;
-      color: theme.$gray_6;
     }
   }
 }

--- a/src/components/datasets/metadata/models/OntologyBrowser.vue
+++ b/src/components/datasets/metadata/models/OntologyBrowser.vue
@@ -300,6 +300,7 @@ const defaultExpandedKeys = computed(() => []) // top level is loaded directly; 
 // Plain-language descriptions so users don't need to know the acronyms.
 const ONTOLOGY_META = {
   MONDO: { title: 'Diseases & disorders', desc: 'Harmonized disease definitions merged from many disease resources.' },
+  EPSO: { title: 'Epilepsy & seizures', desc: 'Epilepsy-specific terms — seizure types, syndromes, and ILAE classification.' },
   HPO: { title: 'Phenotypes & signs', desc: 'Human phenotypic abnormalities — symptoms and clinical findings.' },
   UBERON: { title: 'Anatomy', desc: 'Anatomical structures across species — organs, tissues, body parts.' },
   CL: { title: 'Cell types', desc: 'Types of cells across organisms — neurons, glia, immune cells, and more.' },
@@ -328,7 +329,7 @@ const releaseTitle = (o) => {
 
 // Preferred card order (and default landing = first). Anything not listed sorts
 // after, alphabetically. UCUM is a flat unit list — not a browsable tree.
-const ONTOLOGY_ORDER = ['MONDO', 'HPO', 'UBERON', 'CL', 'NCBITaxon', 'CHEBI', 'NCIT']
+const ONTOLOGY_ORDER = ['MONDO', 'EPSO', 'HPO', 'UBERON', 'CL', 'NCBITaxon', 'CHEBI', 'NCIT']
 const browsableOntologies = computed(() => {
   const rank = (o) => {
     const i = ONTOLOGY_ORDER.indexOf(o.ontology)

--- a/src/components/datasets/metadata/models/OntologyBrowser.vue
+++ b/src/components/datasets/metadata/models/OntologyBrowser.vue
@@ -1,5 +1,16 @@
 <template>
   <bf-stage>
+    <template #actions>
+      <stage-actions>
+        <template #left>
+          <a class="back-to-resources-link" @click="goBackToResources">
+            <IconArrowLeft :height="12" :width="12" />
+            Resources
+          </a>
+        </template>
+      </stage-actions>
+    </template>
+
     <div class="ontology-browser">
       <div class="ob-head">
         <div class="ob-title-row">
@@ -252,11 +263,23 @@
 
 <script setup>
 import { ref, reactive, computed, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import { Search, Check, PriceTag, Collection, QuestionFilled, InfoFilled, Calendar, List } from '@element-plus/icons-vue'
 import debounce from 'lodash.debounce'
 import { useOntologyStore } from '@/stores/ontologyStore'
+import StageActions from '@/components/shared/StageActions/StageActions.vue'
+import IconArrowLeft from '@/components/icons/IconArrowLeft.vue'
 
 const store = useOntologyStore()
+
+const router = useRouter()
+const route = useRoute()
+
+// Reachable from MyWorkspace and org workspaces — back within the same context.
+const goBackToResources = () => {
+  const orgId = route.params.orgId
+  router.push(orgId ? { name: 'workspace-resources', params: { orgId } } : { name: 'resources' })
+}
 
 const CHILD_DISPLAY_CAP = 60 // chips in the drawer "narrower terms" list
 
@@ -509,10 +532,25 @@ onMounted(async () => {
 <style scoped lang="scss">
 @use '../../../../styles/theme' as theme;
 
+.back-to-resources-link {
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+  gap: 4px;
+  color: theme.$purple_3;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 .ontology-browser {
   min-height: 500px;
-  /* bf-stage gives only 8px top vs 32px sides; add 24px so the top inset matches. */
-  padding-top: 24px;
+  /* The stage-actions bar (back link) above already provides the top inset. */
+  padding-top: 0;
 }
 .ob-title-row {
   display: flex;

--- a/src/components/datasets/metadata/models/OntologyBrowser.vue
+++ b/src/components/datasets/metadata/models/OntologyBrowser.vue
@@ -38,6 +38,12 @@
                   property in a metadata model — so records are filled in with consistent, standardized
                   codes.</p>
               </div>
+              <div class="ob-help-item">
+                <div class="ob-help-h"><el-icon><Collection /></el-icon> Ontologies vs. termsets</div>
+                <p>An <strong>ontology</strong> is a full source vocabulary (MONDO, UBERON…). A
+                  <strong>termset</strong> is a curated list for a specific project or consortium
+                  (e.g. SPARC, REJOIN) that pulls terms from several ontologies.</p>
+              </div>
               <p class="ob-help-note">Pennsieve refreshes these vocabularies from their sources
                 quarterly — each card shows the version it's on.</p>
             </div>
@@ -50,29 +56,66 @@
         </p>
       </div>
 
-      <!-- Vocabulary chooser -->
+      <!-- Vocabulary chooser: a kind filter above one horizontal-scrolling row -->
       <div v-if="booting" class="ob-status">Loading vocabularies…</div>
-      <div v-else class="ob-onto-cards">
-        <button
-          v-for="o in browsableOntologies"
-          :key="o.ontology"
-          type="button"
-          class="ob-onto-card"
-          :class="{ 'is-active': o.ontology === selectedOntology }"
-          @click="selectOntology(o.ontology)"
-        >
-          <span class="ob-onto-card-top">
-            <span class="ob-onto-code">{{ o.ontology }}</span>
-            <el-icon v-if="o.ontology === selectedOntology" class="ob-onto-check"><Check /></el-icon>
-          </span>
-          <span class="ob-onto-title">{{ ontologyMeta(o.ontology).title }}</span>
-          <span class="ob-onto-desc">{{ ontologyMeta(o.ontology).desc }}</span>
-          <span class="ob-onto-meta">
-            <span class="ob-onto-count"><el-icon><List /></el-icon>{{ formatCount(o.count) }} terms</span>
-            <span class="ob-onto-rel" :title="releaseTitle(o)"><el-icon><Calendar /></el-icon>{{ releaseDate(o) }}</span>
-          </span>
-        </button>
-      </div>
+      <template v-else>
+        <div v-if="hasTermsets" class="ob-onto-filter" role="tablist" aria-label="Filter vocabularies by kind">
+          <button
+            v-for="f in kindFilters"
+            :key="f.key"
+            type="button"
+            role="tab"
+            :aria-selected="kindFilter === f.key"
+            class="ob-onto-filter-btn"
+            :class="{ 'is-active': kindFilter === f.key }"
+            @click="kindFilter = f.key"
+          >
+            {{ f.label }}<span class="ob-onto-filter-count">{{ f.count }}</span>
+          </button>
+        </div>
+        <div class="ob-onto-row-wrap">
+          <button
+            v-if="canScrollLeft"
+            type="button"
+            class="ob-onto-arrow ob-onto-arrow-left"
+            aria-label="Scroll left"
+            @click="scrollByCards(-1)"
+          >
+            <el-icon><ArrowLeft /></el-icon>
+          </button>
+          <div class="ob-onto-row" ref="rowEl" :style="fadeStyle" @scroll="updateScroll">
+          <button
+            v-for="o in filteredOntologies"
+            :key="o.ontology"
+            type="button"
+            class="ob-onto-card"
+            :class="{ 'is-active': o.ontology === selectedOntology, 'is-termset': o.kind === 'termset' }"
+            @click="selectOntology(o.ontology)"
+          >
+            <span class="ob-onto-card-top">
+              <span v-if="o.kind === 'termset'" class="ob-onto-badge">Termset</span>
+              <span v-else class="ob-onto-code">{{ o.ontology }}</span>
+              <el-icon v-if="o.ontology === selectedOntology" class="ob-onto-check"><Check /></el-icon>
+            </span>
+            <span class="ob-onto-title">{{ metaTitle(o) }}</span>
+            <span class="ob-onto-desc">{{ metaDesc(o) }}</span>
+            <span class="ob-onto-meta">
+              <span class="ob-onto-count"><el-icon><List /></el-icon>{{ formatCount(o.count) }} terms</span>
+              <span class="ob-onto-rel" :title="releaseTitle(o)"><el-icon><Calendar /></el-icon>{{ releaseDate(o) }}</span>
+            </span>
+          </button>
+          </div>
+          <button
+            v-if="canScrollRight"
+            type="button"
+            class="ob-onto-arrow ob-onto-arrow-right"
+            aria-label="Scroll right"
+            @click="scrollByCards(1)"
+          >
+            <el-icon><ArrowRight /></el-icon>
+          </button>
+        </div>
+      </template>
 
       <div v-if="!booting && browsableOntologies.length" class="ob-request-row">
         <el-popover placement="top-start" :width="240" trigger="hover" popper-class="ob-help-popper">
@@ -262,9 +305,9 @@
 </template>
 
 <script setup>
-import { ref, reactive, computed, onMounted } from 'vue'
+import { ref, reactive, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
-import { Search, Check, PriceTag, Collection, QuestionFilled, InfoFilled, Calendar, List } from '@element-plus/icons-vue'
+import { Search, Check, PriceTag, Collection, QuestionFilled, InfoFilled, Calendar, List, ArrowLeft, ArrowRight } from '@element-plus/icons-vue'
 import debounce from 'lodash.debounce'
 import { useOntologyStore } from '@/stores/ontologyStore'
 import StageActions from '@/components/shared/StageActions/StageActions.vue'
@@ -333,6 +376,10 @@ const ONTOLOGY_META = {
   UCUM: { title: 'Units of measure', desc: 'Standard units for measurements.' },
 }
 const ontologyMeta = (name) => ONTOLOGY_META[name] || { title: name, desc: '' }
+// Prefer the registry's own name/summary (sources.json now carries display_name +
+// summary); fall back to the curated ONTOLOGY_META for any entry that predates it.
+const metaTitle = (o) => o.display_name || ontologyMeta(o.ontology).title
+const metaDesc = (o) => o.summary || ontologyMeta(o.ontology).desc
 const formatCount = (n) => Number(n || 0).toLocaleString()
 
 // The upstream release date is embedded in most ontology_version strings
@@ -363,6 +410,58 @@ const browsableOntologies = computed(() => {
     .slice()
     .sort((a, b) => rank(a) - rank(b) || a.ontology.localeCompare(b.ontology))
 })
+// Split the chooser into two sections so ontologies and termsets read as distinct
+// kinds. Core = anything not explicitly a termset (covers entries with no kind).
+const coreOntologies = computed(() => browsableOntologies.value.filter((o) => o.kind !== 'termset'))
+const termsets = computed(() => browsableOntologies.value.filter((o) => o.kind === 'termset'))
+const hasTermsets = computed(() => termsets.value.length > 0)
+// One scrollable row, narrowed by a kind filter (All / Ontologies / Termsets).
+const kindFilter = ref('all')
+const kindFilters = computed(() => [
+  { key: 'all', label: 'All', count: browsableOntologies.value.length },
+  { key: 'core', label: 'Ontologies', count: coreOntologies.value.length },
+  { key: 'termset', label: 'Termsets', count: termsets.value.length },
+])
+const filteredOntologies = computed(() => {
+  if (kindFilter.value === 'core') return coreOntologies.value
+  if (kindFilter.value === 'termset') return termsets.value
+  return browsableOntologies.value
+})
+
+// Horizontal-scroll affordance for the vocabulary row: fade the scrollable edges
+// and show a scroll arrow on each side, only when there's overflow in that
+// direction. The fade is a mask (background-agnostic), toggled with the arrows.
+const rowEl = ref(null)
+const canScrollLeft = ref(false)
+const canScrollRight = ref(false)
+const FADE = '36px'
+const fadeStyle = computed(() => {
+  const l = canScrollLeft.value
+  const r = canScrollRight.value
+  let mask = 'none'
+  if (l && r) mask = `linear-gradient(to right, transparent 0, #000 ${FADE}, #000 calc(100% - ${FADE}), transparent 100%)`
+  else if (r) mask = `linear-gradient(to right, #000 calc(100% - ${FADE}), transparent 100%)`
+  else if (l) mask = `linear-gradient(to right, transparent 0, #000 ${FADE})`
+  return { maskImage: mask, WebkitMaskImage: mask }
+})
+const updateScroll = () => {
+  const el = rowEl.value
+  if (!el) return
+  canScrollLeft.value = el.scrollLeft > 1
+  canScrollRight.value = el.scrollLeft + el.clientWidth < el.scrollWidth - 1
+}
+const scrollByCards = (dir) => {
+  const el = rowEl.value
+  if (!el) return
+  el.scrollBy({ left: dir * Math.max(el.clientWidth * 0.8, 292), behavior: 'smooth' })
+}
+// Recompute when the list changes (filter/data load) and on viewport resize.
+watch([filteredOntologies, booting], () => nextTick(updateScroll))
+onMounted(() => {
+  window.addEventListener('resize', updateScroll)
+  nextTick(updateScroll)
+})
+onBeforeUnmount(() => window.removeEventListener('resize', updateScroll))
 const focusableSel = computed(() => sel.curie && (!focus.value || focus.value.curie !== sel.curie))
 const synonymList = computed(() =>
   String(sel.synonyms || '')
@@ -589,29 +688,116 @@ onMounted(async () => {
     font-size: 12px;
   }
 }
-/* Vocabulary chooser — a row of selectable cards */
-.ob-onto-cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 12px;
-  margin-bottom: 24px;
-  max-width: 940px;
+/* Vocabulary chooser — a kind filter above one horizontal-scrolling row */
+.ob-onto-filter {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 12px;
 }
+.ob-onto-filter-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: theme.$gray_5;
+  background: theme.$white;
+  border: 1px solid theme.$gray_2;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+  &:hover {
+    border-color: theme.$purple_0_7;
+  }
+  &.is-active {
+    color: theme.$purple_2;
+    background: theme.$purple_tint;
+    border-color: theme.$purple_2;
+  }
+}
+.ob-onto-filter-count {
+  font-size: 11px;
+  color: theme.$gray_4;
+}
+.ob-onto-filter-btn.is-active .ob-onto-filter-count {
+  color: theme.$purple_2;
+}
+.ob-onto-row-wrap {
+  position: relative;
+  margin-bottom: 24px;
+}
+.ob-onto-row {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  /* overflow-x:auto forces overflow-y:auto, which would clip the cards' hover
+     shadow — pad the scrollport so it isn't cut off. */
+  padding: 4px 0 10px;
+}
+/* Scroll affordance: an arrow on each side, shown only when scrollable that way. */
+.ob-onto-arrow {
+  position: absolute;
+  top: calc(50% - 3px);
+  transform: translateY(-50%);
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: theme.$white;
+  border: 1px solid theme.$gray_2;
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  color: theme.$gray_6;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+  &:hover {
+    border-color: theme.$purple_0_7;
+    color: theme.$purple_2;
+  }
+  .el-icon {
+    font-size: 16px;
+  }
+}
+.ob-onto-arrow-left {
+  left: -8px;
+}
+.ob-onto-arrow-right {
+  right: -8px;
+}
+/* Termset badge — distinguishes a curated list from a full ontology */
+.ob-onto-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 18px;
+  color: theme.$teal_2;
+  background: theme.$teal_tint;
+  border: 1px solid theme.$teal_1;
+  border-radius: 4px;
+  padding: 0 7px;
+}
+
 .ob-onto-card {
+  flex: 0 0 auto;
+  width: 280px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
   text-align: left;
-  padding: 14px 16px;
+  padding: 16px 18px;
   background: theme.$white;
   border: 1px solid theme.$gray_2;
   border-radius: 8px;
   cursor: pointer;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease, background 0.15s ease;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
   &:hover {
     border-color: theme.$purple_0_7;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
-    transform: translateY(-1px);
   }
   &.is-active {
     border-color: theme.$purple_2;
@@ -645,6 +831,11 @@ onMounted(async () => {
   color: theme.$gray_5;
   line-height: 1.4;
   min-height: 4.2em; /* reserve 3 lines so the meta row aligns across cards */
+  display: -webkit-box;
+  -webkit-line-clamp: 3; /* truncate longer summaries with an ellipsis */
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 .ob-onto-meta {
   display: flex;

--- a/src/components/datasets/metadata/models/OntologyTreePicker.vue
+++ b/src/components/datasets/metadata/models/OntologyTreePicker.vue
@@ -33,7 +33,7 @@
             <li
               v-for="r in results"
               :key="r.curie"
-              :class="{ active: selected && selected.curie === r.curie }"
+              :class="{ active: isPicked(r.curie) }"
               @click="pick(r)"
             >
               <span class="otp-label">{{ r.label }}</span>
@@ -57,7 +57,7 @@
           @node-click="pick"
         >
           <template #default="{ data }">
-            <span class="otp-node" :class="{ active: selected && selected.curie === data.curie }">
+            <span class="otp-node" :class="{ active: isPicked(data.curie) }">
               <span class="otp-label">{{ data.label }}</span>
               <span class="otp-code">{{ data.curie }}</span>
             </span>
@@ -68,13 +68,30 @@
 
     <template #footer>
       <div class="otp-footer">
-        <span v-if="selected" class="otp-selected">
-          Selected: <strong>{{ selected.label }}</strong> <span class="otp-code">{{ selected.curie }}</span>
-        </span>
-        <span v-else class="otp-selected otp-muted">Pick a term to use as the value-set root.</span>
-        <span class="otp-spacer" />
-        <el-button @click="$emit('update:modelValue', false)">Cancel</el-button>
-        <el-button type="primary" :disabled="!selected" @click="confirm">Use this term</el-button>
+        <div v-if="picked.length" class="otp-picked">
+          <el-tag
+            v-for="p in visiblePicked"
+            :key="p.curie"
+            closable
+            size="small"
+            disable-transitions
+            @close="unpick(p.curie)"
+          >{{ p.label }}</el-tag>
+          <el-tag v-if="hiddenPicked" size="small" type="info" disable-transitions :title="hiddenLabels">
+            +{{ hiddenPicked }} more
+          </el-tag>
+        </div>
+        <p v-else class="otp-picked-hint">
+          {{ isTermset ? 'Pick one or more terms, or use the entire termset.' : 'Pick one or more terms for the value set.' }}
+        </p>
+        <div class="otp-actions">
+          <el-button @click="$emit('update:modelValue', false)">Cancel</el-button>
+          <el-button v-if="isTermset" @click="useTermset">Use entire termset</el-button>
+          <el-button v-if="picked.length === 1" @click="useSubtreeRoot">Use subtree of this term</el-button>
+          <el-button type="primary" :disabled="!picked.length" @click="useSelected">
+            Use {{ picked.length ? picked.length + ' ' : '' }}selected term{{ picked.length === 1 ? '' : 's' }}
+          </el-button>
+        </div>
       </div>
     </template>
   </el-dialog>
@@ -94,11 +111,23 @@ const store = useOntologyStore()
 // UCUM is a flat unit list — not a browsable tree.
 const options = computed(() => (store.available || []).filter((o) => o.ontology !== 'UCUM'))
 const scope = ref('')
+// The chosen vocabulary's registry entry. A termset (kind:'termset') is a curated
+// flat list, so the whole set can be used as a value set (no single root term).
+const scopeEntry = computed(() => (store.available || []).find((o) => o.ontology === scope.value) || null)
+const isTermset = computed(() => scopeEntry.value?.kind === 'termset')
 const loading = ref(false)
 const term = ref('')
 const results = ref([])
 const searching = ref(false)
-const selected = ref(null)
+// Multi-pick: clicking a term toggles it into `picked`. Picks persist across scope
+// changes so a value set can be composed from several ontologies/termsets.
+const picked = ref([])
+const isPicked = (curie) => picked.value.some((p) => p.curie === curie)
+// Cap the chips shown in the footer; the rest collapse into a "+N more" tag.
+const MAX_CHIPS = 10
+const visiblePicked = computed(() => picked.value.slice(0, MAX_CHIPS))
+const hiddenPicked = computed(() => Math.max(0, picked.value.length - MAX_CHIPS))
+const hiddenLabels = computed(() => picked.value.slice(MAX_CHIPS).map((p) => p.label).join(', '))
 
 const treeProps = { label: 'label', children: 'children', isLeaf: (d) => !d.has_children }
 // Terms in a slice share the ontology's version (the tree rows don't carry it).
@@ -116,7 +145,7 @@ const loadOntology = async () => {
 }
 
 const onOpen = async () => {
-  selected.value = null
+  picked.value = []
   term.value = ''
   results.value = []
   loading.value = true
@@ -132,7 +161,7 @@ const onOpen = async () => {
 }
 
 const onScopeChange = async () => {
-  selected.value = null
+  // Keep picks when switching ontology so a set can span vocabularies.
   term.value = ''
   results.value = []
   await loadOntology()
@@ -162,14 +191,43 @@ const onSearch = debounce(async () => {
   }
 }, 250)
 
+// Toggle a term in/out of the picked set.
 const pick = (node) => {
   if (!node || !node.curie) return
-  selected.value = { curie: node.curie, label: node.label, ontology: scope.value, ontology_version: scopeVersion() }
+  const i = picked.value.findIndex((p) => p.curie === node.curie)
+  if (i >= 0) picked.value.splice(i, 1)
+  else picked.value.push({ curie: node.curie, label: node.label, ontology: scope.value, ontology_version: scopeVersion() })
+}
+const unpick = (curie) => {
+  picked.value = picked.value.filter((p) => p.curie !== curie)
 }
 
-const confirm = () => {
-  if (!selected.value) return
-  emit('select', { ...selected.value })
+// Use the picked terms as the value set (exactly those terms, materialized).
+const useSelected = () => {
+  if (!picked.value.length) return
+  emit('select', { terms: picked.value.map((p) => ({ ...p })) })
+  emit('update:modelValue', false)
+}
+
+// One term picked: offer its is_a subtree instead of just the single term.
+const useSubtreeRoot = () => {
+  if (picked.value.length !== 1) return
+  emit('select', { ...picked.value[0] })
+  emit('update:modelValue', false)
+}
+
+// Use the entire termset as the value set (all members), not a single term's subtree.
+const useTermset = () => {
+  const e = scopeEntry.value
+  if (!e) return
+  emit('select', {
+    termset: true,
+    ontology: e.ontology,
+    slug: e.slug,
+    label: e.display_name || e.ontology,
+    count: e.count,
+    ontology_version: e.ontology_version || '',
+  })
   emit('update:modelValue', false)
 }
 </script>
@@ -238,17 +296,23 @@ const confirm = () => {
 }
 .otp-footer {
   display: flex;
-  align-items: center;
-  gap: 12px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
 }
-.otp-selected {
+.otp-picked {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.otp-picked-hint {
+  margin: 0;
   font-size: 13px;
-  color: theme.$gray_6;
-}
-.otp-muted {
   color: theme.$gray_4;
 }
-.otp-spacer {
-  flex: 1;
+.otp-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
 }
 </style>

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -294,8 +294,8 @@
         <div class="pf-section-title">Data values</div>
         <el-form label-position="top">
           <el-form-item label="Allowed values">
-            <!-- Type a list, or fill from an ontology term's subtree. -->
-            <template v-if="!subtreeRoot">
+            <!-- Type a list, or fill from an ontology term's subtree / a whole termset / picked terms. -->
+            <template v-if="!subtreeRoot && !termsetSource && !selectedTerms">
               <el-input v-model="manual.enumInput" placeholder="Comma-separated, e.g. Low, Medium, High" />
               <!-- Ontology value sets are string codes, so only for Text. -->
               <template v-if="manual.type === 'string'">
@@ -323,6 +323,42 @@
                 </div>
               </template>
             </template>
+
+            <!-- Hand-picked terms: the value set is exactly these, no expansion. -->
+            <div v-else-if="selectedTerms" class="onto-subtree">
+              <div class="onto-subtree-head">
+                <span>{{ selectedTerms.length }} selected term{{ selectedTerms.length === 1 ? '' : 's' }}</span>
+                <el-button text @click="clearPickedTerms">change</el-button>
+              </div>
+              <ul v-if="subtreePreview.length" class="onto-subtree-list">
+                <li v-for="m in subtreePreview" :key="m.curie">
+                  <span class="onto-subtree-item-label">{{ m.label }}</span>
+                  <span class="onto-subtree-code">{{ m.curie }}</span>
+                </li>
+              </ul>
+            </div>
+
+            <!-- A whole termset is chosen: a flat member list, no granularity. -->
+            <div v-else-if="termsetSource" class="onto-subtree">
+              <div class="onto-subtree-head">
+                <span>Entire termset <strong>{{ termsetSource.label }}</strong></span>
+                <el-button text @click="clearTermset">change</el-button>
+              </div>
+              <div v-if="valueDomain" class="onto-subtree-count">
+                <template v-if="valueDomain.over_cap">{{ valueDomain.count != null ? valueDomain.count.toLocaleString() + ' values' : 'All members' }}</template>
+                <template v-else>{{ valueDomain.count.toLocaleString() }} value{{ valueDomain.count === 1 ? '' : 's' }}</template>
+              </div>
+              <ul v-if="subtreePreview.length" class="onto-subtree-list">
+                <li v-for="m in subtreePreview" :key="m.curie">
+                  <span class="onto-subtree-item-label">{{ m.label }}</span>
+                  <span class="onto-subtree-code">{{ m.curie }}</span>
+                </li>
+              </ul>
+              <div v-if="valueDomain && valueDomain.over_cap" class="onto-subtree-more">
+                Showing a sample — the full set is enforced by reference, not listed.
+              </div>
+              <div v-if="subtreeNote" class="wiz-hint" style="margin-top: 6px">{{ subtreeNote }}</div>
+            </div>
 
             <!-- A term is chosen: granularity + a readable preview of the members. -->
             <div v-else class="onto-subtree">
@@ -363,7 +399,7 @@
               </div>
               <div v-if="subtreeNote" class="wiz-hint" style="margin-top: 6px">{{ subtreeNote }}</div>
             </div>
-            <OntologyTreePicker v-model="pickerOpen" @select="selectSubtreeRoot" />
+            <OntologyTreePicker v-model="pickerOpen" @select="onPickerSelect" />
           </el-form-item>
           <template v-if="manual.type === 'string' && !hasControlledValues">
             <div class="wiz-two">
@@ -436,6 +472,8 @@ const ontoTerm = ref('')
 const ontoResults = ref([])
 const subtreeNote = ref('')
 const subtreeRoot = ref(null) // { curie, label, ontology, ontology_version }
+const termsetSource = ref(null) // { ontology, slug, label, ontology_version } — a whole-termset value set
+const selectedTerms = ref(null) // [{ code, label }] — a value set composed of hand-picked terms
 const subtreeDepth = ref('all') // 'all' | '1' | '2' | '3'
 const subtreeLeaves = ref(false)
 const valueDomain = ref(null) // the materialized ontology-subtree value domain (or null)
@@ -489,6 +527,8 @@ const runOntoSearch = debounce(async () => {
 const ontoMeta = (c) => (c.curie.startsWith(c.ontology + ':') ? c.curie : `${c.ontology} · ${c.curie}`)
 
 const selectSubtreeRoot = (term) => {
+  termsetSource.value = null
+  selectedTerms.value = null
   subtreeRoot.value = {
     curie: term.curie,
     label: term.label,
@@ -506,6 +546,96 @@ const clearSubtree = () => {
   subtreeNote.value = ''
   ontoTerm.value = ''
   ontoResults.value = []
+}
+
+// The picker emits a whole termset, a list of hand-picked terms, or a single
+// term (subtree root).
+const onPickerSelect = (payload) => {
+  if (payload && payload.termset) selectTermset(payload)
+  else if (payload && payload.terms) selectTerms(payload.terms)
+  else selectSubtreeRoot(payload)
+}
+
+const selectTermset = (ts) => {
+  subtreeRoot.value = null
+  selectedTerms.value = null
+  termsetSource.value = {
+    ontology: ts.ontology,
+    slug: ts.slug,
+    label: ts.label,
+    ontology_version: ts.ontology_version,
+  }
+  ontoResults.value = []
+  ontoTerm.value = ''
+  applyTermset()
+}
+const clearTermset = () => {
+  termsetSource.value = null
+  valueDomain.value = null
+  subtreePreview.value = []
+  subtreeNote.value = ''
+}
+
+// A value set composed of exactly the hand-picked terms (materialized, no subtree
+// expansion). Terms may span ontologies — the anchor ontology is left blank then.
+const selectTerms = (terms) => {
+  subtreeRoot.value = null
+  termsetSource.value = null
+  const onts = [...new Set(terms.map((t) => t.ontology).filter(Boolean))]
+  selectedTerms.value = terms.map((t) => ({ code: t.curie, label: t.label }))
+  valueDomain.value = {
+    kind: 'terms',
+    ontology: onts.length === 1 ? onts[0] : '',
+    ontology_version: onts.length === 1 ? terms[0].ontology_version || '' : '',
+    count: terms.length,
+    over_cap: false,
+    members: terms.map((t) => ({ code: t.curie, label: t.label })),
+  }
+  subtreePreview.value = terms.slice(0, PREVIEW_CAP).map((t) => ({ curie: t.curie, label: t.label }))
+  manual.enumInput = ''
+  subtreeNote.value = ''
+  ontoResults.value = []
+  ontoTerm.value = ''
+}
+const clearPickedTerms = () => {
+  selectedTerms.value = null
+  valueDomain.value = null
+  subtreePreview.value = []
+  subtreeNote.value = ''
+}
+
+// Resolve a whole termset as the value domain: a flat list of all its members
+// (no is_a walk). Under the inline cap it carries {code,label} members; over the
+// cap it's a termset REFERENCE (ontology + slug) resolved at record time.
+const applyTermset = async () => {
+  const src = termsetSource.value
+  if (!src) return
+  subtreeNote.value = 'Loading…'
+  try {
+    const { members, overCap } = await ontology.allMembers(src.ontology, { cap: SUBTREE_INLINE_CAP })
+    // The registry knows the exact total; use it for the over-cap count display.
+    const total = (ontology.available || []).find((o) => o.ontology === src.ontology)?.count ?? null
+    valueDomain.value = {
+      kind: 'termset',
+      ontology: src.ontology,
+      slug: src.slug,
+      label: src.label,
+      ontology_version: src.ontology_version,
+      count: overCap ? total : members.length,
+      over_cap: overCap,
+      members: overCap ? null : members.map((m) => ({ code: m.curie, label: m.label })),
+    }
+    subtreePreview.value = members.slice(0, PREVIEW_CAP).map((m) => ({ curie: m.curie, label: m.label }))
+    manual.enumInput = ''
+    subtreeNote.value = overCap
+      ? `More than ${SUBTREE_INLINE_CAP} values — stored as a termset reference and enforced by a ` +
+        `membership check rather than an inline list.`
+      : ''
+  } catch (e) {
+    valueDomain.value = null
+    subtreePreview.value = []
+    subtreeNote.value = 'Could not load termset: ' + (e?.message || e)
+  }
 }
 
 // Resolve the value set from the chosen root + granularity (depth / leaves-only)
@@ -563,26 +693,27 @@ const applyValueDomain = (schema, vd) => {
   // code and always fail). The x-pennsieve-* annotations stay on the property,
   // where the rest of the app reads them.
   const target = schema.type === 'array' && schema.items ? schema.items : schema
+  const isTermset = vd.kind === 'termset'
+  const isTerms = vd.kind === 'terms'
+  // The concept anchor names the value set. A termset / hand-picked set has no
+  // single root term, so its curie is blank and the label describes the set.
   schema['x-pennsieve-concept'] = {
-    curie: vd.root_curie,
-    label: vd.root_label,
-    ontology: vd.ontology,
-    ontology_version: vd.ontology_version,
+    curie: isTermset || isTerms ? '' : vd.root_curie,
+    label: isTermset ? vd.label : isTerms ? `${vd.count} selected terms` : vd.root_label,
+    ontology: vd.ontology || '',
+    ontology_version: vd.ontology_version || '',
   }
   // The values are ontology codes, not a formatted string — a date/email/uri
   // format would contradict the value set.
   delete target.format
   if (vd.over_cap) {
     delete target.enum
-    const ref = {
-      tier: 'subtree',
-      ontology: vd.ontology,
-      root: vd.root_curie,
-      ontology_version: vd.ontology_version,
-    }
+    const ref = isTermset
+      ? { tier: 'termset', ontology: vd.ontology, slug: vd.slug, ontology_version: vd.ontology_version }
+      : { tier: 'subtree', ontology: vd.ontology, root: vd.root_curie, ontology_version: vd.ontology_version }
     if (vd.count != null) ref.count = vd.count // unknown for a broad (bounded) subtree
-    if (vd.max_depth != null) ref.max_depth = vd.max_depth
-    if (vd.leaves_only) ref.leaves_only = true
+    if (!isTermset && vd.max_depth != null) ref.max_depth = vd.max_depth
+    if (!isTermset && vd.leaves_only) ref.leaves_only = true
     schema['x-pennsieve-concept-valueset'] = ref
   } else {
     target.type = target.type || 'string'

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -558,6 +558,11 @@ const applySubtree = async () => {
 // anchor always; under the cap an enum (codes) + display labels; over the cap the
 // subtree reference (membership-enforced at record write, VALSET-style).
 const applyValueDomain = (schema, vd) => {
+  // For an array property the constraint applies per item, so enum/format land
+  // on `items` (a property-level enum would require the whole array to equal one
+  // code and always fail). The x-pennsieve-* annotations stay on the property,
+  // where the rest of the app reads them.
+  const target = schema.type === 'array' && schema.items ? schema.items : schema
   schema['x-pennsieve-concept'] = {
     curie: vd.root_curie,
     label: vd.root_label,
@@ -566,9 +571,9 @@ const applyValueDomain = (schema, vd) => {
   }
   // The values are ontology codes, not a formatted string — a date/email/uri
   // format would contradict the value set.
-  delete schema.format
+  delete target.format
   if (vd.over_cap) {
-    delete schema.enum
+    delete target.enum
     const ref = {
       tier: 'subtree',
       ontology: vd.ontology,
@@ -580,8 +585,8 @@ const applyValueDomain = (schema, vd) => {
     if (vd.leaves_only) ref.leaves_only = true
     schema['x-pennsieve-concept-valueset'] = ref
   } else {
-    schema.type = schema.type || 'string'
-    schema.enum = vd.members.map((m) => m.code)
+    target.type = target.type || 'string'
+    target.enum = vd.members.map((m) => m.code)
     schema['x-pennsieve-concept-values'] = vd.members
   }
 }

--- a/src/components/datasets/metadata/models/modelList.vue
+++ b/src/components/datasets/metadata/models/modelList.vue
@@ -42,22 +42,11 @@
               </template>
             </bf-card>
           </button>
-          <button
-            @click="openCdeGallery"
-          >
-            <bf-card
-              title="CDE Catalog"
-              card-copy="Browse common data elements and bundles"
-            >
-              <template #icon>
-                <icon-collection
-                  class="card-icon"
-                  :height="48"
-                  :width="48"
-                />
-              </template>
-            </bf-card>
-          </button>
+        </div>
+
+        <div class="resources-hint">
+          Looking for reference catalogs?
+          <a @click="openResources">Browse CDEs and ontologies →</a>
         </div>
 
         <div >
@@ -127,7 +116,6 @@ import { useMetadataStore } from '@/stores/metadataStore.js'
 import IconOverview from "@/components/icons/IconOverview.vue";
 import BfCard from "@/components/shared/bf-card/BfCard.vue";
 import IconAddTemplate from "@/components/icons/IconAddTemplate.vue";
-import IconCollection from "@/components/icons/IconCollection.vue";
 import ModelListItem from "@/components/datasets/metadata/models/modelListItem.vue";
 import CreateModelWizard from "@/components/datasets/metadata/models/CreateModelWizard.vue";
 // Dynamic import to avoid circular dependency issues
@@ -198,15 +186,15 @@ const openTemplateGallery = () => {
   })
 }
 
-const openCdeGallery = () => {
+const openResources = () => {
   router.push({
-    name: 'cde-gallery',
+    name: 'workspace-resources',
     params: {
-      datasetId: props.datasetId,
       orgId: props.orgId,
     }
   })
 }
+
 
 </script>
 
@@ -233,8 +221,23 @@ const openCdeGallery = () => {
 
   .graph-management-cards {
     display: flex;
-    margin-bottom: 48px;
+    margin-bottom: 16px;
+  }
 
+  .resources-hint {
+    margin-bottom: 48px;
+    font-size: 13px;
+    color: theme.$gray_5;
+
+    a {
+      color: theme.$purple_3;
+      font-weight: 500;
+      cursor: pointer;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
 
   .gallery-link {

--- a/src/components/datasets/metadata/records/ListRecords.vue
+++ b/src/components/datasets/metadata/records/ListRecords.vue
@@ -5,7 +5,7 @@ import { ArrowDown, View, InfoFilled } from '@element-plus/icons-vue'
 import { useRouter } from 'vue-router'
 import { useMetadataStore } from '@/stores/metadataStore.js'
 import { useOntologyStore } from '@/stores/ontologyStore.js'
-import { summarizeObject } from '@/utils/objectSummary.js'
+import { summarizeObject, stripHtml } from '@/utils/objectSummary.js'
 import MultiModelFilter from '../../explore/GraphExplorer/MultiModelFilter.vue'
 import IconPlus from '@/components/icons/IconPlus.vue'
 import StageActions from "@/components/shared/StageActions/StageActions.vue";
@@ -698,11 +698,6 @@ const resolveSubtreeLabels = async () => {
 }
 
 watch([records, modelSchema], () => { resolveSubtreeLabels() })
-
-// Source text can carry literal HTML (e.g. "<br />" in NLM reference fields) —
-// strip tags for the one-line cell display.
-const stripHtml = (s) =>
-  s.includes('<') ? s.replace(/<\/?[a-z][^>]*>/gi, ' ').replace(/\s+/g, ' ').trim() : s
 
 const formatCellValue = (value, column) => {
   if (value === null || value === undefined) {

--- a/src/components/datasets/metadata/records/ListRecords.vue
+++ b/src/components/datasets/metadata/records/ListRecords.vue
@@ -368,12 +368,12 @@ const fetchModel = async () => {
     
     if (model.value?.latest_version?.schema) {
       modelSchema.value = model.value.latest_version.schema
-      // Initialize selected version based on route param or default to all versions
+      // Initialize selected version based on route param or default to latest
       if (!selectedVersion.value) {
         if (props.versionId) {
           selectedVersion.value = props.versionId
         } else {
-          selectedVersion.value = 'all'
+          selectedVersion.value = 'latest'
         }
       }
       

--- a/src/components/datasets/metadata/records/ListRecords.vue
+++ b/src/components/datasets/metadata/records/ListRecords.vue
@@ -1,10 +1,11 @@
 <script setup>
-import { ref, computed, onMounted, watch, nextTick } from 'vue'
-import { ElTable, ElTableColumn, ElCard, ElButton, ElSelect, ElOption, ElMessage, ElDropdown, ElDropdownMenu, ElDropdownItem, ElIcon, ElTag, ElDivider, ElTooltip } from 'element-plus'
+import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
+import { ElTable, ElTableColumn, ElCard, ElButton, ElSelect, ElOption, ElMessage, ElDropdown, ElDropdownMenu, ElDropdownItem, ElIcon, ElTag, ElDivider, ElTooltip, ElCheckbox } from 'element-plus'
 import { ArrowDown, View, InfoFilled } from '@element-plus/icons-vue'
 import { useRouter } from 'vue-router'
 import { useMetadataStore } from '@/stores/metadataStore.js'
 import { useOntologyStore } from '@/stores/ontologyStore.js'
+import { summarizeObject } from '@/utils/objectSummary.js'
 import MultiModelFilter from '../../explore/GraphExplorer/MultiModelFilter.vue'
 import IconPlus from '@/components/icons/IconPlus.vue'
 import StageActions from "@/components/shared/StageActions/StageActions.vue";
@@ -90,6 +91,76 @@ const tableColumns = computed(() => {
     codedTip: codedColumnTip(property)
   }))
 })
+
+// Sparse schemas (e.g. CDE models) carry many properties with no values on a
+// given page — hide those columns by default, with a toggle to show them.
+const showEmptyColumns = ref(false)
+
+const columnHasData = (column) => records.value.some(r => {
+  const v = r.value?.[column.key]
+  if (v == null || v === '') return false
+  if (Array.isArray(v)) return v.length > 0
+  if (typeof v === 'object') return Object.keys(v).length > 0
+  return true
+})
+
+const emptyColumnCount = computed(() =>
+  records.value.length ? tableColumns.value.filter(c => !columnHasData(c)).length : 0
+)
+
+const visibleColumns = computed(() =>
+  showEmptyColumns.value || !emptyColumnCount.value
+    ? tableColumns.value
+    : tableColumns.value.filter(columnHasData)
+)
+
+// --- Column resize ----------------------------------------------------------
+// Custom drag-resize via a handle element on each header cell's right edge:
+// Element Plus's built-in version only applies the new width on mouseup (and
+// requires border mode), so widths here are applied live while dragging. The
+// handle carries cursor: col-resize in CSS, so the browser resolves the hover
+// cursor natively. Widths persist by column key.
+const columnWidths = ref({})
+const MIN_COLUMN_WIDTH = 80
+
+let resizeState = null
+
+const startColumnResize = (column, e) => {
+  const th = e.target.closest('th')
+  if (!th) return
+  resizeState = {
+    key: column.key,
+    startX: e.clientX,
+    startWidth: th.getBoundingClientRect().width,
+    raf: null
+  }
+  document.body.style.cursor = 'col-resize'
+  document.body.style.userSelect = 'none'
+  document.addEventListener('mousemove', onResizing)
+  document.addEventListener('mouseup', endResize)
+}
+
+const onResizing = (e) => {
+  if (!resizeState || resizeState.raf) return
+  const { clientX } = e
+  resizeState.raf = requestAnimationFrame(() => {
+    if (!resizeState) return
+    resizeState.raf = null
+    const width = Math.max(MIN_COLUMN_WIDTH, resizeState.startWidth + (clientX - resizeState.startX))
+    columnWidths.value = { ...columnWidths.value, [resizeState.key]: width }
+  })
+}
+
+const endResize = () => {
+  if (resizeState?.raf) cancelAnimationFrame(resizeState.raf)
+  resizeState = null
+  document.body.style.cursor = ''
+  document.body.style.userSelect = ''
+  document.removeEventListener('mousemove', onResizing)
+  document.removeEventListener('mouseup', endResize)
+}
+
+onBeforeUnmount(endResize)
 
 // Describe a column's coded-value source for a header tooltip, or null if it isn't
 // backed by an ontology / CDE value set.
@@ -628,6 +699,11 @@ const resolveSubtreeLabels = async () => {
 
 watch([records, modelSchema], () => { resolveSubtreeLabels() })
 
+// Source text can carry literal HTML (e.g. "<br />" in NLM reference fields) —
+// strip tags for the one-line cell display.
+const stripHtml = (s) =>
+  s.includes('<') ? s.replace(/<\/?[a-z][^>]*>/gi, ' ').replace(/\s+/g, ' ').trim() : s
+
 const formatCellValue = (value, column) => {
   if (value === null || value === undefined) {
     return ''
@@ -665,46 +741,28 @@ const formatCellValue = (value, column) => {
     }
   }
   
-  // Handle arrays
-  if (column.type === 'array' || Array.isArray(value)) {
-    if (Array.isArray(value)) {
-      if (value.length === 0) {
-        return '[]'
+  // Handle arrays: one-line summary per item, capped at 3 items
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return ''
+    }
+    const preview = value.slice(0, 3).map(item => {
+      if (typeof item === 'object' && item !== null) {
+        return summarizeObject(item)
       }
-      // For arrays, show count and preview of first few items
-      const preview = value.slice(0, 3).map(item => {
-        if (typeof item === 'object' && item !== null) {
-          return '{...}'
-        }
-        return JSON.stringify(item)
-      }).join(', ')
-      
-      const suffix = value.length > 3 ? `, ... +${value.length - 3} more` : ''
-      return `[${preview}${suffix}]`
-    }
-    return String(value)
+      return stripHtml(String(item))
+    }).join(' · ')
+
+    const suffix = value.length > 3 ? ` · +${value.length - 3} more` : ''
+    return `${preview}${suffix}`
   }
-  
+
   // Handle objects
-  if (column.type === 'object' || (typeof value === 'object' && value !== null && !Array.isArray(value))) {
-    const keys = Object.keys(value)
-    if (keys.length === 0) {
-      return '{}'
-    }
-    // For objects, show key count and preview of first few keys
-    const preview = keys.slice(0, 2).map(key => {
-      const val = value[key]
-      const displayVal = val === null ? 'null' : 
-                        typeof val === 'object' ? '{...}' : 
-                        JSON.stringify(val)
-      return `${key}: ${displayVal}`
-    }).join(', ')
-    
-    const suffix = keys.length > 2 ? `, ... +${keys.length - 2} more` : ''
-    return `{${preview}${suffix}}`
+  if (typeof value === 'object' && value !== null) {
+    return summarizeObject(value)
   }
-  
-  return String(value)
+
+  return stripHtml(String(value))
 }
 
 // Helper function to get a record display name
@@ -943,8 +1001,15 @@ onMounted(async () => {
       <div class="records-controls">
         <div class="records-controls-left">
           <span class="records-count">{{ recordsHeading }}</span>
+          <el-checkbox
+            v-if="emptyColumnCount > 0"
+            v-model="showEmptyColumns"
+            class="empty-columns-toggle"
+          >
+            Show empty columns ({{ emptyColumnCount }})
+          </el-checkbox>
         </div>
-        
+
         <div v-if="hasNextPage || hasPreviousPage" class="pagination-controls">
           <el-button
             :disabled="!hasPreviousPage"
@@ -974,10 +1039,11 @@ onMounted(async () => {
         >
           <!-- Dynamic columns from model schema -->
           <el-table-column
-            v-for="column in tableColumns"
+            v-for="column in visibleColumns"
             :key="column.key"
             :prop="`value.${column.key}`"
             :label="column.label"
+            :width="columnWidths[column.key]"
             :min-width="120"
             show-overflow-tooltip
           >
@@ -988,6 +1054,11 @@ onMounted(async () => {
                   <el-icon class="coded-indicator"><InfoFilled /></el-icon>
                 </el-tooltip>
               </span>
+              <span
+                class="col-resize-handle"
+                @mousedown.prevent.stop="startColumnResize(column, $event)"
+                @click.stop
+              />
             </template>
             <template #default="{ row }">
               {{ formatCellValue(row.value[column.key], column) }}
@@ -1322,10 +1393,23 @@ onMounted(async () => {
       }
       
       .records-controls-left {
+        display: flex;
+        align-items: center;
+
         .records-count {
           color: theme.$gray_5;
           font-size: 14px;
           font-weight: 500;
+        }
+
+        .empty-columns-toggle {
+          margin-left: 24px;
+
+          :deep(.el-checkbox__label) {
+            color: theme.$gray_5;
+            font-size: 14px;
+            font-weight: 400;
+          }
         }
         
         .page-size-selector {
@@ -1383,20 +1467,33 @@ onMounted(async () => {
       :deep(.el-table) {
         .el-table__header {
           background-color: theme.$gray_1;
-          
+
           th {
             background-color: theme.$gray_1 !important;
             color: theme.$gray_6;
             font-weight: 600;
             border-bottom: 1px solid theme.$gray_2;
+            position: relative;
           }
         }
-        
+
+        // Drag handle on the header cell's right edge. Kept fully inside its
+        // own cell — an overhang into the neighbor gets covered by that th.
+        .col-resize-handle {
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          right: 0;
+          width: 8px;
+          cursor: col-resize;
+          z-index: 1;
+        }
+
         .el-table__row {
           &:hover {
             background-color: theme.$gray_1;
           }
-          
+
           td {
             border-bottom: 1px solid theme.$gray_2;
             color: theme.$gray_6;

--- a/src/components/datasets/metadata/records/RecordSpecGenerator.vue
+++ b/src/components/datasets/metadata/records/RecordSpecGenerator.vue
@@ -491,13 +491,20 @@ const conceptValueSet = (property) => {
   const vs =
     property?.property?.['x-pennsieve-concept-valueset'] ||
     property?.property?.items?.['x-pennsieve-concept-valueset']
-  return vs && vs.ontology && vs.root ? vs : null
+  if (!vs || !vs.ontology) return null
+  // termset tier: whole flat list (no root); subtree tier: is_a subtree of `root`.
+  if (vs.tier === 'termset' && vs.slug) return vs
+  if (vs.root) return vs
+  return null
 }
 
 const conceptValueSetHint = (property) => {
   const vs = conceptValueSet(property)
   if (!vs) return ''
   const anchor = property?.property?.['x-pennsieve-concept']
+  if (vs.tier === 'termset') {
+    return `Search the ${anchor?.label || vs.ontology} termset for a term.`
+  }
   const rootLabel = anchor?.label || vs.root
   return `Search ${vs.ontology} for a term under “${rootLabel}”.`
 }
@@ -540,7 +547,10 @@ const runSubtreeSearch = async (key, vs, query) => {
   }
   subtreeSearching.value = { ...subtreeSearching.value, [key]: true }
   try {
-    const hits = await ontologyStore.searchSubtree(vs.root, term, { ontology: vs.ontology, limit: 25 })
+    // termset tier: flat search over the whole slice; subtree tier: restricted to root's descendants.
+    const hits = vs.tier === 'termset'
+      ? await ontologyStore.search(term, { ontologies: [vs.ontology], limit: 25 })
+      : await ontologyStore.searchSubtree(vs.root, term, { ontology: vs.ontology, limit: 25 })
     subtreeOptions.value = {
       ...subtreeOptions.value,
       [key]: hits.map((h) => ({ code: h.curie, label: h.label || h.curie }))

--- a/src/components/datasets/metadata/records/RecordSpecGenerator.vue
+++ b/src/components/datasets/metadata/records/RecordSpecGenerator.vue
@@ -478,13 +478,19 @@ const updateRecord = async () => {
 // A required CDE binding whose value set was too large to inline (or has no
 // published values) carries `x-pennsieve-cde-valueset` instead of an `enum`.
 // Surface it so the field reads as controlled-by-a-CDE rather than free-form.
-const cdeValueSet = (property) => property?.property?.['x-pennsieve-cde-valueset'] || null
+// For array-typed properties the value-set annotations/enum may sit on `items`.
+const cdeValueSet = (property) =>
+  property?.property?.['x-pennsieve-cde-valueset'] ||
+  property?.property?.items?.['x-pennsieve-cde-valueset'] ||
+  null
 
 // An over-cap ontology value set carries `x-pennsieve-concept-valueset` (tier:"subtree",
 // with `ontology` + `root`) instead of an enum. It's browsable/searchable, so the field
 // becomes a subtree-restricted remote search rather than a plain text box.
 const conceptValueSet = (property) => {
-  const vs = property?.property?.['x-pennsieve-concept-valueset']
+  const vs =
+    property?.property?.['x-pennsieve-concept-valueset'] ||
+    property?.property?.items?.['x-pennsieve-concept-valueset']
   return vs && vs.ontology && vs.root ? vs : null
 }
 
@@ -503,6 +509,8 @@ const enumOptionLabels = (property) => {
   const vals =
     property?.property?.['x-pennsieve-concept-values'] ||
     property?.property?.['x-pennsieve-cde-values'] ||
+    property?.property?.items?.['x-pennsieve-concept-values'] ||
+    property?.property?.items?.['x-pennsieve-cde-values'] ||
     []
   const map = {}
   for (const v of vals) {
@@ -546,15 +554,21 @@ const runSubtreeSearch = async (key, vs, query) => {
 
 const renderSubtreeSelect = (property, vs) => {
   const { key } = property
-  const current = formData.value[key]
+  // Array-typed properties take multiple codes from the same value set.
+  const isMulti = property.type === 'array'
+  const raw = formData.value[key]
+  const currentCodes = Array.isArray(raw) ? raw : raw != null && raw !== '' ? [raw] : []
   const opts = subtreeOptions.value[key] || []
-  // Always keep the current value selectable so its label shows even before searching.
+  // Always keep the current value(s) selectable so their labels show even before searching.
   const merged = [...opts]
-  if (current != null && current !== '' && !merged.some((o) => o.code === current)) {
-    merged.unshift({ code: current, label: subtreeValueLabels.value[current] || current })
+  for (const code of currentCodes) {
+    if (!merged.some((o) => o.code === code)) {
+      merged.unshift({ code, label: subtreeValueLabels.value[code] || code })
+    }
   }
   return h(ElSelect, {
-    modelValue: current,
+    modelValue: isMulti ? currentCodes : raw,
+    multiple: isMulti,
     'onUpdate:modelValue': (value) => {
       formData.value[key] = value
       if (nullKeyFields.value[key]) nullKeyFields.value[key] = false
@@ -580,13 +594,21 @@ const renderFormFieldInput = (property) => {
     return renderSubtreeSelect(property, conceptVs)
   }
 
-  if (enumValues && enumValues.length > 0) {
+  // Arrays of enum items (e.g. multi-value coded fields) carry the enum on `items`.
+  const itemsEnum = type === 'array' ? property.property?.items?.enum : null
+  const effectiveEnum = enumValues && enumValues.length > 0 ? enumValues : itemsEnum
+
+  if (effectiveEnum && effectiveEnum.length > 0) {
     // Enum stores codes; show human labels when a values annotation carries them
     // (CDE-materialized or ontology value domains), so the dropdown reads
     // "type 2 diabetes mellitus" while the record stores "MONDO:0005148".
+    const isMulti = type === 'array'
     const labels = enumOptionLabels(property)
     return h(ElSelect, {
-      modelValue: formData.value[key],
+      modelValue: isMulti
+        ? (Array.isArray(formData.value[key]) ? formData.value[key] : [])
+        : formData.value[key],
+      multiple: isMulti,
       'onUpdate:modelValue': (value) => {
         formData.value[key] = value
         // If user selects a value, uncheck the null checkbox
@@ -598,7 +620,7 @@ const renderFormFieldInput = (property) => {
       clearable: true,
       filterable: true,
       size: 'default'
-    }, () => enumValues.map(option =>
+    }, () => effectiveEnum.map(option =>
       h(ElOption, { key: option, label: labels[option] || option, value: option })
     ))
   }
@@ -1046,11 +1068,30 @@ const cleanSchemaForValidation = (schema) => {
     return cleaned
   }
   
+  // Some models (built before the PropertyForm fix) carry a value-set enum on an
+  // array property itself; JSON Schema applies enum to the whole array value, so
+  // every record fails with "must be equal to one of the allowed values". Move
+  // the enum onto items, where it was always meant to apply.
+  const fixArrayEnums = (obj) => {
+    if (!obj || typeof obj !== 'object') return obj
+    if (Array.isArray(obj)) return obj.map(fixArrayEnums)
+
+    const processed = {}
+    for (const [key, value] of Object.entries(obj)) {
+      processed[key] = typeof value === 'object' && value !== null ? fixArrayEnums(value) : value
+    }
+    if (processed.type === 'array' && Array.isArray(processed.enum)) {
+      processed.items = { ...(processed.items || {}), enum: processed.enum }
+      delete processed.enum
+    }
+    return processed
+  }
+
   // First add x-pennsieve-key properties to required arrays
   const schemaWithPennsieveKeys = addPennsieveKeysToRequired(cleanedSchema)
-  
+
   // Then remove problematic references
-  return removeRefs(schemaWithPennsieveKeys)
+  return fixArrayEnums(removeRefs(schemaWithPennsieveKeys))
 }
 
 // Validation helper functions

--- a/src/components/datasets/metadata/records/RecordSpecViewer.vue
+++ b/src/components/datasets/metadata/records/RecordSpecViewer.vue
@@ -5,7 +5,7 @@ import { useRouter, useRoute } from 'vue-router'
 import { useMetadataStore } from '@/stores/metadataStore.js'
 import { useOntologyStore } from '@/stores/ontologyStore.js'
 import { useRecordData } from '@/composables/useRecordData.js'
-import { summarizeObject } from '@/utils/objectSummary.js'
+import { summarizeObject, stripHtml } from '@/utils/objectSummary.js'
 
 // Import components
 import BfStage from '@/components/layout/BfStage/BfStage.vue'
@@ -391,18 +391,18 @@ const formatPropertyValue = (value, property) => {
     // Arrays of objects: one summary pill per item instead of "[object Object]".
     if (value.some((v) => v != null && typeof v === 'object')) {
       const items = value.map((v) =>
-        v != null && typeof v === 'object' ? summarizeObject(v) : String(v)
+        v != null && typeof v === 'object' ? summarizeObject(v) : stripHtml(String(v))
       )
       return { display: '', items, isNull: false }
     }
-    return { display: value.join(', '), isNull: false }
+    return { display: value.map((v) => stripHtml(String(v))).join(', '), isNull: false }
   }
 
   if (typeof value === 'object') {
     return { display: summarizeObject(value), isNull: false }
   }
-  
-  return { display: String(value), isNull: false }
+
+  return { display: stripHtml(String(value)), isNull: false }
 }
 
 // Resolve labels for the record's subtree value-set codes (no inline labels in the

--- a/src/components/datasets/metadata/records/RecordSpecViewer.vue
+++ b/src/components/datasets/metadata/records/RecordSpecViewer.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
-import { ElCard, ElTag, ElMessage, ElButton, ElPagination, ElMessageBox } from 'element-plus'
+import { ElCard, ElTag, ElMessage, ElButton, ElPagination, ElMessageBox, ElPopover } from 'element-plus'
 import { useRouter, useRoute } from 'vue-router'
 import { useMetadataStore } from '@/stores/metadataStore.js'
 import { useOntologyStore } from '@/stores/ontologyStore.js'
@@ -544,6 +544,54 @@ const getRecordDisplayValue = (record) => {
   
   // Fall back to record ID
   return `Record ${record.id.slice(0, 8)}...`
+}
+
+// --- Related-record hover preview -------------------------------------------
+// The relationships payload includes each linked record's full value and
+// model_id, so the hover card is built from data already loaded — no fetch.
+const relatedModelName = (record) => {
+  const m = metadataStore.modelById(record?.model_id)
+  return m?.display_name || m?.name || 'Record'
+}
+
+const previewFieldValue = (v) => {
+  if (Array.isArray(v)) {
+    const items = v.slice(0, 2).map((x) =>
+      x != null && typeof x === 'object' ? summarizeObject(x) : stripHtml(String(x))
+    )
+    return items.join(' · ') + (v.length > 2 ? ` · +${v.length - 2} more` : '')
+  }
+  if (v != null && typeof v === 'object') return summarizeObject(v)
+  if (typeof v === 'boolean') return v ? 'Yes' : 'No'
+  return stripHtml(String(v))
+}
+
+// First few non-empty fields of the linked record, in schema order when the
+// related model's schema is loaded (with property titles as labels).
+const recordPreviewFields = (record, max = 6) => {
+  const data = record?.value
+  if (!data) return { fields: [], more: 0 }
+
+  const schemaProps = metadataStore.modelById(record.model_id)?.latest_version?.schema?.properties
+  const keys = schemaProps
+    ? Object.keys(schemaProps).filter((k) => k in data)
+    : Object.keys(data)
+
+  const nonEmpty = keys.filter((k) => {
+    const v = data[k]
+    if (v == null || v === '') return false
+    if (Array.isArray(v) && !v.length) return false
+    return true
+  })
+
+  return {
+    fields: nonEmpty.slice(0, max).map((k) => ({
+      key: k,
+      label: schemaProps?.[k]?.title || k,
+      value: previewFieldValue(data[k])
+    })),
+    more: Math.max(0, nonEmpty.length - max)
+  }
 }
 
 // Pagination methods
@@ -1179,11 +1227,30 @@ onMounted(async () => {
                     :key="`inbound-${index}`"
                     class="relationship-item"
                   >
-                    <div class="relationship-content clickable" @click="goToRelatedRecord(relationship.record)" :title="'Click to view record'">
-                      <el-tag size="small" class="relationship-type inbound">{{ relationship.relationship_type }}</el-tag>
-                      <span class="record-title">{{ getRecordDisplayValue(relationship.record) }}</span>
-                      <IconArrowRight class="nav-icon" :width="12" :height="12" />
-                    </div>
+                    <el-popover placement="top-start" :width="340" trigger="hover" :show-after="350" popper-class="record-preview-popover">
+                      <template #reference>
+                        <div class="relationship-content clickable" @click="goToRelatedRecord(relationship.record)">
+                          <el-tag size="small" class="relationship-type inbound">{{ relationship.relationship_type }}</el-tag>
+                          <span class="record-title">{{ getRecordDisplayValue(relationship.record) }}</span>
+                          <IconArrowRight class="nav-icon" :width="12" :height="12" />
+                        </div>
+                      </template>
+                      <div class="record-preview">
+                        <div class="record-preview-header">
+                          <span class="record-preview-model">{{ relatedModelName(relationship.record) }}</span>
+                          <span class="record-preview-title">{{ getRecordDisplayValue(relationship.record) }}</span>
+                        </div>
+                        <div class="record-preview-fields">
+                          <div v-for="f in recordPreviewFields(relationship.record).fields" :key="f.key" class="record-preview-field">
+                            <span class="field-label">{{ f.label }}</span>
+                            <span class="field-value">{{ f.value }}</span>
+                          </div>
+                        </div>
+                        <div v-if="recordPreviewFields(relationship.record).more" class="record-preview-more">
+                          +{{ recordPreviewFields(relationship.record).more }} more fields — click to open
+                        </div>
+                      </div>
+                    </el-popover>
                     <el-button
                       @click.stop="deleteRelationship(relationship, 'inbound')"
                       link
@@ -1220,11 +1287,30 @@ onMounted(async () => {
                     :key="`outbound-${index}`"
                     class="relationship-item"
                   >
-                    <div class="relationship-content clickable" @click="goToRelatedRecord(relationship.record)" :title="'Click to view record'">
-                      <el-tag size="small" class="relationship-type outbound">{{ relationship.relationship_type }}</el-tag>
-                      <span class="record-title">{{ getRecordDisplayValue(relationship.record) }}</span>
-                      <IconArrowRight class="nav-icon" :width="12" :height="12" />
-                    </div>
+                    <el-popover placement="top-start" :width="340" trigger="hover" :show-after="350" popper-class="record-preview-popover">
+                      <template #reference>
+                        <div class="relationship-content clickable" @click="goToRelatedRecord(relationship.record)">
+                          <el-tag size="small" class="relationship-type outbound">{{ relationship.relationship_type }}</el-tag>
+                          <span class="record-title">{{ getRecordDisplayValue(relationship.record) }}</span>
+                          <IconArrowRight class="nav-icon" :width="12" :height="12" />
+                        </div>
+                      </template>
+                      <div class="record-preview">
+                        <div class="record-preview-header">
+                          <span class="record-preview-model">{{ relatedModelName(relationship.record) }}</span>
+                          <span class="record-preview-title">{{ getRecordDisplayValue(relationship.record) }}</span>
+                        </div>
+                        <div class="record-preview-fields">
+                          <div v-for="f in recordPreviewFields(relationship.record).fields" :key="f.key" class="record-preview-field">
+                            <span class="field-label">{{ f.label }}</span>
+                            <span class="field-value">{{ f.value }}</span>
+                          </div>
+                        </div>
+                        <div v-if="recordPreviewFields(relationship.record).more" class="record-preview-more">
+                          +{{ recordPreviewFields(relationship.record).more }} more fields — click to open
+                        </div>
+                      </div>
+                    </el-popover>
                     <el-button
                       @click.stop="deleteRelationship(relationship, 'outbound')"
                       link
@@ -2142,6 +2228,67 @@ onMounted(async () => {
 
   .mr-8 {
     margin-right: 8px;
+  }
+}
+</style>
+
+<!-- Unscoped: the popover popper is teleported to <body>. -->
+<style lang="scss">
+@use '../../../../styles/theme';
+
+.record-preview-popover {
+  .record-preview-header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding-bottom: 8px;
+    margin-bottom: 8px;
+    border-bottom: 1px solid theme.$gray_2;
+
+    .record-preview-model {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+      color: theme.$gray_4;
+    }
+
+    .record-preview-title {
+      font-size: 14px;
+      font-weight: 600;
+      color: theme.$gray_6;
+    }
+  }
+
+  .record-preview-field {
+    display: flex;
+    gap: 8px;
+    font-size: 13px;
+    line-height: 1.5;
+    margin-bottom: 4px;
+
+    .field-label {
+      flex: 0 0 112px;
+      color: theme.$gray_4;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .field-value {
+      flex: 1;
+      color: theme.$gray_6;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+  }
+
+  .record-preview-more {
+    margin-top: 8px;
+    font-size: 12px;
+    color: theme.$gray_4;
   }
 }
 </style>

--- a/src/components/datasets/metadata/records/RecordSpecViewer.vue
+++ b/src/components/datasets/metadata/records/RecordSpecViewer.vue
@@ -12,6 +12,7 @@ import BfStage from '@/components/layout/BfStage/BfStage.vue'
 import StageActions from '@/components/shared/StageActions/StageActions.vue'
 import BfButton from '@/components/shared/bf-button/BfButton.vue'
 import IconArrowRight from '@/components/icons/IconArrowRight.vue'
+import IconArrowLeft from '@/components/icons/IconArrowLeft.vue'
 import IconPencil from '@/components/icons/IconPencil.vue'
 import PsButtonDropdown from '@/components/shared/ps-button-dropdown/PsButtonDropdown.vue'
 import IconTrash from "@/components/icons/IconTrash.vue"
@@ -1071,12 +1072,10 @@ onMounted(async () => {
     <template #actions>
       <stage-actions>
         <template #left>
-<!--          <bf-button @click="goBackToRecords" size="small">-->
-<!--            <template #prefix>-->
-<!--              <IconArrowLeft class="mr-8" :height="16" :width="16" />-->
-<!--            </template>-->
-<!--            Back to Records-->
-<!--          </bf-button>-->
+          <a class="back-to-records-link" @click="goBackToRecords">
+            <IconArrowLeft :height="12" :width="12" />
+            {{ model?.display_name || model?.name || 'Model' }} Records
+          </a>
         </template>
         <template #right>
           <template v-if="quickActionsVisible">
@@ -2228,6 +2227,20 @@ onMounted(async () => {
 
   .mr-8 {
     margin-right: 8px;
+  }
+
+  .back-to-records-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: theme.$purple_3;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }
 </style>

--- a/src/components/datasets/metadata/records/RecordSpecViewer.vue
+++ b/src/components/datasets/metadata/records/RecordSpecViewer.vue
@@ -5,6 +5,7 @@ import { useRouter, useRoute } from 'vue-router'
 import { useMetadataStore } from '@/stores/metadataStore.js'
 import { useOntologyStore } from '@/stores/ontologyStore.js'
 import { useRecordData } from '@/composables/useRecordData.js'
+import { summarizeObject } from '@/utils/objectSummary.js'
 
 // Import components
 import BfStage from '@/components/layout/BfStage/BfStage.vue'
@@ -387,11 +388,18 @@ const formatPropertyValue = (value, property) => {
   }
   
   if (Array.isArray(value)) {
+    // Arrays of objects: one summary pill per item instead of "[object Object]".
+    if (value.some((v) => v != null && typeof v === 'object')) {
+      const items = value.map((v) =>
+        v != null && typeof v === 'object' ? summarizeObject(v) : String(v)
+      )
+      return { display: '', items, isNull: false }
+    }
     return { display: value.join(', '), isNull: false }
   }
-  
+
   if (typeof value === 'object') {
-    return { display: JSON.stringify(value, null, 2), isNull: false }
+    return { display: summarizeObject(value), isNull: false }
   }
   
   return { display: String(value), isNull: false }
@@ -1104,7 +1112,14 @@ onMounted(async () => {
             >
               <span class="attribute-name">{{ prop.label }}:</span>
               <span class="attribute-value" :class="{ 'is-null': prop.formatted.isNull }">
-                {{ prop.formatted.display }}
+                <template v-if="prop.formatted.items">
+                  <span
+                    v-for="(item, idx) in prop.formatted.items"
+                    :key="idx"
+                    class="attribute-object-item"
+                  >{{ item }}</span>
+                </template>
+                <template v-else>{{ prop.formatted.display }}</template>
                 <span v-if="prop.formatted.code" class="attribute-code" :title="`Stored value: ${prop.formatted.code}`">{{ prop.formatted.code }}</span>
               </span>
             </div>
@@ -1743,6 +1758,25 @@ onMounted(async () => {
                 font-size: 11px;
                 font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
                 vertical-align: middle;
+              }
+
+              .attribute-object-item {
+                display: inline-block;
+                margin: 0 8px 4px 0;
+                padding: 2px 8px;
+                border-radius: 4px;
+                background: theme.$gray_1;
+                color: theme.$gray_6;
+                font-size: 13px;
+                white-space: nowrap;
+                max-width: 400px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                vertical-align: middle;
+
+                &:last-child {
+                  margin-right: 0;
+                }
               }
             }
           }

--- a/src/router/MyWorkSpace/ResourcesList.vue
+++ b/src/router/MyWorkSpace/ResourcesList.vue
@@ -11,23 +11,15 @@
       <user-dashboard-card
         title="CDE Catalog"
         description="Browse common data elements and bundles indexed from the NLM CDE Repository"
-        :route="{ name: 'cde-catalog' }"
+        :route="cdeCatalogRoute"
         icon="cde-catalog"
       />
 
       <user-dashboard-card
         title="Ontology Browser"
         description="Explore standard biomedical ontologies (MONDO, HPO, UBERON, NCIt) and their hierarchy"
-        :route="{ name: 'ontology-browser' }"
+        :route="ontologyBrowserRoute"
         icon="ontology-browser"
-      />
-
-      <user-dashboard-card
-        title="Model Templates"
-        description="Browse reusable model templates"
-        :route="{ name: 'resources' }"
-        icon="model-templates"
-        :coming-soon="true"
       />
     </div>
   </div>
@@ -38,7 +30,24 @@ import UserDashboardCard from "@/components/user/dashboard/UserDashboardCard.vue
 
 export default {
   name: "ResourcesList",
-  components: { UserDashboardCard }
+  components: { UserDashboardCard },
+  computed: {
+    // Rendered both in MyWorkspace (/my-workspace/resources) and in an org
+    // workspace (/:orgId/resources) — route the cards within the same context.
+    orgId() {
+      return this.$route.params.orgId || null;
+    },
+    cdeCatalogRoute() {
+      return this.orgId
+        ? { name: "workspace-cde-catalog", params: { orgId: this.orgId } }
+        : { name: "cde-catalog" };
+    },
+    ontologyBrowserRoute() {
+      return this.orgId
+        ? { name: "workspace-ontology-browser", params: { orgId: this.orgId } }
+        : { name: "ontology-browser" };
+    }
+  }
 };
 </script>
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -91,6 +91,7 @@ const Settings = () => import('./OrgSettings/Settings.vue')
 const OrgSettings = () => import('../components/OrgSettings/OrgSettings.vue')
 
 const People = () => import('./people/People.vue')
+const WorkspaceResources = () => import('./resources/WorkspaceResources.vue')
 const PeopleList = () => import('../components/people/list/PeopleList.vue')
 
 const Teams = () => import('./teams/Teams.vue')
@@ -1407,22 +1408,6 @@ const router = createRouter({
                   }
                 },
                 {
-                  path: 'cde-gallery',
-                  name: 'cde-gallery',
-                  props: true,
-                  meta: {
-                    backLink: { name: "Models", to: "models-list" },
-                    breadcrumbs: [
-                      { name: "Metadata", to: "metadata" },
-                      { name: "Models", to: "models-list" },
-                      { name: "CDE Catalog", current: true }
-                    ]
-                  },
-                  components: {
-                    stage: CdeGallery
-                  }
-                },
-                {
                   path: 'details/:modelId',
                   name: 'model-details',
                   props: true,
@@ -1639,6 +1624,42 @@ const router = createRouter({
             },
           ]
         },
+      ]
+    },
+    {
+      // Org-level resources hub — same shared catalogs as the MyWorkspace
+      // version (the content is global), reachable from the workspace nav.
+      path: '/:orgId/resources',
+      components: {
+        page: WorkspaceResources,
+        navigation: BfNavigation
+      },
+      props: true,
+      children: [
+        {
+          name: 'workspace-resources',
+          path: '',
+          components: {
+            stage: ResourcesList
+          },
+          props: true
+        },
+        {
+          name: 'workspace-cde-catalog',
+          path: 'cde-catalog',
+          components: {
+            stage: CdeGallery
+          },
+          props: true
+        },
+        {
+          name: 'workspace-ontology-browser',
+          path: 'ontology-browser',
+          components: {
+            stage: OntologyBrowser
+          },
+          props: true
+        }
       ]
     },
     {

--- a/src/router/resources/WorkspaceResources.vue
+++ b/src/router/resources/WorkspaceResources.vue
@@ -1,0 +1,37 @@
+<template>
+  <bf-page class="bf-workspace-resources">
+    <template #heading>
+      <bf-rafter
+        class="primary"
+        :org-id="orgId"
+      >
+        <template #breadcrumb>
+          <org-breadcrumb page-name="Resources" />
+        </template>
+      </bf-rafter>
+    </template>
+
+    <template #stage>
+      <router-view name="stage" />
+    </template>
+  </bf-page>
+</template>
+
+<script>
+import BfRafter from "../../components/shared/bf-rafter/BfRafter.vue";
+import OrgBreadcrumb from "../../components/shared/OrgBreadcrumb/OrgBreadcrumb.vue";
+
+export default {
+  name: 'WorkspaceResources',
+  components: {
+    BfRafter,
+    OrgBreadcrumb
+  },
+  props: {
+    orgId: {
+      type: String,
+      default: ''
+    }
+  }
+}
+</script>

--- a/src/stores/ontologyStore.js
+++ b/src/stores/ontologyStore.js
@@ -483,10 +483,30 @@ export const useOntologyStore = defineStore('ontology', () => {
         return { members, overCap: members.length > cap }
     }
 
+    // All non-obsolete terms of an ontology/termset slice, as a flat value set.
+    // Termsets are flat (every member is a root with no in-slice is_a parent), so
+    // subtreeMembers can't enumerate them — this just reads the whole slice.
+    // Ordered by label, capped at cap+1 so a large slice becomes an over-cap
+    // reference rather than materializing thousands of options. Returns
+    // { members: [{ curie, label }], overCap }.
+    const allMembers = async (ontology, { cap = 512 } = {}) => {
+        await ensureOntology(ontology)
+        const src = sources.value.find((s) => s.ontology === ontology)
+        if (!src) return { members: [], overCap: false }
+        const rows = await duck.executeQuery(
+            `SELECT curie, label FROM ${src.table} WHERE COALESCE(obsolete, false) = false ORDER BY lower(label) LIMIT ${cap + 1}`,
+            connectionId,
+        )
+        const members = (rows || [])
+            .map((r) => ({ curie: r.curie == null ? '' : String(r.curie), label: r.label == null ? '' : String(r.label) }))
+            .filter((m) => m.curie)
+        return { members, overCap: members.length > cap }
+    }
+
     return {
         loading, loaded, error, available, sources, isConfigured,
         ensureRegistry, ensureOntology, ensureLoaded,
-        search, searchSubtree, descendants, ancestors, subtreeMembers,
+        search, searchSubtree, descendants, ancestors, subtreeMembers, allMembers,
         getByCurie, roots, children, lineage, labelsFor,
     }
 })

--- a/src/utils/objectSummary.js
+++ b/src/utils/objectSummary.js
@@ -1,0 +1,25 @@
+/**
+ * One-line human summary for an object value (e.g. an xref entry). Prefers a
+ * name-ish + value-ish key pair ("NINDS: C57136"), falling back to the first
+ * few primitive fields as "key: value" pairs.
+ */
+export function summarizeObject(obj) {
+  const primitives = Object.entries(obj).filter(
+    ([, v]) => v != null && typeof v !== 'object'
+  )
+  const pick = (keys) => {
+    for (const key of keys) {
+      const hit = primitives.find(([k]) => k.toLowerCase() === key)
+      if (hit) return String(hit[1])
+    }
+    return null
+  }
+  const name = pick(['label', 'name', 'title', 'system', 'source', 'key', 'type'])
+  const val = pick(['value', 'id', 'code', 'identifier', 'url'])
+  if (name && val && name !== val) return `${name}: ${val}`
+  if (name || val) return name || val
+  if (primitives.length) {
+    return primitives.slice(0, 3).map(([k, v]) => `${k}: ${v}`).join(', ')
+  }
+  return JSON.stringify(obj)
+}

--- a/src/utils/objectSummary.js
+++ b/src/utils/objectSummary.js
@@ -1,4 +1,12 @@
 /**
+ * Strip literal HTML tags from source text (e.g. "<br />" in NLM reference
+ * fields) for plain-text display. Leaves non-tag uses of "<" alone.
+ */
+export function stripHtml(s) {
+  return s.includes('<') ? s.replace(/<\/?[a-z][^>]*>/gi, ' ').replace(/\s+/g, ' ').trim() : s
+}
+
+/**
  * One-line human summary for an object value (e.g. an xref entry). Prefers a
  * name-ish + value-ish key pair ("NINDS: C57136"), falling back to the first
  * few primitive fields as "key: value" pairs.


### PR DESCRIPTION
Same change set as the main-targeted PR #779, opened against `dev`.

## What
- **Ontology Browser**: registry-driven `display_name`/`summary`, `All / Ontologies / Termsets` filter pills, single full-width scroll row (fade + arrows), teal termset badge.
- **Property value sets**: use a whole termset ("Use entire termset") or multiple hand-picked terms (multi-pick with chips, capped at 10 + "+N more") as a property's value set. Under the inline cap → materialized `enum`; over the cap → `x-pennsieve-concept-valueset {tier:'termset', ontology, slug}` resolved live at record fill.
- `ontologyStore.allMembers`, `RecordSpecGenerator` termset-tier resolution.

## Compatibility
Record submission JSON unchanged (curie / array of curies). Only new schema is the `termset` tier in the existing `x-pennsieve-concept-valueset` annotation. Degrades gracefully against an old registry.

## Depends on
[cde-service#49](https://github.com/Pennsieve/cde-service/pull/49) (registry `kind`/`display_name`/`summary`/`workspaces`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)