### PR TITLE
feat(ontology-browser): ontologies vs termsets, registry-driven metadata, termset value sets

### DIFF
--- a/src/components/datasets/metadata/models/OntologyBrowser.vue
+++ b/src/components/datasets/metadata/models/OntologyBrowser.vue
@@ -38,6 +38,12 @@
                   property in a metadata model — so records are filled in with consistent, standardized
                   codes.</p>
               </div>
+              <div class="ob-help-item">
+                <div class="ob-help-h"><el-icon><Collection /></el-icon> Ontologies vs. termsets</div>
+                <p>An <strong>ontology</strong> is a full source vocabulary (MONDO, UBERON…). A
+                  <strong>termset</strong> is a curated list for a specific project or consortium
+                  (e.g. SPARC, REJOIN) that pulls terms from several ontologies.</p>
+              </div>
               <p class="ob-help-note">Pennsieve refreshes these vocabularies from their sources
                 quarterly — each card shows the version it's on.</p>
             </div>
@@ -50,29 +56,66 @@
         </p>
       </div>
 
-      <!-- Vocabulary chooser -->
+      <!-- Vocabulary chooser: a kind filter above one horizontal-scrolling row -->
       <div v-if="booting" class="ob-status">Loading vocabularies…</div>
-      <div v-else class="ob-onto-cards">
-        <button
-          v-for="o in browsableOntologies"
-          :key="o.ontology"
-          type="button"
-          class="ob-onto-card"
-          :class="{ 'is-active': o.ontology === selectedOntology }"
-          @click="selectOntology(o.ontology)"
-        >
-          <span class="ob-onto-card-top">
-            <span class="ob-onto-code">{{ o.ontology }}</span>
-            <el-icon v-if="o.ontology === selectedOntology" class="ob-onto-check"><Check /></el-icon>
-          </span>
-          <span class="ob-onto-title">{{ ontologyMeta(o.ontology).title }}</span>
-          <span class="ob-onto-desc">{{ ontologyMeta(o.ontology).desc }}</span>
-          <span class="ob-onto-meta">
-            <span class="ob-onto-count"><el-icon><List /></el-icon>{{ formatCount(o.count) }} terms</span>
-            <span class="ob-onto-rel" :title="releaseTitle(o)"><el-icon><Calendar /></el-icon>{{ releaseDate(o) }}</span>
-          </span>
-        </button>
-      </div>
+      <template v-else>
+        <div v-if="hasTermsets" class="ob-onto-filter" role="tablist" aria-label="Filter vocabularies by kind">
+          <button
+            v-for="f in kindFilters"
+            :key="f.key"
+            type="button"
+            role="tab"
+            :aria-selected="kindFilter === f.key"
+            class="ob-onto-filter-btn"
+            :class="{ 'is-active': kindFilter === f.key }"
+            @click="kindFilter = f.key"
+          >
+            {{ f.label }}<span class="ob-onto-filter-count">{{ f.count }}</span>
+          </button>
+        </div>
+        <div class="ob-onto-row-wrap">
+          <button
+            v-if="canScrollLeft"
+            type="button"
+            class="ob-onto-arrow ob-onto-arrow-left"
+            aria-label="Scroll left"
+            @click="scrollByCards(-1)"
+          >
+            <el-icon><ArrowLeft /></el-icon>
+          </button>
+          <div class="ob-onto-row" ref="rowEl" :style="fadeStyle" @scroll="updateScroll">
+          <button
+            v-for="o in filteredOntologies"
+            :key="o.ontology"
+            type="button"
+            class="ob-onto-card"
+            :class="{ 'is-active': o.ontology === selectedOntology, 'is-termset': o.kind === 'termset' }"
+            @click="selectOntology(o.ontology)"
+          >
+            <span class="ob-onto-card-top">
+              <span v-if="o.kind === 'termset'" class="ob-onto-badge">Termset</span>
+              <span v-else class="ob-onto-code">{{ o.ontology }}</span>
+              <el-icon v-if="o.ontology === selectedOntology" class="ob-onto-check"><Check /></el-icon>
+            </span>
+            <span class="ob-onto-title">{{ metaTitle(o) }}</span>
+            <span class="ob-onto-desc">{{ metaDesc(o) }}</span>
+            <span class="ob-onto-meta">
+              <span class="ob-onto-count"><el-icon><List /></el-icon>{{ formatCount(o.count) }} terms</span>
+              <span class="ob-onto-rel" :title="releaseTitle(o)"><el-icon><Calendar /></el-icon>{{ releaseDate(o) }}</span>
+            </span>
+          </button>
+          </div>
+          <button
+            v-if="canScrollRight"
+            type="button"
+            class="ob-onto-arrow ob-onto-arrow-right"
+            aria-label="Scroll right"
+            @click="scrollByCards(1)"
+          >
+            <el-icon><ArrowRight /></el-icon>
+          </button>
+        </div>
+      </template>
 
       <div v-if="!booting && browsableOntologies.length" class="ob-request-row">
         <el-popover placement="top-start" :width="240" trigger="hover" popper-class="ob-help-popper">
@@ -262,9 +305,9 @@
 </template>
 
 <script setup>
-import { ref, reactive, computed, onMounted } from 'vue'
+import { ref, reactive, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
-import { Search, Check, PriceTag, Collection, QuestionFilled, InfoFilled, Calendar, List } from '@element-plus/icons-vue'
+import { Search, Check, PriceTag, Collection, QuestionFilled, InfoFilled, Calendar, List, ArrowLeft, ArrowRight } from '@element-plus/icons-vue'
 import debounce from 'lodash.debounce'
 import { useOntologyStore } from '@/stores/ontologyStore'
 import StageActions from '@/components/shared/StageActions/StageActions.vue'
@@ -332,6 +375,10 @@ const ONTOLOGY_META = {
   UCUM: { title: 'Units of measure', desc: 'Standard units for measurements.' },
 }
 const ontologyMeta = (name) => ONTOLOGY_META[name] || { title: name, desc: '' }
+// Prefer the registry's own name/summary (sources.json now carries display_name +
+// summary); fall back to the curated ONTOLOGY_META for any entry that predates it.
+const metaTitle = (o) => o.display_name || ontologyMeta(o.ontology).title
+const metaDesc = (o) => o.summary || ontologyMeta(o.ontology).desc
 const formatCount = (n) => Number(n || 0).toLocaleString()
 
 // The upstream release date is embedded in most ontology_version strings
@@ -362,6 +409,58 @@ const browsableOntologies = computed(() => {
     .slice()
     .sort((a, b) => rank(a) - rank(b) || a.ontology.localeCompare(b.ontology))
 })
+// Split the chooser into two sections so ontologies and termsets read as distinct
+// kinds. Core = anything not explicitly a termset (covers entries with no kind).
+const coreOntologies = computed(() => browsableOntologies.value.filter((o) => o.kind !== 'termset'))
+const termsets = computed(() => browsableOntologies.value.filter((o) => o.kind === 'termset'))
+const hasTermsets = computed(() => termsets.value.length > 0)
+// One scrollable row, narrowed by a kind filter (All / Ontologies / Termsets).
+const kindFilter = ref('all')
+const kindFilters = computed(() => [
+  { key: 'all', label: 'All', count: browsableOntologies.value.length },
+  { key: 'core', label: 'Ontologies', count: coreOntologies.value.length },
+  { key: 'termset', label: 'Termsets', count: termsets.value.length },
+])
+const filteredOntologies = computed(() => {
+  if (kindFilter.value === 'core') return coreOntologies.value
+  if (kindFilter.value === 'termset') return termsets.value
+  return browsableOntologies.value
+})
+
+// Horizontal-scroll affordance for the vocabulary row: fade the scrollable edges
+// and show a scroll arrow on each side, only when there's overflow in that
+// direction. The fade is a mask (background-agnostic), toggled with the arrows.
+const rowEl = ref(null)
+const canScrollLeft = ref(false)
+const canScrollRight = ref(false)
+const FADE = '36px'
+const fadeStyle = computed(() => {
+  const l = canScrollLeft.value
+  const r = canScrollRight.value
+  let mask = 'none'
+  if (l && r) mask = `linear-gradient(to right, transparent 0, #000 ${FADE}, #000 calc(100% - ${FADE}), transparent 100%)`
+  else if (r) mask = `linear-gradient(to right, #000 calc(100% - ${FADE}), transparent 100%)`
+  else if (l) mask = `linear-gradient(to right, transparent 0, #000 ${FADE})`
+  return { maskImage: mask, WebkitMaskImage: mask }
+})
+const updateScroll = () => {
+  const el = rowEl.value
+  if (!el) return
+  canScrollLeft.value = el.scrollLeft > 1
+  canScrollRight.value = el.scrollLeft + el.clientWidth < el.scrollWidth - 1
+}
+const scrollByCards = (dir) => {
+  const el = rowEl.value
+  if (!el) return
+  el.scrollBy({ left: dir * Math.max(el.clientWidth * 0.8, 292), behavior: 'smooth' })
+}
+// Recompute when the list changes (filter/data load) and on viewport resize.
+watch([filteredOntologies, booting], () => nextTick(updateScroll))
+onMounted(() => {
+  window.addEventListener('resize', updateScroll)
+  nextTick(updateScroll)
+})
+onBeforeUnmount(() => window.removeEventListener('resize', updateScroll))
 const focusableSel = computed(() => sel.curie && (!focus.value || focus.value.curie !== sel.curie))
 const synonymList = computed(() =>
   String(sel.synonyms || '')
@@ -588,29 +687,116 @@ onMounted(async () => {
     font-size: 12px;
   }
 }
-/* Vocabulary chooser — a row of selectable cards */
-.ob-onto-cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 12px;
-  margin-bottom: 24px;
-  max-width: 940px;
+/* Vocabulary chooser — a kind filter above one horizontal-scrolling row */
+.ob-onto-filter {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 12px;
 }
+.ob-onto-filter-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: theme.$gray_5;
+  background: theme.$white;
+  border: 1px solid theme.$gray_2;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+  &:hover {
+    border-color: theme.$purple_0_7;
+  }
+  &.is-active {
+    color: theme.$purple_2;
+    background: theme.$purple_tint;
+    border-color: theme.$purple_2;
+  }
+}
+.ob-onto-filter-count {
+  font-size: 11px;
+  color: theme.$gray_4;
+}
+.ob-onto-filter-btn.is-active .ob-onto-filter-count {
+  color: theme.$purple_2;
+}
+.ob-onto-row-wrap {
+  position: relative;
+  margin-bottom: 24px;
+}
+.ob-onto-row {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  /* overflow-x:auto forces overflow-y:auto, which would clip the cards' hover
+     shadow — pad the scrollport so it isn't cut off. */
+  padding: 4px 0 10px;
+}
+/* Scroll affordance: an arrow on each side, shown only when scrollable that way. */
+.ob-onto-arrow {
+  position: absolute;
+  top: calc(50% - 3px);
+  transform: translateY(-50%);
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: theme.$white;
+  border: 1px solid theme.$gray_2;
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  color: theme.$gray_6;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+  &:hover {
+    border-color: theme.$purple_0_7;
+    color: theme.$purple_2;
+  }
+  .el-icon {
+    font-size: 16px;
+  }
+}
+.ob-onto-arrow-left {
+  left: -8px;
+}
+.ob-onto-arrow-right {
+  right: -8px;
+}
+/* Termset badge — distinguishes a curated list from a full ontology */
+.ob-onto-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 18px;
+  color: theme.$teal_2;
+  background: theme.$teal_tint;
+  border: 1px solid theme.$teal_1;
+  border-radius: 4px;
+  padding: 0 7px;
+}
+
 .ob-onto-card {
+  flex: 0 0 auto;
+  width: 280px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
   text-align: left;
-  padding: 14px 16px;
+  padding: 16px 18px;
   background: theme.$white;
   border: 1px solid theme.$gray_2;
   border-radius: 8px;
   cursor: pointer;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease, background 0.15s ease;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
   &:hover {
     border-color: theme.$purple_0_7;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
-    transform: translateY(-1px);
   }
   &.is-active {
     border-color: theme.$purple_2;
@@ -644,6 +830,11 @@ onMounted(async () => {
   color: theme.$gray_5;
   line-height: 1.4;
   min-height: 4.2em; /* reserve 3 lines so the meta row aligns across cards */
+  display: -webkit-box;
+  -webkit-line-clamp: 3; /* truncate longer summaries with an ellipsis */
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 .ob-onto-meta {
   display: flex;

--- a/src/components/datasets/metadata/models/OntologyTreePicker.vue
+++ b/src/components/datasets/metadata/models/OntologyTreePicker.vue
@@ -33,7 +33,7 @@
             <li
               v-for="r in results"
               :key="r.curie"
-              :class="{ active: selected && selected.curie === r.curie }"
+              :class="{ active: isPicked(r.curie) }"
               @click="pick(r)"
             >
               <span class="otp-label">{{ r.label }}</span>
@@ -57,7 +57,7 @@
           @node-click="pick"
         >
           <template #default="{ data }">
-            <span class="otp-node" :class="{ active: selected && selected.curie === data.curie }">
+            <span class="otp-node" :class="{ active: isPicked(data.curie) }">
               <span class="otp-label">{{ data.label }}</span>
               <span class="otp-code">{{ data.curie }}</span>
             </span>
@@ -68,13 +68,30 @@
 
     <template #footer>
       <div class="otp-footer">
-        <span v-if="selected" class="otp-selected">
-          Selected: <strong>{{ selected.label }}</strong> <span class="otp-code">{{ selected.curie }}</span>
-        </span>
-        <span v-else class="otp-selected otp-muted">Pick a term to use as the value-set root.</span>
-        <span class="otp-spacer" />
-        <el-button @click="$emit('update:modelValue', false)">Cancel</el-button>
-        <el-button type="primary" :disabled="!selected" @click="confirm">Use this term</el-button>
+        <div v-if="picked.length" class="otp-picked">
+          <el-tag
+            v-for="p in visiblePicked"
+            :key="p.curie"
+            closable
+            size="small"
+            disable-transitions
+            @close="unpick(p.curie)"
+          >{{ p.label }}</el-tag>
+          <el-tag v-if="hiddenPicked" size="small" type="info" disable-transitions :title="hiddenLabels">
+            +{{ hiddenPicked }} more
+          </el-tag>
+        </div>
+        <p v-else class="otp-picked-hint">
+          {{ isTermset ? 'Pick one or more terms, or use the entire termset.' : 'Pick one or more terms for the value set.' }}
+        </p>
+        <div class="otp-actions">
+          <el-button @click="$emit('update:modelValue', false)">Cancel</el-button>
+          <el-button v-if="isTermset" @click="useTermset">Use entire termset</el-button>
+          <el-button v-if="picked.length === 1" @click="useSubtreeRoot">Use subtree of this term</el-button>
+          <el-button type="primary" :disabled="!picked.length" @click="useSelected">
+            Use {{ picked.length ? picked.length + ' ' : '' }}selected term{{ picked.length === 1 ? '' : 's' }}
+          </el-button>
+        </div>
       </div>
     </template>
   </el-dialog>
@@ -94,11 +111,23 @@ const store = useOntologyStore()
 // UCUM is a flat unit list — not a browsable tree.
 const options = computed(() => (store.available || []).filter((o) => o.ontology !== 'UCUM'))
 const scope = ref('')
+// The chosen vocabulary's registry entry. A termset (kind:'termset') is a curated
+// flat list, so the whole set can be used as a value set (no single root term).
+const scopeEntry = computed(() => (store.available || []).find((o) => o.ontology === scope.value) || null)
+const isTermset = computed(() => scopeEntry.value?.kind === 'termset')
 const loading = ref(false)
 const term = ref('')
 const results = ref([])
 const searching = ref(false)
-const selected = ref(null)
+// Multi-pick: clicking a term toggles it into `picked`. Picks persist across scope
+// changes so a value set can be composed from several ontologies/termsets.
+const picked = ref([])
+const isPicked = (curie) => picked.value.some((p) => p.curie === curie)
+// Cap the chips shown in the footer; the rest collapse into a "+N more" tag.
+const MAX_CHIPS = 10
+const visiblePicked = computed(() => picked.value.slice(0, MAX_CHIPS))
+const hiddenPicked = computed(() => Math.max(0, picked.value.length - MAX_CHIPS))
+const hiddenLabels = computed(() => picked.value.slice(MAX_CHIPS).map((p) => p.label).join(', '))
 
 const treeProps = { label: 'label', children: 'children', isLeaf: (d) => !d.has_children }
 // Terms in a slice share the ontology's version (the tree rows don't carry it).
@@ -116,7 +145,7 @@ const loadOntology = async () => {
 }
 
 const onOpen = async () => {
-  selected.value = null
+  picked.value = []
   term.value = ''
   results.value = []
   loading.value = true
@@ -132,7 +161,7 @@ const onOpen = async () => {
 }
 
 const onScopeChange = async () => {
-  selected.value = null
+  // Keep picks when switching ontology so a set can span vocabularies.
   term.value = ''
   results.value = []
   await loadOntology()
@@ -162,14 +191,43 @@ const onSearch = debounce(async () => {
   }
 }, 250)
 
+// Toggle a term in/out of the picked set.
 const pick = (node) => {
   if (!node || !node.curie) return
-  selected.value = { curie: node.curie, label: node.label, ontology: scope.value, ontology_version: scopeVersion() }
+  const i = picked.value.findIndex((p) => p.curie === node.curie)
+  if (i >= 0) picked.value.splice(i, 1)
+  else picked.value.push({ curie: node.curie, label: node.label, ontology: scope.value, ontology_version: scopeVersion() })
+}
+const unpick = (curie) => {
+  picked.value = picked.value.filter((p) => p.curie !== curie)
 }
 
-const confirm = () => {
-  if (!selected.value) return
-  emit('select', { ...selected.value })
+// Use the picked terms as the value set (exactly those terms, materialized).
+const useSelected = () => {
+  if (!picked.value.length) return
+  emit('select', { terms: picked.value.map((p) => ({ ...p })) })
+  emit('update:modelValue', false)
+}
+
+// One term picked: offer its is_a subtree instead of just the single term.
+const useSubtreeRoot = () => {
+  if (picked.value.length !== 1) return
+  emit('select', { ...picked.value[0] })
+  emit('update:modelValue', false)
+}
+
+// Use the entire termset as the value set (all members), not a single term's subtree.
+const useTermset = () => {
+  const e = scopeEntry.value
+  if (!e) return
+  emit('select', {
+    termset: true,
+    ontology: e.ontology,
+    slug: e.slug,
+    label: e.display_name || e.ontology,
+    count: e.count,
+    ontology_version: e.ontology_version || '',
+  })
   emit('update:modelValue', false)
 }
 </script>
@@ -238,17 +296,23 @@ const confirm = () => {
 }
 .otp-footer {
   display: flex;
-  align-items: center;
-  gap: 12px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
 }
-.otp-selected {
+.otp-picked {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.otp-picked-hint {
+  margin: 0;
   font-size: 13px;
-  color: theme.$gray_6;
-}
-.otp-muted {
   color: theme.$gray_4;
 }
-.otp-spacer {
-  flex: 1;
+.otp-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
 }
 </style>

--- a/src/components/datasets/metadata/models/PropertyForm.vue
+++ b/src/components/datasets/metadata/models/PropertyForm.vue
@@ -294,8 +294,8 @@
         <div class="pf-section-title">Data values</div>
         <el-form label-position="top">
           <el-form-item label="Allowed values">
-            <!-- Type a list, or fill from an ontology term's subtree. -->
-            <template v-if="!subtreeRoot">
+            <!-- Type a list, or fill from an ontology term's subtree / a whole termset / picked terms. -->
+            <template v-if="!subtreeRoot && !termsetSource && !selectedTerms">
               <el-input v-model="manual.enumInput" placeholder="Comma-separated, e.g. Low, Medium, High" />
               <!-- Ontology value sets are string codes, so only for Text. -->
               <template v-if="manual.type === 'string'">
@@ -323,6 +323,42 @@
                 </div>
               </template>
             </template>
+
+            <!-- Hand-picked terms: the value set is exactly these, no expansion. -->
+            <div v-else-if="selectedTerms" class="onto-subtree">
+              <div class="onto-subtree-head">
+                <span>{{ selectedTerms.length }} selected term{{ selectedTerms.length === 1 ? '' : 's' }}</span>
+                <el-button text @click="clearPickedTerms">change</el-button>
+              </div>
+              <ul v-if="subtreePreview.length" class="onto-subtree-list">
+                <li v-for="m in subtreePreview" :key="m.curie">
+                  <span class="onto-subtree-item-label">{{ m.label }}</span>
+                  <span class="onto-subtree-code">{{ m.curie }}</span>
+                </li>
+              </ul>
+            </div>
+
+            <!-- A whole termset is chosen: a flat member list, no granularity. -->
+            <div v-else-if="termsetSource" class="onto-subtree">
+              <div class="onto-subtree-head">
+                <span>Entire termset <strong>{{ termsetSource.label }}</strong></span>
+                <el-button text @click="clearTermset">change</el-button>
+              </div>
+              <div v-if="valueDomain" class="onto-subtree-count">
+                <template v-if="valueDomain.over_cap">{{ valueDomain.count != null ? valueDomain.count.toLocaleString() + ' values' : 'All members' }}</template>
+                <template v-else>{{ valueDomain.count.toLocaleString() }} value{{ valueDomain.count === 1 ? '' : 's' }}</template>
+              </div>
+              <ul v-if="subtreePreview.length" class="onto-subtree-list">
+                <li v-for="m in subtreePreview" :key="m.curie">
+                  <span class="onto-subtree-item-label">{{ m.label }}</span>
+                  <span class="onto-subtree-code">{{ m.curie }}</span>
+                </li>
+              </ul>
+              <div v-if="valueDomain && valueDomain.over_cap" class="onto-subtree-more">
+                Showing a sample — the full set is enforced by reference, not listed.
+              </div>
+              <div v-if="subtreeNote" class="wiz-hint" style="margin-top: 6px">{{ subtreeNote }}</div>
+            </div>
 
             <!-- A term is chosen: granularity + a readable preview of the members. -->
             <div v-else class="onto-subtree">
@@ -363,7 +399,7 @@
               </div>
               <div v-if="subtreeNote" class="wiz-hint" style="margin-top: 6px">{{ subtreeNote }}</div>
             </div>
-            <OntologyTreePicker v-model="pickerOpen" @select="selectSubtreeRoot" />
+            <OntologyTreePicker v-model="pickerOpen" @select="onPickerSelect" />
           </el-form-item>
           <template v-if="manual.type === 'string' && !hasControlledValues">
             <div class="wiz-two">
@@ -436,6 +472,8 @@ const ontoTerm = ref('')
 const ontoResults = ref([])
 const subtreeNote = ref('')
 const subtreeRoot = ref(null) // { curie, label, ontology, ontology_version }
+const termsetSource = ref(null) // { ontology, slug, label, ontology_version } — a whole-termset value set
+const selectedTerms = ref(null) // [{ code, label }] — a value set composed of hand-picked terms
 const subtreeDepth = ref('all') // 'all' | '1' | '2' | '3'
 const subtreeLeaves = ref(false)
 const valueDomain = ref(null) // the materialized ontology-subtree value domain (or null)
@@ -489,6 +527,8 @@ const runOntoSearch = debounce(async () => {
 const ontoMeta = (c) => (c.curie.startsWith(c.ontology + ':') ? c.curie : `${c.ontology} · ${c.curie}`)
 
 const selectSubtreeRoot = (term) => {
+  termsetSource.value = null
+  selectedTerms.value = null
   subtreeRoot.value = {
     curie: term.curie,
     label: term.label,
@@ -506,6 +546,96 @@ const clearSubtree = () => {
   subtreeNote.value = ''
   ontoTerm.value = ''
   ontoResults.value = []
+}
+
+// The picker emits a whole termset, a list of hand-picked terms, or a single
+// term (subtree root).
+const onPickerSelect = (payload) => {
+  if (payload && payload.termset) selectTermset(payload)
+  else if (payload && payload.terms) selectTerms(payload.terms)
+  else selectSubtreeRoot(payload)
+}
+
+const selectTermset = (ts) => {
+  subtreeRoot.value = null
+  selectedTerms.value = null
+  termsetSource.value = {
+    ontology: ts.ontology,
+    slug: ts.slug,
+    label: ts.label,
+    ontology_version: ts.ontology_version,
+  }
+  ontoResults.value = []
+  ontoTerm.value = ''
+  applyTermset()
+}
+const clearTermset = () => {
+  termsetSource.value = null
+  valueDomain.value = null
+  subtreePreview.value = []
+  subtreeNote.value = ''
+}
+
+// A value set composed of exactly the hand-picked terms (materialized, no subtree
+// expansion). Terms may span ontologies — the anchor ontology is left blank then.
+const selectTerms = (terms) => {
+  subtreeRoot.value = null
+  termsetSource.value = null
+  const onts = [...new Set(terms.map((t) => t.ontology).filter(Boolean))]
+  selectedTerms.value = terms.map((t) => ({ code: t.curie, label: t.label }))
+  valueDomain.value = {
+    kind: 'terms',
+    ontology: onts.length === 1 ? onts[0] : '',
+    ontology_version: onts.length === 1 ? terms[0].ontology_version || '' : '',
+    count: terms.length,
+    over_cap: false,
+    members: terms.map((t) => ({ code: t.curie, label: t.label })),
+  }
+  subtreePreview.value = terms.slice(0, PREVIEW_CAP).map((t) => ({ curie: t.curie, label: t.label }))
+  manual.enumInput = ''
+  subtreeNote.value = ''
+  ontoResults.value = []
+  ontoTerm.value = ''
+}
+const clearPickedTerms = () => {
+  selectedTerms.value = null
+  valueDomain.value = null
+  subtreePreview.value = []
+  subtreeNote.value = ''
+}
+
+// Resolve a whole termset as the value domain: a flat list of all its members
+// (no is_a walk). Under the inline cap it carries {code,label} members; over the
+// cap it's a termset REFERENCE (ontology + slug) resolved at record time.
+const applyTermset = async () => {
+  const src = termsetSource.value
+  if (!src) return
+  subtreeNote.value = 'Loading…'
+  try {
+    const { members, overCap } = await ontology.allMembers(src.ontology, { cap: SUBTREE_INLINE_CAP })
+    // The registry knows the exact total; use it for the over-cap count display.
+    const total = (ontology.available || []).find((o) => o.ontology === src.ontology)?.count ?? null
+    valueDomain.value = {
+      kind: 'termset',
+      ontology: src.ontology,
+      slug: src.slug,
+      label: src.label,
+      ontology_version: src.ontology_version,
+      count: overCap ? total : members.length,
+      over_cap: overCap,
+      members: overCap ? null : members.map((m) => ({ code: m.curie, label: m.label })),
+    }
+    subtreePreview.value = members.slice(0, PREVIEW_CAP).map((m) => ({ curie: m.curie, label: m.label }))
+    manual.enumInput = ''
+    subtreeNote.value = overCap
+      ? `More than ${SUBTREE_INLINE_CAP} values — stored as a termset reference and enforced by a ` +
+        `membership check rather than an inline list.`
+      : ''
+  } catch (e) {
+    valueDomain.value = null
+    subtreePreview.value = []
+    subtreeNote.value = 'Could not load termset: ' + (e?.message || e)
+  }
 }
 
 // Resolve the value set from the chosen root + granularity (depth / leaves-only)
@@ -563,26 +693,27 @@ const applyValueDomain = (schema, vd) => {
   // code and always fail). The x-pennsieve-* annotations stay on the property,
   // where the rest of the app reads them.
   const target = schema.type === 'array' && schema.items ? schema.items : schema
+  const isTermset = vd.kind === 'termset'
+  const isTerms = vd.kind === 'terms'
+  // The concept anchor names the value set. A termset / hand-picked set has no
+  // single root term, so its curie is blank and the label describes the set.
   schema['x-pennsieve-concept'] = {
-    curie: vd.root_curie,
-    label: vd.root_label,
-    ontology: vd.ontology,
-    ontology_version: vd.ontology_version,
+    curie: isTermset || isTerms ? '' : vd.root_curie,
+    label: isTermset ? vd.label : isTerms ? `${vd.count} selected terms` : vd.root_label,
+    ontology: vd.ontology || '',
+    ontology_version: vd.ontology_version || '',
   }
   // The values are ontology codes, not a formatted string — a date/email/uri
   // format would contradict the value set.
   delete target.format
   if (vd.over_cap) {
     delete target.enum
-    const ref = {
-      tier: 'subtree',
-      ontology: vd.ontology,
-      root: vd.root_curie,
-      ontology_version: vd.ontology_version,
-    }
+    const ref = isTermset
+      ? { tier: 'termset', ontology: vd.ontology, slug: vd.slug, ontology_version: vd.ontology_version }
+      : { tier: 'subtree', ontology: vd.ontology, root: vd.root_curie, ontology_version: vd.ontology_version }
     if (vd.count != null) ref.count = vd.count // unknown for a broad (bounded) subtree
-    if (vd.max_depth != null) ref.max_depth = vd.max_depth
-    if (vd.leaves_only) ref.leaves_only = true
+    if (!isTermset && vd.max_depth != null) ref.max_depth = vd.max_depth
+    if (!isTermset && vd.leaves_only) ref.leaves_only = true
     schema['x-pennsieve-concept-valueset'] = ref
   } else {
     target.type = target.type || 'string'

--- a/src/components/datasets/metadata/records/RecordSpecGenerator.vue
+++ b/src/components/datasets/metadata/records/RecordSpecGenerator.vue
@@ -491,13 +491,20 @@ const conceptValueSet = (property) => {
   const vs =
     property?.property?.['x-pennsieve-concept-valueset'] ||
     property?.property?.items?.['x-pennsieve-concept-valueset']
-  return vs && vs.ontology && vs.root ? vs : null
+  if (!vs || !vs.ontology) return null
+  // termset tier: whole flat list (no root); subtree tier: is_a subtree of `root`.
+  if (vs.tier === 'termset' && vs.slug) return vs
+  if (vs.root) return vs
+  return null
 }
 
 const conceptValueSetHint = (property) => {
   const vs = conceptValueSet(property)
   if (!vs) return ''
   const anchor = property?.property?.['x-pennsieve-concept']
+  if (vs.tier === 'termset') {
+    return `Search the ${anchor?.label || vs.ontology} termset for a term.`
+  }
   const rootLabel = anchor?.label || vs.root
   return `Search ${vs.ontology} for a term under “${rootLabel}”.`
 }
@@ -540,7 +547,10 @@ const runSubtreeSearch = async (key, vs, query) => {
   }
   subtreeSearching.value = { ...subtreeSearching.value, [key]: true }
   try {
-    const hits = await ontologyStore.searchSubtree(vs.root, term, { ontology: vs.ontology, limit: 25 })
+    // termset tier: flat search over the whole slice; subtree tier: restricted to root's descendants.
+    const hits = vs.tier === 'termset'
+      ? await ontologyStore.search(term, { ontologies: [vs.ontology], limit: 25 })
+      : await ontologyStore.searchSubtree(vs.root, term, { ontology: vs.ontology, limit: 25 })
     subtreeOptions.value = {
       ...subtreeOptions.value,
       [key]: hits.map((h) => ({ code: h.curie, label: h.label || h.curie }))

--- a/src/stores/ontologyStore.js
+++ b/src/stores/ontologyStore.js
@@ -483,10 +483,30 @@ export const useOntologyStore = defineStore('ontology', () => {
         return { members, overCap: members.length > cap }
     }
 
+    // All non-obsolete terms of an ontology/termset slice, as a flat value set.
+    // Termsets are flat (every member is a root with no in-slice is_a parent), so
+    // subtreeMembers can't enumerate them — this just reads the whole slice.
+    // Ordered by label, capped at cap+1 so a large slice becomes an over-cap
+    // reference rather than materializing thousands of options. Returns
+    // { members: [{ curie, label }], overCap }.
+    const allMembers = async (ontology, { cap = 512 } = {}) => {
+        await ensureOntology(ontology)
+        const src = sources.value.find((s) => s.ontology === ontology)
+        if (!src) return { members: [], overCap: false }
+        const rows = await duck.executeQuery(
+            `SELECT curie, label FROM ${src.table} WHERE COALESCE(obsolete, false) = false ORDER BY lower(label) LIMIT ${cap + 1}`,
+            connectionId,
+        )
+        const members = (rows || [])
+            .map((r) => ({ curie: r.curie == null ? '' : String(r.curie), label: r.label == null ? '' : String(r.label) }))
+            .filter((m) => m.curie)
+        return { members, overCap: members.length > cap }
+    }
+
     return {
         loading, loaded, error, available, sources, isConfigured,
         ensureRegistry, ensureOntology, ensureLoaded,
-        search, searchSubtree, descendants, ancestors, subtreeMembers,
+        search, searchSubtree, descendants, ancestors, subtreeMembers, allMembers,
         getByCurie, roots, children, lineage, labelsFor,
     }
 })


### PR DESCRIPTION
Same change set as the main-targeted PR #779, rebased onto `dev` (only the 2 relevant commits — 5 files).

## What
- **Ontology Browser**: registry-driven `display_name`/`summary`, `All / Ontologies / Termsets` filter pills, single full-width scroll row (fade + arrows), teal termset badge.
- **Property value sets**: use a whole termset ("Use entire termset") or multiple hand-picked terms (multi-pick with chips, capped at 10 + "+N more") as a property's value set. Under the inline cap → materialized `enum`; over the cap → `x-pennsieve-concept-valueset {tier:'termset', ontology, slug}` resolved live at record fill.
- `ontologyStore.allMembers`; `RecordSpecGenerator` termset-tier resolution.

## Compatibility
Record submission JSON unchanged (curie / array of curies). Only new schema is the `termset` tier in the existing `x-pennsieve-concept-valueset` annotation. Degrades gracefully against an old registry.

## Depends on
[cde-service#49](https://github.com/Pennsieve/cde-service/pull/49) (registry `kind`/`display_name`/`summary`/`workspaces`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)