### PR TITLE
feat(notifications): add event batching to coalesce notification floods

### DIFF
--- a/src/utils/notificationBatcher.js
+++ b/src/utils/notificationBatcher.js
@@ -1,0 +1,68 @@
+// utils/notificationBatcher.js
+// Coalesces bursts of same-category events on the same dataset (e.g. a bulk
+// upload firing hundreds of FILES events) into a single NotificationEvent
+// instead of flooding a user's feed with one row per event.
+
+function defaultFormatMessage(count, sampleEvent) {
+  if (count === 1) {
+    return sampleEvent.message
+  }
+  return `${count} ${sampleEvent.category.toLowerCase()} events`
+}
+
+function bucketKey(event) {
+  return `${event.datasetId}:${event.category}:${event.eventType}`
+}
+
+export class NotificationBatcher {
+  constructor({ windowMs = 5 * 60 * 1000, onFlush, formatMessage = defaultFormatMessage } = {}) {
+    if (typeof onFlush !== 'function') {
+      throw new Error('NotificationBatcher requires an onFlush callback')
+    }
+    this.windowMs = windowMs
+    this.onFlush = onFlush
+    this.formatMessage = formatMessage
+    this.buckets = new Map()
+  }
+
+  ingest(event) {
+    const key = bucketKey(event)
+    const bucket = this.buckets.get(key)
+
+    if (!bucket) {
+      this.buckets.set(key, {
+        count: 1,
+        sampleEvent: event,
+        firstAt: event.createdAt,
+        timer: setTimeout(() => this.flush(key), this.windowMs)
+      })
+      return
+    }
+
+    bucket.count += 1
+  }
+
+  flush(key) {
+    const bucket = this.buckets.get(key)
+    if (!bucket) {
+      return
+    }
+
+    clearTimeout(bucket.timer)
+    this.buckets.delete(key)
+
+    const { datasetId, category, eventType } = bucket.sampleEvent
+    this.onFlush({
+      datasetId,
+      category,
+      eventType,
+      count: bucket.count,
+      message: this.formatMessage(bucket.count, bucket.sampleEvent),
+      createdAt: bucket.firstAt
+    })
+  }
+
+  flushAll() {
+    Array.from(this.buckets.keys()).forEach(key => this.flush(key))
+  }
+}

--- a/src/utils/notificationBatcher.spec.js
+++ b/src/utils/notificationBatcher.spec.js
@@ -1,0 +1,122 @@
+import { NotificationBatcher } from './notificationBatcher'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+function makeEvent(overrides = {}) {
+  return {
+    datasetId: 'N:dataset:1',
+    category: 'FILES',
+    eventType: 'PACKAGE_CREATED',
+    message: '1 file added',
+    createdAt: '2026-08-03T00:00:00.000Z',
+    ...overrides
+  }
+}
+
+describe('NotificationBatcher', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('requires an onFlush callback', () => {
+    expect(() => new NotificationBatcher()).toThrow()
+  })
+
+  it('flushes a single event as-is after the window elapses', () => {
+    const onFlush = vi.fn()
+    const batcher = new NotificationBatcher({ windowMs: 1000, onFlush })
+
+    batcher.ingest(makeEvent())
+    expect(onFlush).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1000)
+
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    expect(onFlush).toHaveBeenCalledWith({
+      datasetId: 'N:dataset:1',
+      category: 'FILES',
+      eventType: 'PACKAGE_CREATED',
+      count: 1,
+      message: '1 file added',
+      createdAt: '2026-08-03T00:00:00.000Z'
+    })
+  })
+
+  it('coalesces multiple matching events within the window into one notification', () => {
+    const onFlush = vi.fn()
+    const batcher = new NotificationBatcher({ windowMs: 1000, onFlush })
+
+    for (let i = 0; i < 212; i += 1) {
+      batcher.ingest(makeEvent())
+    }
+    vi.advanceTimersByTime(1000)
+
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    expect(onFlush.mock.calls[0][0]).toMatchObject({ count: 212, message: '212 files events' })
+  })
+
+  it('keeps buckets independent by dataset, category, and event type', () => {
+    const onFlush = vi.fn()
+    const batcher = new NotificationBatcher({ windowMs: 1000, onFlush })
+
+    batcher.ingest(makeEvent({ eventType: 'PACKAGE_CREATED' }))
+    batcher.ingest(makeEvent({ eventType: 'PACKAGE_DELETED' }))
+    batcher.ingest(makeEvent({ datasetId: 'N:dataset:2' }))
+    batcher.ingest(makeEvent({ category: 'STATUS', eventType: 'PROCESSING_COMPLETE' }))
+
+    vi.advanceTimersByTime(1000)
+
+    expect(onFlush).toHaveBeenCalledTimes(4)
+  })
+
+  it('starts a fresh window once a bucket flushes', () => {
+    const onFlush = vi.fn()
+    const batcher = new NotificationBatcher({ windowMs: 1000, onFlush })
+
+    batcher.ingest(makeEvent())
+    vi.advanceTimersByTime(1000)
+    expect(onFlush).toHaveBeenCalledTimes(1)
+
+    batcher.ingest(makeEvent())
+    vi.advanceTimersByTime(1000)
+    expect(onFlush).toHaveBeenCalledTimes(2)
+  })
+
+  it('supports a custom formatMessage', () => {
+    const onFlush = vi.fn()
+    const formatMessage = (count, sampleEvent) =>
+      count === 1 ? sampleEvent.message : `${count} files added`
+    const batcher = new NotificationBatcher({ windowMs: 1000, onFlush, formatMessage })
+
+    batcher.ingest(makeEvent())
+    batcher.ingest(makeEvent())
+    vi.advanceTimersByTime(1000)
+
+    expect(onFlush.mock.calls[0][0].message).toBe('2 files added')
+  })
+
+  it('flushAll immediately flushes every pending bucket', () => {
+    const onFlush = vi.fn()
+    const batcher = new NotificationBatcher({ windowMs: 60000, onFlush })
+
+    batcher.ingest(makeEvent())
+    batcher.ingest(makeEvent({ datasetId: 'N:dataset:2' }))
+    batcher.flushAll()
+
+    expect(onFlush).toHaveBeenCalledTimes(2)
+  })
+
+  it('is a no-op to flush a key that already flushed', () => {
+    const onFlush = vi.fn()
+    const batcher = new NotificationBatcher({ windowMs: 1000, onFlush })
+
+    batcher.ingest(makeEvent())
+    batcher.flushAll()
+    batcher.flushAll()
+
+    expect(onFlush).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

Prototype of a rate-limiting/batching mechanism for the notification subscriptions feature discussed in this session (dataset-level "notify me" event categories, Account Settings subscriptions list, Recent Notifications feed).

- Adds `NotificationBatcher` (`src/utils/notificationBatcher.js`): coalesces bursts of same-dataset/category/eventType events within a configurable time window (default 5 min) into a single notification with a count, so a bulk operation (e.g. uploading 212 files) produces one feed entry instead of 212.
- Buckets key on `datasetId:category:eventType` so unrelated events are never merged together.
- `formatMessage` is pluggable for nicer per-event-type copy (default: `"N <category> events"`).
- `flushAll()` lets a caller force-drain pending buckets (e.g. on shutdown/unmount).

This is a standalone, unit-tested module — no wiring into the app yet, since the NotificationEvent/UserSubscription backend doesn't exist in this repo. It's meant to validate the batching algorithm and serve as a reference for the service that will actually emit these events (likely in a separate backend repo).

## Test plan

- [x] `npx vitest run src/utils/notificationBatcher.spec.js` — 8/8 passing
- [x] `npx vitest run src/utils` — full utils suite still green (11/11)
- [ ] Wire `NotificationBatcher` into the real event-emission path once the NotificationEvent backend exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)