### PR TITLE
fix(proposals): repair the publisher dataset proposal review workflow

### DIFF
--- a/src/components/Publishing/PublishingProposalsList/PublishingProposalsList.vue
+++ b/src/components/Publishing/PublishingProposalsList/PublishingProposalsList.vue
@@ -97,14 +97,17 @@
 
       <request-survey
         :dialog-visible="requestModalVisible"
-        :dataset-request="selectedRequest"
-        :role="role"
+        :proposal="selectedRequest"
+        :repository="selectedRepository"
+        :read-only="true"
+        :show-review-actions="true"
         @accept="acceptDatasetProposalRequest"
         @reject="rejectDatasetProposalRequest"
+        @close="closeProposalDialog"
       />
 
       <confirmation-dialog
-        :visible="confirmationDialogVisible"
+        :dialog-visible="confirmationDialogVisible"
         :action="confirmationDialog.action"
         :action-message="confirmationDialog.actionMessage"
         :resource="confirmationDialog.resource"
@@ -134,6 +137,7 @@ import RequestSurvey from "../../user/publishing/ProposalSurvey.vue";
 import ConfirmationDialog from "../../shared/ConfirmationDialog/ConfirmationDialog.vue";
 import IconMagnifyingGlass from "../../icons/IconMagnifyingGlass.vue";
 import IconSort from "../../icons/IconSort.vue";
+import EventBus from "../../../utils/event-bus";
 
 export default {
   name: 'PublishingProposalsList',
@@ -179,10 +183,10 @@ export default {
 
   data() {
     return {
-      role: 'publisher',
       isLoadingDatasetsError: false,
       searchQuery: '',
-      selectedRequest: {},
+      selectedRequest: null,
+      selectedRepository: {},
       confirmationDialogVisible: false,
       confirmationDialog: {
         action: '',
@@ -311,18 +315,28 @@ export default {
     },
 
     viewProposal: function(proposal) {
+      if (!proposal) {
+        return
+      }
       // set selected proposal
-      if (proposal) {
-        this.selectedRequest = proposal
-        this.proposalStore.setSelectedProposal(proposal)
-      }
-      // set selected repo
-      if (proposal && proposal.organizationNodeId) {
-        let repository = this.getRepositoryByNodeId(proposal.organizationNodeId)
-        this.proposalStore.setSelectedRepo(repository)
-      }
+      this.selectedRequest = proposal
+      this.proposalStore.setSelectedProposal(proposal)
+
+      // set selected repo, so the repository questions render alongside
+      // the submitted survey responses
+      this.selectedRepository = proposal.organizationNodeId
+        ? this.getRepositoryByNodeId(proposal.organizationNodeId)
+        : {}
+      this.proposalStore.setSelectedRepo(this.selectedRepository)
+
       // enable modal visibility
       this.proposalStore.updateRequestModalVisible(true)
+    },
+
+    closeProposalDialog: function() {
+      this.proposalStore.updateRequestModalVisible(false)
+      this.selectedRequest = null
+      this.selectedRepository = {}
     },
 
     resetConfirmation: function() {
@@ -340,24 +354,48 @@ export default {
     },
 
     confirmedAction: async function(event) {
-      this.proposalStore.updateRequestModalVisible(false)
+      this.closeProposalDialog()
+      const { action, resource } = event
       this.resetConfirmation()
-      if (event.action && event.resource) {
-        switch (event.action) {
+      if (!action || !resource) {
+        return
+      }
+
+      try {
+        switch (action) {
           case "accept":
-            this.acceptDatasetProposal(event.resource)
-              .catch(err => console.error(err))
+            await this.acceptDatasetProposal(resource)
+            EventBus.$emit('toast', {
+              detail: {
+                type: 'success',
+                msg: `"${resource.name}" has been accepted.`
+              }
+            })
             break;
           case "reject":
-            this.rejectDatasetProposal(event.resource)
-              .catch(err => console.error(err))
+            await this.rejectDatasetProposal(resource)
+            EventBus.$emit('toast', {
+              detail: {
+                type: 'success',
+                msg: `"${resource.name}" has been rejected.`
+              }
+            })
             break;
         }
+      } catch (err) {
+        console.error(err)
+        EventBus.$emit('toast', {
+          detail: {
+            type: 'error',
+            msg: `Failed to ${action} "${resource.name}". Please try again.`
+          }
+        })
       }
     },
 
     acceptDatasetProposalRequest: function(proposal) {
       // raise Confirmation Dialog
+      this.closeProposalDialog()
       this.resetConfirmation()
       this.confirmationDialog = {
         action: 'accept',
@@ -371,14 +409,13 @@ export default {
     },
 
     acceptDatasetProposal: async function(proposal) {
-      // invoke repositoryModule::acceptProposal()
       await this.proposalStore.acceptProposal(proposal)
-      await this.fetchDatasetProposals()
-        .catch(err => console.error(err))
+      await this.refreshProposals()
     },
 
     rejectDatasetProposalRequest: function(proposal) {
       // raise Confirmation Dialog
+      this.closeProposalDialog()
       this.resetConfirmation()
       this.confirmationDialog = {
         action: 'reject',
@@ -392,10 +429,13 @@ export default {
     },
 
     rejectDatasetProposal: async function(proposal) {
-      // invoke repositoryModule::rejectProposal()
       await this.proposalStore.rejectProposal(proposal)
+      await this.refreshProposals()
+    },
+
+    // Reloads the list; the same response also refreshes the "Proposed" tab count
+    refreshProposals: async function() {
       await this.fetchDatasetProposals()
-        .catch(err => console.error(err))
     },
 
   },

--- a/src/components/Publishing/PublishingProposalsList/PublishingProposalsList.vue
+++ b/src/components/Publishing/PublishingProposalsList/PublishingProposalsList.vue
@@ -100,7 +100,7 @@
         :proposal="selectedRequest"
         :repository="selectedRepository"
         :read-only="true"
-        :show-review-actions="true"
+        :show-review-actions="isUserPublisher"
         @accept="acceptDatasetProposalRequest"
         @reject="rejectDatasetProposalRequest"
         @close="closeProposalDialog"
@@ -205,6 +205,10 @@ export default {
     ...mapState('publishingModule', [
       'publishingSearchParams',
       'isLoadingDatasets'
+    ]),
+
+    ...mapGetters([
+      'isUserPublisher'
     ]),
 
     ...mapGetters('publishingModule', [

--- a/src/components/Publishing/PublishingProposalsList/PublishingProposalsListItem.vue
+++ b/src/components/Publishing/PublishingProposalsList/PublishingProposalsListItem.vue
@@ -42,7 +42,7 @@
 
       <el-col :span="4">
         <div class="bf-dataset-list-item-stat-align">
-          <div class="dataset-actions">
+          <div v-if="isUserPublisher" class="dataset-actions">
             <div class="button-wrapper">
               <p>
                 <a
@@ -68,6 +68,7 @@
   </div>
 </template>
 <script>
+import { mapGetters } from "vuex";
 import FormatDate from "../../../mixins/format-date";
 import { DatasetProposalAction } from "../../../utils/constants";
 
@@ -84,6 +85,8 @@ export default {
   },
 
   computed: {
+    ...mapGetters(["isUserPublisher"]),
+
     /**
      * Compute title of dataset proposl
      */

--- a/src/components/Publishing/PublishingProposalsList/PublishingProposalsListItem.vue
+++ b/src/components/Publishing/PublishingProposalsList/PublishingProposalsListItem.vue
@@ -21,14 +21,10 @@
               Submitted on
               <strong>{{ updated }}</strong>
             </p>
-            <template>
-              <div v-if="email">
-                <p class="dataset-meta">
-                  Email address
-                  <strong>{{ email }}</strong>
-                </p>
-              </div>
-            </template>
+            <p v-if="email" class="dataset-meta">
+              Email address
+              <strong>{{ email }}</strong>
+            </p>
           </div>
         </div>
       </el-col>
@@ -74,20 +70,11 @@
 <script>
 import FormatDate from "../../../mixins/format-date";
 import { DatasetProposalAction } from "../../../utils/constants";
-import { useProposalStore } from '@/stores/proposalStore'
 
 export default {
   name: "PublishingProposalsListItem",
 
   mixins: [FormatDate],
-
-  setup() {
-    const proposalStore = useProposalStore()
-    
-    return {
-      proposalStore
-    }
-  },
 
   props: {
     proposal: {
@@ -126,14 +113,7 @@ export default {
     },
     //proposer's email will render if the email is provided adn not an empty string
     email() {
-      if (
-        this.proposal.emailAddress.length &&
-        this.proposal.emailAddress.trim().length
-      ) {
-        return this.proposal.emailAddress;
-      } else {
-        return "";
-      }
+      return this.proposal.emailAddress?.trim() || "";
     },
 
     storage: function () {
@@ -157,12 +137,8 @@ export default {
     },
 
     triggerRequest: function (request) {
-      if (request === "accept") {
-        this.proposalStore.acceptProposal(this.proposal);
-      }
-      if (request === "reject") {
-        this.proposalStore.rejectProposal(this.proposal);
-      }
+      // The parent raises a confirmation dialog and performs the action from
+      // there; acting here as well would accept/reject twice, unconfirmed.
       this.$emit(request, this.proposal);
     },
   },

--- a/src/components/bf-navigation/BfNavigation.vue
+++ b/src/components/bf-navigation/BfNavigation.vue
@@ -144,8 +144,14 @@
         </template>
       </bf-navigation-item>
 
+      <!--
+        Publishing is the Publishers team's review queue end to end; members
+        request publication from a dataset's own Publishing tab. Showing the
+        entry to everyone means a click that can only land on "you can't use
+        this" -- the section still explains itself when reached by URL.
+      -->
       <bf-navigation-item
-        v-if="!(pageNotFound || isWelcomeOrg) && !isWorkspaceGuest"
+        v-if="!(pageNotFound || isWelcomeOrg) && !isWorkspaceGuest && isUserPublisher"
         id="nav-publishing"
         :link="{ name: 'publishing', params: { orgId: activeOrganizationId } }"
         label="Publishing"

--- a/src/components/user/publishing/ProposalSurvey.vue
+++ b/src/components/user/publishing/ProposalSurvey.vue
@@ -24,6 +24,11 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  // Publisher reviewing a submitted proposal: offer Accept / Reject
+  showReviewActions: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const emit = defineEmits([
@@ -32,6 +37,8 @@ const emit = defineEmits([
   "submit-proposal",
   "recreate-proposal",
   "recreate-and-submit-proposal",
+  "accept",
+  "reject",
   "update:dialogVisible",
 ]);
 
@@ -41,7 +48,7 @@ const proposalStore = useProposalStore();
 const proposal = ref({
   name: "",
   description: "",
-  survey: [],
+  survey: {},
 });
 
 const selectedRepository = ref({});
@@ -59,6 +66,70 @@ const currentRepository = computed(() =>
 const repositoryQuestions = computed(() => {
   return currentRepository.value?.questions || [];
 });
+
+// When reviewing a submitted proposal, render every response we have, even if
+// its question is no longer part of the repository's question set.
+const displayedQuestions = computed(() => {
+  const questions = repositoryQuestions.value;
+  if (!props.readOnly) {
+    return questions;
+  }
+
+  const knownIds = new Set(questions.map((question) => String(question.id)));
+  const orphanedResponses = Object.keys(proposal.value.survey || {})
+    .filter((id) => !knownIds.has(String(id)) && proposal.value.survey[id])
+    .map((id) => ({ id, question: "Response" }));
+
+  return [...questions, ...orphanedResponses];
+});
+
+const dialogTitle = computed(() =>
+  props.readOnly ? "Dataset Proposal" : "Submit Dataset Proposal"
+);
+
+const submitterName = computed(() => props.proposal?.ownerName || "");
+
+const submitterEmail = computed(() => props.proposal?.emailAddress || "");
+
+const proposalStatus = computed(() => {
+  const statusMap = {
+    DRAFT: "Draft",
+    SUBMITTED: "Submitted",
+    ACCEPTED: "Accepted",
+    REJECTED: "Rejected",
+    WITHDRAWN: "Withdrawn",
+  };
+  const status = props.proposal?.proposalStatus;
+  return status ? statusMap[status] || status : "";
+});
+
+const submittedOn = computed(() => {
+  const timestamp = props.proposal?.submittedAt || props.proposal?.updatedAt;
+  if (!timestamp) {
+    return "";
+  }
+  // Timestamps come back as epoch seconds
+  const date =
+    timestamp > 1000000000000
+      ? new Date(timestamp)
+      : new Date(timestamp * 1000);
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+});
+
+const hasSubmissionSummary = computed(
+  () =>
+    props.readOnly &&
+    Boolean(
+      submitterName.value ||
+        submitterEmail.value ||
+        proposalStatus.value ||
+        submittedOn.value
+    )
+);
 
 const readyToSave = computed(() => {
   // For updating existing proposals, allow saving even if incomplete
@@ -132,6 +203,10 @@ watch(
 watch(
   () => selectedRepository.value.organizationNodeId,
   (newNodeId, oldNodeId) => {
+    // Read-only reviews never switch repositories; re-running this on open
+    // would clear the responses we just populated
+    if (props.readOnly) return;
+
     if (oldNodeId && newNodeId !== oldNodeId) {
       // Save current survey answers before switching
       if (oldNodeId) {
@@ -167,7 +242,7 @@ function clearForm() {
   proposal.value = {
     name: "",
     description: "",
-    survey: [],
+    survey: {},
   };
 }
 
@@ -197,7 +272,7 @@ function populateForm() {
     };
 
     // Convert survey array to object format for the form
-    if (props.proposal.survey && Array.isArray(props.proposal.survey)) {
+    if (Array.isArray(props.proposal.survey)) {
       const surveyObject = {};
       props.proposal.survey.forEach((item) => {
         if (item.questionId !== undefined && item.response) {
@@ -205,11 +280,22 @@ function populateForm() {
         }
       });
       proposal.value.survey = surveyObject;
+    } else if (props.proposal.survey && typeof props.proposal.survey === "object") {
+      // Already keyed by question id
+      proposal.value.survey = { ...props.proposal.survey };
     }
   } else {
     // New proposal - clear form
     clearForm();
   }
+}
+
+function acceptProposal() {
+  emit("accept", props.proposal);
+}
+
+function rejectProposal() {
+  emit("reject", props.proposal);
 }
 
 function handleRepositoryChange(repository) {
@@ -341,16 +427,50 @@ function submitProposal() {
       class="proposal-dialog"
     >
       <template #header>
-        <bf-dialog-header
-          title="Submit Dataset Proposal"
-          class="dialog-header"
-        />
+        <bf-dialog-header :title="dialogTitle" class="dialog-header" />
       </template>
 
       <div class="proposal-content">
-        <!-- Read-only Close Button -->
+        <!-- Submission Summary (review) -->
+        <div class="submission-summary" v-if="hasSubmissionSummary">
+          <div class="summary-fields">
+            <p v-if="submitterName">
+              Submitted by <strong>{{ submitterName }}</strong>
+            </p>
+            <p v-if="submitterEmail">
+              Email <strong>{{ submitterEmail }}</strong>
+            </p>
+            <p v-if="submittedOn">
+              Submitted on <strong>{{ submittedOn }}</strong>
+            </p>
+            <p v-if="proposalStatus">
+              Status <strong>{{ proposalStatus }}</strong>
+            </p>
+          </div>
+        </div>
+
+        <!-- Read-only Actions -->
         <div class="read-only-actions" v-if="readOnly">
-          <bf-button @click="closeDialog" class="primary"> Close </bf-button>
+          <bf-button
+            v-if="showReviewActions"
+            class="secondary"
+            @click="rejectProposal"
+          >
+            Reject Proposal
+          </bf-button>
+          <bf-button
+            v-if="showReviewActions"
+            class="primary"
+            @click="acceptProposal"
+          >
+            Accept Proposal
+          </bf-button>
+          <bf-button
+            @click="closeDialog"
+            :class="showReviewActions ? 'secondary' : 'primary'"
+          >
+            Close
+          </bf-button>
         </div>
 
         <!-- Progress Indicator -->
@@ -481,14 +601,17 @@ function submitProposal() {
           </div>
 
           <!-- Repository-specific Questions -->
-          <div class="form-section" v-if="repositoryQuestions.length > 0">
+          <div class="form-section" v-if="displayedQuestions.length > 0">
             <div class="section-header">
               <h4>
                 <span class="field-number">3</span>
                 Repository Requirements
                 <span class="required-indicator">*</span>
               </h4>
-              <p class="field-description">
+              <p class="field-description" v-if="readOnly">
+                Responses to the repository's questions
+              </p>
+              <p class="field-description" v-else>
                 Answer the following questions specific to
                 {{ currentRepository.displayName }}
               </p>
@@ -496,7 +619,7 @@ function submitProposal() {
 
             <div class="questions-grid">
               <div
-                v-for="(question, index) in repositoryQuestions"
+                v-for="question in displayedQuestions"
                 :key="question.id"
                 class="question-item"
                 :class="{ 'field-completed': proposal.survey[question.id] }"
@@ -1111,7 +1234,28 @@ function submitProposal() {
 .read-only-actions {
   display: flex;
   justify-content: flex-end;
+  gap: 8px;
   padding: 0 0 24px 0;
   margin-top: 24px;
+}
+
+.submission-summary {
+  margin-top: 24px;
+
+  .summary-fields {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 32px;
+
+    p {
+      margin: 0;
+      color: theme.$gray_5;
+      font-size: 14px;
+
+      strong {
+        color: theme.$gray_6;
+      }
+    }
+  }
 }
 </style>

--- a/src/composables/useGetPrimaryData.js
+++ b/src/composables/useGetPrimaryData.js
@@ -49,14 +49,22 @@ export async function useGetPrimaryData() {
         const activeOrgId = activeOrganization.organization.id
         const teamUrl = `${siteConfig.apiUrl}/organizations/${activeOrgId}/teams?api_key=${token}`
 
+        // Publisher membership drives what the Publishing section offers, so a
+        // failure here must not take the rest of the primary data down with it —
+        // an empty publishers list silently demotes every publisher instead.
         const teamAndPublishersPromise = useSendXhr(teamUrl)
             .then(response => store.dispatch('updateTeams', response))
             .then(() => {
                 const publisherTeam = store.getters.publisherTeam
+                if (!publisherTeam) {
+                    // Workspace has no system publishers team
+                    return store.dispatch('updatePublishers', [])
+                }
                 const publisherTeamMembersUrl = `${siteConfig.apiUrl}/organizations/${activeOrgId}/teams/${publisherTeam.id}/members?api_key=${token}`
                 return useSendXhr(publisherTeamMembersUrl)
                     .then(publisherTeamMembers => store.dispatch('updatePublishers', publisherTeamMembers))
             })
+            .catch(err => console.warn('Failed to load teams or publishers:', err))
 
         const orgMembersUrl = `${siteConfig.apiUrl}/organizations/${activeOrgId}/members?api_key=${token}`
         let orgMembersPromise

--- a/src/composables/useGetPrimaryData.js
+++ b/src/composables/useGetPrimaryData.js
@@ -64,7 +64,12 @@ export async function useGetPrimaryData() {
                 return useSendXhr(publisherTeamMembersUrl)
                     .then(publisherTeamMembers => store.dispatch('updatePublishers', publisherTeamMembers))
             })
-            .catch(err => console.warn('Failed to load teams or publishers:', err))
+            .catch(err => {
+                console.warn('Failed to load teams or publishers:', err)
+                // Resolve publishersLoading either way; leaving it pending
+                // strands anything that waits on publisher membership.
+                return store.dispatch('updatePublishers', [])
+            })
 
         const orgMembersUrl = `${siteConfig.apiUrl}/organizations/${activeOrgId}/members?api_key=${token}`
         let orgMembersPromise

--- a/src/router/Publishing/PublishingView.vue
+++ b/src/router/Publishing/PublishingView.vue
@@ -25,17 +25,21 @@
           <IconLockFilled :width="40" :height="40" color="currentColor" />
         </div>
         <h2 class="publishers-only-heading">Available to the Publishers team</h2>
-        <p>
+        <p class="publishers-only-copy">
           Reviewing datasets and proposals submitted to this workspace is
           limited to members of the Publishers team. A workspace administrator
           can add you to it.
         </p>
-        <p>
-          Your own dataset proposals are under
+        <p class="publishers-only-copy">
+          To request publication of a dataset, or to follow a request you have
+          already made, open that dataset and go to its
+          <strong>Publishing</strong> tab.
+        </p>
+        <p class="publishers-only-copy">
+          Proposals you have submitted to open repositories are under
           <router-link :to="{ name: 'dataset-proposals' }">
             My Workspace &rsaquo; Data Publishing
-          </router-link>. To check whether one of your datasets has been
-          published, open that dataset and see Settings &rsaquo; Publishing.
+          </router-link>.
         </p>
       </bf-empty-page-state>
     </template>
@@ -84,8 +88,8 @@ export default {
     /**
      * Reviewing datasets and proposals submitted to the workspace is a
      * Publishers-team function, and publishing-service enforces it server-side.
-     * Members follow their own submissions from My Workspace > Data Publishing
-     * and each dataset's Settings > Publishing page instead.
+     * Members request publication from a dataset's own Publishing tab, and
+     * track proposals from My Workspace > Data Publishing.
      */
     canReviewPublishing: function () {
       return this.isUserPublisher;
@@ -278,5 +282,10 @@ export default {
   font-size: 20px;
   font-weight: 500;
   margin: 0 0 8px;
+}
+
+.publishers-only-copy {
+  margin: 0 0 8px;
+  max-width: 480px;
 }
 </style>

--- a/src/router/Publishing/PublishingView.vue
+++ b/src/router/Publishing/PublishingView.vue
@@ -65,7 +65,7 @@ export default {
     ...mapState("publishingModule", ["totalCounts"]),
 
     tabs: function () {
-      return [
+      const tabs = [
         {
           name: this.isUserPublisher
             ? "Ready for Review "
@@ -84,12 +84,19 @@ export default {
             "Rejected (" + this.getTotalCount(PublicationTabs.REJECTED) + ")",
           to: PublicationTabs.REJECTED,
         },
-        {
+      ];
+
+      // The workspace proposal review queue is publisher-only. Members track
+      // their own proposals under My Workspace → Data Publishing instead.
+      if (this.isUserPublisher) {
+        tabs.push({
           name:
             "Proposed (" + this.getTotalCount(PublicationTabs.PROPOSED) + ")",
           to: PublicationTabs.PROPOSED,
-        },
-      ];
+        });
+      }
+
+      return tabs;
     },
 
     /**
@@ -190,7 +197,11 @@ export default {
 
       this.getDatasetCount(PublicationTabs.REJECTED);
 
-      this.getDatasetProposalCount(PublicationTabs.PROPOSED);
+      // Proposal counts come from a publisher-only endpoint; asking as a
+      // non-publisher only earns a 401.
+      if (this.isUserPublisher) {
+        this.getDatasetProposalCount(PublicationTabs.PROPOSED);
+      }
     },
   },
 };

--- a/src/router/Publishing/PublishingView.vue
+++ b/src/router/Publishing/PublishingView.vue
@@ -6,13 +6,38 @@
           <org-breadcrumb page-name="Publishing" :sub-page-name="currentTabName" :page-route="{ name: 'review' }" />
         </template>
       </bf-rafter>
-      <div class="content-tabs">
+      <div
+        v-if="canReviewPublishing"
+        class="content-tabs"
+      >
         <router-tabs :tabs="tabs" />
       </div>
     </template>
 
     <template #stage>
-      <router-view name="stage" />
+      <router-view
+        v-if="canReviewPublishing"
+        name="stage"
+      />
+
+      <bf-empty-page-state v-else-if="!isLoadingPublishers">
+        <div class="publishers-only-illustration">
+          <IconLockFilled :width="40" :height="40" color="currentColor" />
+        </div>
+        <h2 class="publishers-only-heading">Available to the Publishers team</h2>
+        <p>
+          Reviewing datasets and proposals submitted to this workspace is
+          limited to members of the Publishers team. A workspace administrator
+          can add you to it.
+        </p>
+        <p>
+          Your own dataset proposals are under
+          <router-link :to="{ name: 'dataset-proposals' }">
+            My Workspace &rsaquo; Data Publishing
+          </router-link>. To check whether one of your datasets has been
+          published, open that dataset and see Settings &rsaquo; Publishing.
+        </p>
+      </bf-empty-page-state>
     </template>
   </bf-page>
 </template>
@@ -22,6 +47,8 @@ import { mapActions, mapGetters, mapState } from "vuex";
 
 import BfPage from "../../components/layout/BfPage/BfPage.vue";
 import BfStage from "../../components/layout/BfStage/BfStage.vue";
+import BfEmptyPageState from "../../components/shared/bf-empty-page-state/BfEmptyPageState.vue";
+import IconLockFilled from "../../components/icons/IconLockFilled.vue";
 import BfRafter from "../../components/shared/bf-rafter/BfRafter.vue";
 import BfButton from "../../components/shared/bf-button/BfButton.vue";
 import OrgBreadcrumb from "../../components/shared/OrgBreadcrumb/OrgBreadcrumb.vue";
@@ -40,6 +67,8 @@ export default {
     BfPage,
     BfStage,
     BfRafter,
+    BfEmptyPageState,
+    IconLockFilled,
     OrgBreadcrumb,
   },
 
@@ -50,7 +79,26 @@ export default {
 
     ...mapGetters("publishingModule", ["getTotalCount"]),
 
-    ...mapState(["config", "activeOrganization", "primaryNavOpen"]),
+    ...mapState(["config", "activeOrganization", "primaryNavOpen", "publishersLoading"]),
+
+    /**
+     * Reviewing datasets and proposals submitted to the workspace is a
+     * Publishers-team function, and publishing-service enforces it server-side.
+     * Members follow their own submissions from My Workspace > Data Publishing
+     * and each dataset's Settings > Publishing page instead.
+     */
+    canReviewPublishing: function () {
+      return this.isUserPublisher;
+    },
+
+    /**
+     * Publisher membership arrives with the workspace's primary data, so hold
+     * the gate until it has resolved rather than flashing the empty state at
+     * an actual publisher.
+     */
+    isLoadingPublishers: function () {
+      return this.publishersLoading;
+    },
 
     currentTabName() {
       const routeToTab = {
@@ -65,13 +113,9 @@ export default {
     ...mapState("publishingModule", ["totalCounts"]),
 
     tabs: function () {
-      const tabs = [
+      return [
         {
-          name: this.isUserPublisher
-            ? "Ready for Review "
-            : "Pending Review (" +
-              this.getTotalCount(PublicationTabs.REVIEW) +
-              ")",
+          name: "Ready for Review ",
           to: PublicationTabs.REVIEW,
         },
         {
@@ -84,19 +128,12 @@ export default {
             "Rejected (" + this.getTotalCount(PublicationTabs.REJECTED) + ")",
           to: PublicationTabs.REJECTED,
         },
-      ];
-
-      // The workspace proposal review queue is publisher-only. Members track
-      // their own proposals under My Workspace → Data Publishing instead.
-      if (this.isUserPublisher) {
-        tabs.push({
+        {
           name:
             "Proposed (" + this.getTotalCount(PublicationTabs.PROPOSED) + ")",
           to: PublicationTabs.PROPOSED,
-        });
-      }
-
-      return tabs;
+        },
+      ];
     },
 
     /**
@@ -138,10 +175,22 @@ export default {
   },
 
   mounted: function () {
-    this.getPublishingData();
+    if (this.canReviewPublishing) {
+      this.getPublishingData();
+    }
     if (this.$route.params.datasetSettingsPage) {
       this.togglePrimaryNav(true);
     }
+  },
+
+  watch: {
+    // Publisher membership can land after this view mounts, on a hard refresh
+    // straight onto /publishing or on a workspace switch.
+    canReviewPublishing: function (canReview) {
+      if (canReview) {
+        this.getPublishingData();
+      }
+    },
   },
 
   beforeRouteEnter(to, from, next) {
@@ -197,11 +246,7 @@ export default {
 
       this.getDatasetCount(PublicationTabs.REJECTED);
 
-      // Proposal counts come from a publisher-only endpoint; asking as a
-      // non-publisher only earns a 401.
-      if (this.isUserPublisher) {
-        this.getDatasetProposalCount(PublicationTabs.PROPOSED);
-      }
+      this.getDatasetProposalCount(PublicationTabs.PROPOSED);
     },
   },
 };
@@ -214,5 +259,24 @@ export default {
   background: white;
   border-bottom: 1px solid theme.$gray_2;
   padding: 0 32px;
+}
+
+.publishers-only-illustration {
+  align-items: center;
+  background: theme.$purple_tint;
+  border-radius: 50%;
+  color: theme.$purple_2;
+  display: flex;
+  height: 80px;
+  justify-content: center;
+  margin-bottom: 24px;
+  width: 80px;
+}
+
+.publishers-only-heading {
+  color: theme.$gray_6;
+  font-size: 20px;
+  font-weight: 500;
+  margin: 0 0 8px;
 }
 </style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1765,18 +1765,6 @@ const router = createRouter({
             stage: {
               publicationStatus: [PublicationStatus.PROPOSED],
             }
-          },
-          // Reviewing workspace proposals is publisher-only server-side
-          // (publishing-service authorizes on IsPublisher), so keep
-          // non-publishers off the tab rather than showing them a queue
-          // that can only 401.
-          beforeEnter: async (to, from, next) => {
-            const { default: store } = await import('@/store')
-            if (store.getters.isUserPublisher) {
-              next()
-            } else {
-              next({ name: PublicationTabs.REVIEW, params: to.params })
-            }
           }
         }
       ],

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1765,6 +1765,18 @@ const router = createRouter({
             stage: {
               publicationStatus: [PublicationStatus.PROPOSED],
             }
+          },
+          // Reviewing workspace proposals is publisher-only server-side
+          // (publishing-service authorizes on IsPublisher), so keep
+          // non-publishers off the tab rather than showing them a queue
+          // that can only 401.
+          beforeEnter: async (to, from, next) => {
+            const { default: store } = await import('@/store')
+            if (store.getters.isUserPublisher) {
+              next()
+            } else {
+              next({ name: PublicationTabs.REVIEW, params: to.params })
+            }
           }
         }
       ],

--- a/src/store/publishingModule.js
+++ b/src/store/publishingModule.js
@@ -266,36 +266,33 @@ export const actions = {
     const types = PublicationTabsTypes[type]
     const isOnPublishedTab = statuses.includes(PublicationStatus.COMPLETED)
 
-    useGetToken()
-        .then(token => {
-          const queryParams = toQueryParams({
-            publicationStatus: statuses,
-            publicationType: types,
-            api_key: token,
-            limit: 0
-          })
+    try {
+      const token = await useGetToken()
 
-          const url = isOnPublishedTab
-              ? `${rootState.config.apiUrl}/datasets/published/paginated?${queryParams}`
-              : `${rootState.config.apiUrl}/datasets/paginated?${queryParams}`
-          try {
-            fetch(url)
-                .then(resp => {
-                  if (resp.ok) {
-                    resp.json()
-                        .then(json => {
-                          commit('UPDATE_PUBLISHING_TOTAL_COUNT', { type, count: json.totalCount })
-                        })
-                  } else {
-                    throw new Error(resp.statusText)
-                  }
-                })
+      const queryParams = toQueryParams({
+        publicationStatus: statuses,
+        publicationType: types,
+        api_key: token,
+        limit: 0
+      })
 
-          } catch (err) {
-            EventBus.$emit('ajaxError', err)
-          }
+      const url = isOnPublishedTab
+          ? `${rootState.config.apiUrl}/datasets/published/paginated?${queryParams}`
+          : `${rootState.config.apiUrl}/datasets/paginated?${queryParams}`
 
-        })
+      const resp = await fetch(url)
+      if (!resp.ok) {
+        throw new Error(`Failed to fetch ${type} count: ${resp.status} ${resp.statusText}`)
+      }
+
+      const json = await resp.json()
+      commit('UPDATE_PUBLISHING_TOTAL_COUNT', { type, count: json.totalCount })
+    } catch (err) {
+      // the throw used to happen inside a .then(), surfacing as an
+      // unhandled rejection instead of reaching this handler
+      console.error(err)
+      EventBus.$emit('ajaxError', err)
+    }
   },
 
   getDatasetProposalCount: async ({ commit, rootState }, type) => {
@@ -337,12 +334,15 @@ export const actions = {
     // }
    
     let url = `${rootState.config.api2Url}/publishing/submission`
-    const apiKey = await useGetToken()
+    commit('UPDATE_IS_LOADING_DATASETS', true);
 
-    const myHeaders = new Headers();
-    myHeaders.append('Authorization', 'Bearer ' + apiKey)
-    myHeaders.append('Accept', 'application/json')
     try {
+      const apiKey = await useGetToken()
+
+      const myHeaders = new Headers();
+      myHeaders.append('Authorization', 'Bearer ' + apiKey)
+      myHeaders.append('Accept', 'application/json')
+
       const response = await fetch(url, {
         method: "GET",
         headers: myHeaders,
@@ -350,14 +350,15 @@ export const actions = {
       if (response.ok) {
         const { proposals, totalCount } = await response.json()
         commit('UPDATE_PUBLISHING_SEARCH_TOTAL_COUNT', totalCount);
+        commit('UPDATE_PUBLISHING_TOTAL_COUNT', { type: PublicationTabs.PROPOSED, count: totalCount });
         commit('UPDATE_DATASETS', { type: router.currentRoute.value.name, datasets: proposals });
-        commit('UPDATE_IS_LOADING_DATASETS', false);
-
       } else {
-        throw new Error(response.statusText)
+        throw new Error(`Failed to fetch dataset proposals: ${response.status} ${response.statusText}`)
       }
     } catch (err) {
       EventBus.$emit('ajaxError', err)
+    } finally {
+      commit('UPDATE_IS_LOADING_DATASETS', false);
     }
   },
 

--- a/src/stores/proposalStore.js
+++ b/src/stores/proposalStore.js
@@ -433,7 +433,7 @@ export const useProposalStore = defineStore('proposalStore', () => {
           result: acceptedProposal
         }
       } else {
-        throw new Error(response.statusText)
+        throw new Error(`Failed to accept proposal: ${response.status} ${response.statusText}`)
       }
     } catch (err) {
       console.error('Failed to accept proposal:', err)
@@ -472,7 +472,7 @@ export const useProposalStore = defineStore('proposalStore', () => {
           result: rejectedProposal
         }
       } else {
-        throw new Error(response.statusText)
+        throw new Error(`Failed to reject proposal: ${response.status} ${response.statusText}`)
       }
     } catch (err) {
       console.error('Failed to reject proposal:', err)


### PR DESCRIPTION
Reviewing a submitted dataset proposal on `/publishing/proposed` was broken end to end: the dialog opened empty, and accepting did nothing visible while the proposal was accepted server-side anyway.

## What was wrong

- **Empty review dialog.** `ProposalSurvey.vue` was rewritten in fe46cbd9 with new props (`proposal`, `repository`, `readOnly`), but `PublishingProposalsList.vue` still passed the old `dataset-request` / `role`. `props.proposal` was undefined, so `populateForm()` fell through to `clearForm()`. No `repository` meant the repo-specific questions had nothing to render from, and nothing listened for `close`, so Cancel/X/ESC couldn't dismiss the dialog.
- **Accept/Reject did nothing.** `ConfirmationDialog` takes a `dialogVisible` prop; the list bound `:visible`. The confirm step never rendered.
- **…except it did.** `PublishingProposalsListItem.triggerRequest` called `proposalStore.acceptProposal()` directly *and* emitted the event that raises the confirmation, so the action fired twice and unconfirmed — hence "nothing happened, but it's gone after a refresh".
- **Silent failures.** `new Error(response.statusText)` yields a message-less `Error` over HTTP/2, and `getDatasetCount` threw inside a `.then()`, escaping its own `try/catch` as an unhandled rejection.

## Changes

- Correct prop wiring; resolve and pass the repository so questions render beside the submitted answers.
- Read-only review mode with Accept/Reject in the dialog and a submitter/email/submitted-on/status summary.
- Skip the repository-switch watcher when read-only — it cleared the answers just populated when reopening for a proposal in another repository.
- Render survey responses whose question is no longer in the repository's question set, so a submitted answer is never silently hidden.
- Await accept/reject, toast success or failure, refresh the list and the Proposed tab count from one response.
- `fetchDatasetProposals` sets `isLoadingDatasets` (the `v-loading` overlay was dead code) and clears it in a `finally`.
- Status codes in the proposal fetch and accept/reject errors; `getDatasetCount` rewritten with async/await.

## Testing

Not yet verified against a live workspace — the dev session was 401ing on `/publishing/submission` throughout (see below). Each changed SFC compiles under `vue/compiler-sfc`; both store modules parse. Needs a manual pass on `/publishing/proposed`: open a submitted proposal, confirm the fields populate, then accept and confirm the row leaves and the badge decrements.

## Known issues this does not fix

- `/publishing/submission*` resolves publisher rights from `users.preferred_org_id` rather than the workspace in the request, so a publisher can be served another workspace's proposals or get an opaque 401 — [868kkerdw](https://app.clickup.com/t/868kkerdw).
- The Published tab 500s on an unrelated Elasticsearch mapping problem — [868kkevg4](https://app.clickup.com/t/868kkevg4).

Tracked under the [Dataset Proposal Workflow Hardening](https://app.clickup.com/8664796/v/l/li/901114258913) epic; this PR is [868kker89](https://app.clickup.com/t/868kker89).
