### PR TITLE
fix(upload): stop stranding the tail of every upload batch

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -114,6 +114,9 @@ export default {
 
       // Bound handler reference so we can removeEventListener on unmount.
       _spotlightKeyHandler: null,
+
+      // Bound beforeunload handler guarding in-flight uploads.
+      _uploadUnloadHandler: null,
     };
   },
   mounted() {
@@ -121,6 +124,20 @@ export default {
       this.getActiveOrganization,
       this.onActiveOrgChange.bind(this)
     );
+
+    // Warn before navigating away mid-upload. Files whose S3 PUT has finished
+    // but whose finalize call hasn't been confirmed are invisible in the app
+    // until either the recovery replay below or the upload-service's daily
+    // reconcile sweep picks them up — so leaving here has a real cost the user
+    // can't see. Browsers ignore custom text and show their own prompt; the
+    // returnValue assignment is what triggers it.
+    this._uploadUnloadHandler = (e) => {
+      if (!this.$store.getters["uploadModule/getHasUnfinalizedWork"]()) return;
+      e.preventDefault();
+      e.returnValue = "";
+      return "";
+    };
+    window.addEventListener("beforeunload", this._uploadUnloadHandler);
 
     // Keep the document title in sync with the current route (org-less areas
     // like My Workspace rely on the route's meta.title, not the active org).
@@ -167,6 +184,9 @@ export default {
   beforeUnmount() {
     if (this._spotlightKeyHandler) {
       document.removeEventListener("keydown", this._spotlightKeyHandler);
+    }
+    if (this._uploadUnloadHandler) {
+      window.removeEventListener("beforeunload", this._uploadUnloadHandler);
     }
     EventBus.$off("open-chat-spotlight");
   },
@@ -309,6 +329,17 @@ export default {
      */
     onActiveOrgChange: function (activeOrg) {
       this.setPageMeta(activeOrg);
+
+      // First point in the app lifecycle where we know the user is
+      // authenticated, which the finalize endpoint requires. Replays any
+      // uploads whose S3 PUT completed in a previous session but never got
+      // finalized (tab refreshed/closed mid-upload). The action is a no-op
+      // when there's nothing journaled and guards itself against repeat runs.
+      if (activeOrg?.organization?.id) {
+        this.$store
+          .dispatch("uploadModule/recoverPendingFinalizes")
+          .catch((e) => console.warn("upload recovery failed", e));
+      }
     },
 
     /**

--- a/src/store/uploadModule.js
+++ b/src/store/uploadModule.js
@@ -7,6 +7,7 @@ import { v4 as uuidv4 } from 'uuid';
 import router from '@/router'
 import EventBus from '../utils/event-bus'
 import { useGetToken } from "@/composables/useGetToken";
+import finalizeJournal from '../utils/finalizeJournal'
 
 // Finalize batching matches the agent (pennsieve-agent/pkg/server/upload.go):
 // server accepts up to 250 files per POST /upload/manifest/files/finalize call
@@ -28,12 +29,37 @@ const FINALIZE_FLUSH_MS = 1000;
 // over-subscribing CPU on the checksum-per-part work.
 const UPLOAD_CONCURRENCY = 4;
 
-// Module-level guard to serialize finalize POSTs. Without this, the
-// batch-size trigger and the timer-based flush can both capture the same
-// pendingFinalize entries and fire duplicate requests — the second POST
-// would arrive with an empty batch (CLEAR_FINALIZE_QUEUE already ran) or,
-// worse, race on the `batch` snapshot. Not reactive — just a mutex.
-let finalizeInFlight = false;
+// Module-level mutex serializing finalize POSTs. Without it, the batch-size
+// trigger and the timer-based flush can both capture the same pendingFinalize
+// entries and fire duplicate requests — the second POST would arrive with an
+// empty batch (CLEAR_FINALIZE_QUEUE already ran) or, worse, race on the
+// `batch` snapshot.
+//
+// This is a promise chain rather than a boolean because a boolean forces
+// contending callers to choose between blocking and *dropping their work*.
+// The previous implementation returned early when the flag was set, relying on
+// "the next timer tick will pick it up" — which silently strands the tail of
+// every batch that loses this race at the end of the run, when the timer has
+// already been cleared and no next tick is coming. Chaining makes a contending
+// caller wait its turn instead, so `await flushFinalizeBatch()` is a real
+// guarantee that the queue was drained.
+let finalizeChain = Promise.resolve();
+
+// runExclusive queues fn behind any in-flight finalize POST and resolves with
+// fn's result. A rejection is surfaced to that caller but deliberately does not
+// poison the chain for subsequent callers.
+const runExclusive = (fn) => {
+    const result = finalizeChain.then(fn, fn);
+    finalizeChain = result.then(
+        () => undefined,
+        () => undefined
+    );
+    return result;
+};
+
+// Guards recoverPendingFinalizes so the replay runs at most once per app load,
+// even though the org watcher that kicks it can fire repeatedly.
+let recoveryRan = false;
 
 // Refresh storage credentials when the remaining TTL drops below 5 minutes —
 // same headroom the agent uses. STS returns ~1h creds.
@@ -192,7 +218,13 @@ export const mutations = {
         state.uploadFileMap = uploadFileMap
     },
     SET_FILE_STATUS(state, statusInfo) {
-        let curMap = state.uploadFileMap.get(statusInfo.key)
+        // Entry may already have been cleared (REMOVE_COMPLETED_FILE /
+        // CLEAR_COMPLETED_FILES / a new batch) by the time a late finalize
+        // response lands. Throwing here would reject flushFinalizeBatch and
+        // abort the drain loop with files still owed, so treat a missing row
+        // as nothing to update.
+        const curMap = state.uploadFileMap.get(statusInfo.key)
+        if (!curMap) return
         curMap.status = statusInfo.status
     },
     UPDATE_UPLOAD_PROGRESS(state, progressInfo) {
@@ -574,6 +606,21 @@ export const actions = {
                 }
 
                 commit('SET_FILE_STATUS', { key, status: "processing" })
+
+                // Journal before enqueueing. From here until the server
+                // confirms this uploadId, the bytes exist in S3 but the file
+                // is invisible in the app; the journal is what lets a
+                // refreshed/crashed tab replay the finalize instead of
+                // leaving the file for the next daily reconcile sweep.
+                finalizeJournal.add([{
+                    manifestNodeId: state.manifestNodeId,
+                    datasetId,
+                    uploadId: value.config.upload_id,
+                    size: value.file.size,
+                    sha256,
+                    onConflict: state.onConflict || 'keepBoth',
+                }])
+
                 commit('ENQUEUE_FINALIZE', {
                     uploadId: value.config.upload_id,
                     size: value.file.size,
@@ -617,8 +664,17 @@ export const actions = {
             clearInterval(flushTimer)
         }
 
-        // Final flush for any remainder below the batch threshold.
-        if (state.pendingFinalize.length > 0) {
+        // Drain whatever is left below the batch threshold.
+        //
+        // A loop, not a single call: the timer may have been mid-POST when we
+        // cleared it, and files that finished while that POST was in flight are
+        // still sitting in pendingFinalize. runExclusive makes each iteration
+        // wait for the previous POST rather than bail out, and with the workers
+        // finished and the timer stopped nothing new can be enqueued — so this
+        // terminates. flushFinalizeBatch clears the queue unconditionally
+        // before its POST, so every iteration removes at least one entry even
+        // when the request itself fails.
+        while (state.pendingFinalize.length > 0) {
             await dispatch('flushFinalizeBatch')
         }
 
@@ -635,15 +691,11 @@ export const actions = {
     // Per-file failure -> SET_FILE_STATUS=failed so the user sees which
     // file didn't make it. Request-level failures mark every queued file
     // as failed so the UI never silently "forgets" them.
-    flushFinalizeBatch: async ({ rootState, state, commit }) => {
-        // Serialize concurrent callers (timer-based flush + batch-size
-        // trigger + final post-loop flush). The second caller returns
-        // immediately; whatever accumulated while the first POST was
-        // in flight gets picked up by the next timer tick or the final
-        // flush after the worker pool drains.
-        if (finalizeInFlight) return
+    flushFinalizeBatch: ({ rootState, state, commit }) => runExclusive(async () => {
+        // Serializes against the other two callers (timer-based flush and the
+        // batch-size trigger) by queueing behind them rather than bailing out,
+        // so an awaited call is a real guarantee the queue was drained.
         if (state.pendingFinalize.length === 0) return
-        finalizeInFlight = true
         const batch = state.pendingFinalize.slice()
         commit('CLEAR_FINALIZE_QUEUE')
 
@@ -679,9 +731,14 @@ export const actions = {
             }
             const data = await resp.json()
             const byUploadId = new Map(batch.map(b => [b.uploadId, b.mapKey]))
+            const decided = []
             for (const r of data.results || []) {
                 const mapKey = byUploadId.get(r.uploadId)
                 if (!mapKey) continue
+                // The server reached a verdict on this uploadId, so replaying it
+                // later can't change the outcome — drop it from the journal
+                // whether it succeeded or was rejected.
+                decided.push(r.uploadId)
                 if (r.status === 'finalized') {
                     commit('SET_FILE_STATUS', { key: mapKey, status: 'finalized' })
                 } else {
@@ -694,7 +751,10 @@ export const actions = {
                     })
                 }
             }
+            finalizeJournal.remove(decided)
         } catch (e) {
+            // Request-level failure — no per-file verdict, so the journal
+            // entries stay put and get replayed on the next app load.
             console.error(e)
             for (const b of batch) {
                 commit('SET_FILE_STATUS', { key: b.mapKey, status: 'failed' })
@@ -705,8 +765,86 @@ export const actions = {
                     type: 'error',
                 },
             })
-        } finally {
-            finalizeInFlight = false
+        }
+    }),
+
+    // Replay finalize calls for files whose S3 PUT completed in a previous
+    // session but that were never confirmed by the server — the tab was
+    // refreshed, closed, or crashed in the gap between PUT and finalize.
+    //
+    // Runs once per app load. Deliberately does not touch uploadFileMap: the
+    // UI rows for those files are long gone, and the point here is purely to
+    // stop the file being invisible until the server-side reconcile sweep
+    // notices it a day or two later. Finalize is idempotent per uploadId, so
+    // re-sending one the server already handled is a no-op.
+    //
+    // Failures are swallowed: this is opportunistic repair on a code path the
+    // user didn't ask for, and the daily sweep is still the backstop.
+    recoverPendingFinalizes: async ({ rootState }) => {
+        if (recoveryRan) return
+        recoveryRan = true
+
+        finalizeJournal.prune()
+        const pending = finalizeJournal.groups()
+        if (pending.length === 0) return
+
+        let apiKey
+        try {
+            apiKey = await useGetToken()
+        } catch (e) {
+            // Not authenticated (yet) — leave the journal alone so a later
+            // load can retry.
+            recoveryRan = false
+            return
+        }
+
+        const endpoint = `${rootState.config.api2Url}/upload/manifest/files/finalize`
+        let recovered = 0
+
+        for (const group of pending) {
+            const url = `${endpoint}?${toQueryParams({ dataset_id: group.datasetId })}`
+            // Respect the server's per-request cap.
+            for (let i = 0; i < group.files.length; i += FINALIZE_BATCH_SIZE) {
+                const chunk = group.files.slice(i, i + FINALIZE_BATCH_SIZE)
+                try {
+                    const resp = await fetch(url, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'Authorization': `Bearer ${apiKey}`,
+                        },
+                        body: JSON.stringify({
+                            manifestNodeId: group.manifestNodeId,
+                            onConflict: group.onConflict,
+                            files: chunk,
+                        }),
+                    })
+                    if (!resp.ok) {
+                        // 403/404 means the manifest or dataset is gone (deleted,
+                        // or permissions changed) — nothing to recover, so clear
+                        // these rather than retrying on every load forever.
+                        if (resp.status === 403 || resp.status === 404) {
+                            finalizeJournal.remove(chunk.map(f => f.uploadId))
+                        }
+                        continue
+                    }
+                    const data = await resp.json()
+                    const decided = (data.results || []).map(r => r.uploadId)
+                    recovered += (data.results || []).filter(r => r.status === 'finalized').length
+                    finalizeJournal.remove(decided)
+                } catch (e) {
+                    console.warn('recoverPendingFinalizes: chunk failed', e)
+                }
+            }
+        }
+
+        if (recovered > 0) {
+            EventBus.$emit('toast', {
+                detail: {
+                    msg: `Resumed ${recovered} file${recovered === 1 ? '' : 's'} from an interrupted upload. They will appear shortly.`,
+                    type: 'info',
+                },
+            })
         }
     },
 
@@ -933,6 +1071,14 @@ export const getters = {
     },
     getOnConflict: state => () => {
         return state.onConflict
+    },
+    // True while leaving the page would strand files: either PUTs are still
+    // running, or bytes have landed in S3 but the server hasn't confirmed the
+    // finalize yet. Drives the beforeunload guard in App.vue. Reads the
+    // journal rather than pendingFinalize alone so files whose finalize POST
+    // is mid-flight still count.
+    getHasUnfinalizedWork: state => () => {
+        return state.isUploading || finalizeJournal.count() > 0
     },
     // Returns a Map<existingPackageId, uploadEntry> for replace-conflict
     // uploads targeting `folderId`. The DatasetFiles displayFiles walks

--- a/src/store/uploadModule.spec.js
+++ b/src/store/uploadModule.spec.js
@@ -1,0 +1,213 @@
+/* eslint-disable no-undef */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/router', () => ({
+    default: { currentRoute: { value: { params: { datasetId: 'N:dataset:test' } } } },
+}))
+vi.mock('@/composables/useGetToken', () => ({
+    useGetToken: () => Promise.resolve('test-token'),
+}))
+vi.mock('../utils/event-bus', () => ({
+    default: { $emit: vi.fn(), $on: vi.fn(), $off: vi.fn() },
+}))
+// The AWS SDK is only exercised by UploadFiles, which these tests don't drive.
+// Stubbed so importing the store doesn't pull the real client in.
+vi.mock('@aws-sdk/lib-storage', () => ({ Upload: class {} }))
+vi.mock('@aws-sdk/client-s3', () => ({
+    S3Client: class {},
+    ChecksumAlgorithm: { SHA256: 'SHA256' },
+}))
+
+import { actions, getters, mutations } from './uploadModule'
+import finalizeJournal from '../utils/finalizeJournal'
+
+const entry = (n) => ({
+    uploadId: `upload-${n}`,
+    size: 10,
+    sha256: `sha-${n}`,
+    mapKey: `key-${n}`,
+})
+
+const makeContext = (pending) => {
+    const state = {
+        manifestNodeId: 'manifest-1',
+        onConflict: 'keepBoth',
+        pendingFinalize: [...pending],
+        uploadFileMap: new Map(
+            pending.map((p) => [p.mapKey, { status: 'processing' }])
+        ),
+        isUploading: false,
+    }
+    return {
+        state,
+        rootState: { config: { api2Url: 'https://api.test' } },
+        commit: (name, payload) => mutations[name](state, payload),
+    }
+}
+
+// Resolves once the pending microtask/timer queue has drained, so an action
+// that is mid-`await` has a chance to reach its next suspension point.
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe('uploadModule finalize drain', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+        vi.restoreAllMocks()
+    })
+
+    it('queues a contending flush instead of dropping its batch', async () => {
+        const bodies = []
+        let releaseFirst
+        const firstGate = new Promise((r) => { releaseFirst = r })
+        let callCount = 0
+
+        global.fetch = vi.fn(async (url, opts) => {
+            const body = JSON.parse(opts.body)
+            bodies.push(body)
+            // Hold the first POST open so the second caller has to contend.
+            if (++callCount === 1) await firstGate
+            return {
+                ok: true,
+                json: async () => ({
+                    results: body.files.map((f) => ({
+                        uploadId: f.uploadId,
+                        status: 'finalized',
+                    })),
+                }),
+            }
+        })
+
+        const ctx = makeContext([entry(1), entry(2)])
+
+        const first = actions.flushFinalizeBatch(ctx)
+        await settle()
+
+        // First flush has claimed its batch and is blocked in fetch.
+        expect(bodies).toHaveLength(1)
+        expect(ctx.state.pendingFinalize).toHaveLength(0)
+
+        // Two more files finish their PUT while that POST is still in flight.
+        // This is the window the old boolean mutex dropped on the floor.
+        ctx.state.pendingFinalize.push(entry(3), entry(4))
+
+        const second = actions.flushFinalizeBatch(ctx)
+        releaseFirst()
+        await first
+        await second
+
+        expect(bodies).toHaveLength(2)
+        expect(bodies[1].files.map((f) => f.uploadId)).toEqual([
+            'upload-3',
+            'upload-4',
+        ])
+        expect(ctx.state.pendingFinalize).toHaveLength(0)
+    })
+
+    it('empties the queue even when the request fails, so a drain loop terminates', async () => {
+        global.fetch = vi.fn(async () => ({
+            ok: false,
+            status: 500,
+            text: async () => 'boom',
+        }))
+
+        const ctx = makeContext([entry(1)])
+        await actions.flushFinalizeBatch(ctx)
+
+        expect(ctx.state.pendingFinalize).toHaveLength(0)
+        expect(ctx.state.uploadFileMap.get('key-1').status).toBe('failed')
+    })
+
+    it('keeps journal entries after a request-level failure and clears them after a verdict', async () => {
+        finalizeJournal.add([{
+            manifestNodeId: 'manifest-1',
+            datasetId: 'N:dataset:test',
+            uploadId: 'upload-1',
+            size: 10,
+            sha256: 'sha-1',
+            onConflict: 'keepBoth',
+        }])
+        expect(finalizeJournal.count()).toBe(1)
+
+        // Request-level failure: no per-file verdict, entry must survive for a
+        // later replay.
+        global.fetch = vi.fn(async () => { throw new Error('offline') })
+        await actions.flushFinalizeBatch(makeContext([entry(1)]))
+        expect(finalizeJournal.count()).toBe(1)
+
+        // Server verdict: entry is settled either way and drops out.
+        global.fetch = vi.fn(async (url, opts) => {
+            const body = JSON.parse(opts.body)
+            return {
+                ok: true,
+                json: async () => ({
+                    results: body.files.map((f) => ({
+                        uploadId: f.uploadId,
+                        status: 'failed',
+                        error: 'object not found',
+                    })),
+                }),
+            }
+        })
+        await actions.flushFinalizeBatch(makeContext([entry(1)]))
+        expect(finalizeJournal.count()).toBe(0)
+    })
+
+    it('SET_FILE_STATUS ignores rows already cleared from the map', () => {
+        const state = { uploadFileMap: new Map() }
+        expect(() =>
+            mutations.SET_FILE_STATUS(state, { key: 'gone', status: 'finalized' })
+        ).not.toThrow()
+    })
+
+    it('reports unfinalized work while the journal is non-empty', () => {
+        const state = { isUploading: false }
+        expect(getters.getHasUnfinalizedWork(state)()).toBe(false)
+        finalizeJournal.add([{
+            manifestNodeId: 'm',
+            datasetId: 'd',
+            uploadId: 'u',
+            size: 1,
+            sha256: 's',
+        }])
+        expect(getters.getHasUnfinalizedWork(state)()).toBe(true)
+    })
+})
+
+describe('finalizeJournal', () => {
+    beforeEach(() => window.localStorage.clear())
+
+    it('groups outstanding files by dataset, manifest and conflict strategy', () => {
+        finalizeJournal.add([
+            { manifestNodeId: 'm1', datasetId: 'd1', uploadId: 'a', size: 1, sha256: 'x', onConflict: 'keepBoth' },
+            { manifestNodeId: 'm1', datasetId: 'd1', uploadId: 'b', size: 2, sha256: 'y', onConflict: 'keepBoth' },
+            { manifestNodeId: 'm2', datasetId: 'd1', uploadId: 'c', size: 3, sha256: 'z', onConflict: 'replace' },
+        ])
+
+        const groups = finalizeJournal.groups()
+        expect(groups).toHaveLength(2)
+
+        const keepBoth = groups.find((g) => g.onConflict === 'keepBoth')
+        expect(keepBoth.manifestNodeId).toBe('m1')
+        expect(keepBoth.files.map((f) => f.uploadId)).toEqual(['a', 'b'])
+
+        const replace = groups.find((g) => g.onConflict === 'replace')
+        expect(replace.files).toEqual([{ uploadId: 'c', size: 3, sha256: 'z' }])
+    })
+
+    it('deduplicates repeated adds of the same uploadId', () => {
+        const e = { manifestNodeId: 'm', datasetId: 'd', uploadId: 'a', size: 1, sha256: 'x' }
+        finalizeJournal.add([e])
+        finalizeJournal.add([e])
+        expect(finalizeJournal.count()).toBe(1)
+    })
+
+    it('survives localStorage being unavailable', () => {
+        const spy = vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
+            throw new Error('QuotaExceededError')
+        })
+        expect(() =>
+            finalizeJournal.add([{ manifestNodeId: 'm', datasetId: 'd', uploadId: 'a', size: 1, sha256: 'x' }])
+        ).not.toThrow()
+        spy.mockRestore()
+    })
+})

--- a/src/utils/finalizeJournal.js
+++ b/src/utils/finalizeJournal.js
@@ -1,0 +1,145 @@
+// Durable journal of files that finished their S3 PUT but have not yet been
+// confirmed finalized by the server.
+//
+// Why this exists: uploads are two-phase. The browser PUTs bytes straight to
+// the storage bucket, then POSTs /upload/manifest/files/finalize so the server
+// creates the package rows. Between those two steps the file exists in S3 but
+// is invisible in the app — its manifest_files row is still `Registered`. If
+// the tab is refreshed, closed, or crashes in that window, the finalize call
+// for those files is never made and nothing client-side remembers they were
+// owed. The upload-service reconcile sweep does eventually rescue them, but it
+// runs once a day with a 6h grace period, so the files surface one to two days
+// later — long after the user believed the upload was done.
+//
+// Writing the (uploadId, size, sha256) triple to localStorage the moment a PUT
+// completes makes that window survivable: on the next app load we replay the
+// leftovers. Those three fields are exactly what the finalize endpoint needs,
+// and they're only knowable client-side (sha256 comes back on the S3 multipart
+// completion response), so there is no server-side equivalent of this replay.
+//
+// Finalize is idempotent per uploadId — the server short-circuits anything
+// already in `Finalized` status — so a redundant replay is harmless.
+//
+// Every operation is best-effort. localStorage throws in Safari private mode
+// and when the origin is over quota; a journal failure must never break an
+// upload that would otherwise succeed, so all access is wrapped and failures
+// degrade to "no journal" rather than propagating.
+
+const STORAGE_KEY = 'pennsieve.finalizeJournal.v1'
+
+// Bounds so a pathological run can't wedge the origin's storage quota. 5k
+// entries is ~700 KB of JSON, comfortably inside the usual 5 MB budget and
+// well above any realistic count of *unfinalized* files (they're removed as
+// soon as the server confirms them, so steady state is near zero).
+const MAX_ENTRIES = 5000
+
+// Entries older than this are dropped unread. By then the server-side
+// reconcile sweep has long since handled the file one way or the other, so
+// replaying is pointless and we'd only be resurrecting stale uploadIds.
+const TTL_MS = 7 * 24 * 60 * 60 * 1000
+
+const read = () => {
+    try {
+        const raw = window.localStorage.getItem(STORAGE_KEY)
+        if (!raw) return []
+        const parsed = JSON.parse(raw)
+        return Array.isArray(parsed) ? parsed : []
+    } catch (e) {
+        // Corrupt or inaccessible — treat as empty rather than throwing into
+        // the upload path.
+        return []
+    }
+}
+
+const write = (entries) => {
+    try {
+        if (entries.length === 0) {
+            window.localStorage.removeItem(STORAGE_KEY)
+            return
+        }
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
+    } catch (e) {
+        // Quota exceeded or storage disabled. Nothing useful to do — the
+        // upload itself is unaffected, we just lose crash-recovery for it.
+        console.warn('finalizeJournal: unable to persist', e)
+    }
+}
+
+const isFresh = (entry, now) =>
+    entry && typeof entry.uploadId === 'string' && now - (entry.ts || 0) < TTL_MS
+
+// add records files whose S3 PUT just completed. Called once per file, right
+// after the PUT resolves and before the finalize POST is attempted.
+export const add = (entries) => {
+    if (!entries || entries.length === 0) return
+    const now = Date.now()
+    const existing = read().filter((e) => isFresh(e, now))
+    const seen = new Set(existing.map((e) => e.uploadId))
+    for (const e of entries) {
+        if (!e || !e.uploadId || seen.has(e.uploadId)) continue
+        existing.push({ ...e, ts: now })
+        seen.add(e.uploadId)
+    }
+    // Keep the newest when over the cap — the oldest entries are the ones the
+    // server-side sweep is most likely to have already dealt with.
+    write(existing.slice(-MAX_ENTRIES))
+}
+
+// remove drops entries the server has made a determination about, whether the
+// outcome was success or a per-file rejection. Only request-level failures
+// (network error, 5xx, expired token) leave entries in place, because those
+// are the cases where a retry can still change the outcome.
+export const remove = (uploadIds) => {
+    if (!uploadIds || uploadIds.length === 0) return
+    const drop = new Set(uploadIds)
+    const now = Date.now()
+    write(read().filter((e) => isFresh(e, now) && !drop.has(e.uploadId)))
+}
+
+// groups returns the outstanding entries bucketed by the tuple that has to be
+// constant across a single finalize request: the manifest it belongs to, the
+// dataset used for authorization, and the conflict strategy the user chose for
+// that batch. Replaying with a different onConflict than the user picked would
+// silently change whether their files replace or coexist with existing ones,
+// so the choice is journaled alongside the file.
+export const groups = () => {
+    const now = Date.now()
+    const out = new Map()
+    for (const e of read()) {
+        if (!isFresh(e, now)) continue
+        if (!e.manifestNodeId || !e.datasetId) continue
+        const key = `${e.datasetId}|${e.manifestNodeId}|${e.onConflict || 'keepBoth'}`
+        if (!out.has(key)) {
+            out.set(key, {
+                datasetId: e.datasetId,
+                manifestNodeId: e.manifestNodeId,
+                onConflict: e.onConflict || 'keepBoth',
+                files: [],
+            })
+        }
+        out.get(key).files.push({
+            uploadId: e.uploadId,
+            size: e.size,
+            sha256: e.sha256,
+        })
+    }
+    return [...out.values()]
+}
+
+// count is used by the unload guard to decide whether leaving the page would
+// strand anything.
+export const count = () => {
+    const now = Date.now()
+    return read().filter((e) => isFresh(e, now)).length
+}
+
+// prune expires stale entries. Called on load before a replay so the TTL is
+// enforced even if the user never uploads again.
+export const prune = () => {
+    const now = Date.now()
+    const entries = read()
+    const fresh = entries.filter((e) => isFresh(e, now))
+    if (fresh.length !== entries.length) write(fresh)
+}
+
+export default { add, remove, groups, count, prune }


### PR DESCRIPTION
## Problem

Users report the upload progress bar disappearing and files showing up **one to two days later**, forcing curators to re-verify "complete" datasets and delete duplicates.

Root cause is here in the web app, not in upload-service-v2. Uploads are two-phase: the browser PUTs bytes straight to the storage bucket, then POSTs `/upload/manifest/files/finalize` so the server creates the package rows. Between those steps a file exists in S3 but its `manifest_files` row is still `Registered` — invisible in the app. Nothing client-side made sure that second call actually happened for every file.

What eventually rescues them is upload-service-v2's reconcile sweep, which runs **once a day at 07:00 UTC with a 6h grace period**. That schedule is the "day or two."

Confirmed in prod on dataset `N:dataset:031598b5-88eb-44eb-ba70-67ad1c2fe36a` (a reporting investigator's):

| manifest | files | stranded in `Registered` | outcome |
|---|---|---|---|
| `faf16746…` | 64 | 10 | all 64 Finalized — the 10 recovered by the sweep the *next* morning |
| `93ec1b5e…` | 40 | 14 | 11 recovered, 3 `FailedOrphan` (PUT itself failed) |

Both manifests were created at ~01:50 UTC, so at 07:00 that same day they were still inside the 6h grace period and were skipped entirely — recovered 29h later. Zero upload-lambda errors for either: finalize was simply never called for those files.

## Two ways files got stranded

**1. The end-of-run flush race.** `UploadFiles` cleared the 1s flush timer and then made a *single* `flushFinalizeBatch()` call, while `flushFinalizeBatch` opened with `if (finalizeInFlight) return`. If a timer-driven POST was still in flight at that moment, the final flush bailed out, the remaining `pendingFinalize` entries were never sent, and the timer was already cleared so nothing retried. Then `SET_UPLOAD_COMPLETE(true)` hid the progress bar — literally the reported symptom.

Prod finalize POSTs take ~600 ms against a 1 s timer, so a POST is in flight roughly 60% of the time. This is not a rare window; it explains "sometimes."

Intermediate skipped ticks were harmless (the queue isn't cleared, the next tick picks them up). **Only the final flush was fatal.**

**2. Refresh / tab close between PUT and finalize.** Nothing remembered which files were owed a finalize. `(uploadId, size, sha256)` is only knowable in the browser — sha256 comes back on the S3 multipart completion response — so there was no server-side way to reconstruct it either.

## Fix

- **Promise-chained mutex** replaces the boolean. A contending caller now waits its turn instead of dropping its work, so `await flushFinalizeBatch()` is a real guarantee the queue was drained. Rejections don't poison the chain.
- **Loop-drain** after the worker pool finishes. Terminates because `CLEAR_FINALIZE_QUEUE` runs unconditionally before the POST, so every iteration removes at least one entry even when the request fails.
- **`utils/finalizeJournal`** — localStorage record written the instant each PUT completes, cleared once the server returns a verdict for that uploadId. `recoverPendingFinalizes` replays leftovers on the next authenticated app load. Finalize is idempotent per uploadId, so replaying one the server already handled is a no-op.
  - Entries survive *request-level* failures (retryable) but not *per-file* rejections (settled).
  - `onConflict` is journaled per file, so a replay can't silently flip a user's replace/keepBoth choice.
  - Capped at 5k entries, 7-day TTL, and every localStorage access degrades to a no-op rather than breaking an upload (Safari private mode, quota).
- **`beforeunload` guard** so navigating away mid-upload prompts first.
- **`SET_FILE_STATUS` tolerates a missing row.** It previously threw on a late finalize response for a cleared entry, which would reject `flushFinalizeBatch` and abort the new drain loop with files still owed.

## Testing

New `src/store/uploadModule.spec.js`, 8 tests. The key one is a genuine regression test: with the old boolean mutex it fails with `expected length 2 but got 1` — the second batch is dropped — and passes with the chain. Verified by temporarily reverting the mutex.

- `npx vitest run` → **427 tests pass, 0 failures.** (24 files fail to *collect*, all from a stale `.claude/worktrees/elegant-chatterjee-f495ea` git worktree missing its site-config — pre-existing, unrelated to this change. Worth removing separately.)
- `npm run build` → clean.

## Considered and rejected

`fetch(..., {keepalive: true})` on `pagehide` as a best-effort flush. It needs the auth token synchronously and `useGetToken()` is async, so it would mean caching tokens for an unload path — more fragility than the journal replay, which covers the same case deterministically.

## Follow-ups (not in this PR)

Two separate pre-existing prod problems found while tracing this:

1. **A permanent reconcile loop.** 210 files across 5 manifests (org 367, `dataset_id` 4191) are re-enqueued *every day* and always fail on `packages_dataset_id_fkey` — the dataset row is deleted. ~9,700 errors/30 days. This pins the upload DLQ at **1,470 messages** (210/day × 7-day retention), so that DLQ alarm has been paging VictorOps daily since ~June 15. It also inflates `OrphansRecovered`, since reconcile counts *enqueued* not *imported*. Fix belongs in upload-service-v2: treat a deleted dataset the way `markFailedOrphan` already treats a missing manifest.
2. **`pq: syntax error at or near "ON"`** — 2 occurrences in 30 days from the package-insert path. Genuinely malformed SQL.

Tightening the reconcile schedule to hourly would also shrink the blast radius of any future stranding from ~48h to ~1h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
